### PR TITLE
add object_dump_callback

### DIFF
--- a/scripts/train/dinowm.py
+++ b/scripts/train/dinowm.py
@@ -4,7 +4,7 @@ import hydra
 import lightning as pl
 import stable_pretraining as spt
 import torch
-from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.callbacks import Callback, ModelCheckpoint
 from lightning.pytorch.loggers import WandbLogger
 from loguru import logger as logging
 from omegaconf import OmegaConf
@@ -213,6 +213,26 @@ def setup_pl_logger(cfg):
     return wandb_logger
 
 
+class ModelObjectCallBack(Callback):
+    """Callback to pickle model after each epoch."""
+
+    def __init__(self, dirpath, filename="model_object.ckpt", epoch_interval: int = 1):
+        super().__init__()
+        self.dirpath = dirpath
+        self.filename = filename
+        self.epoch_interval = epoch_interval
+
+    def on_train_epoch_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+        super().on_train_epoch_end(trainer, pl_module)
+
+        if trainer.is_global_zero:
+            if (trainer.current_epoch + 1) % self.epoch_interval == 0:
+                output_path = Path(self.dirpath, f"{self.filename}_epoch_{trainer.current_epoch + 1}")
+                torch.save(pl_module.to("cpu"), output_path)
+                logging.info(f"Saved world model object to {output_path}")
+                pl_module.to(trainer.strategy.root_device)
+
+
 # ============================================================================
 # Main Entry Point
 # ============================================================================
@@ -225,28 +245,25 @@ def run(cfg):
     world_model = get_world_model(cfg)
 
     cache_dir = swm.data.get_cache_dir()
+    dump_object_callback = ModelObjectCallBack(dirpath=cache_dir, filename=f"{cfg.output_model_name}_object.ckpt")
     checkpoint_callback = ModelCheckpoint(dirpath=cache_dir, filename=f"{cfg.output_model_name}_weights")
 
     trainer = pl.Trainer(
         max_epochs=cfg.epochs,
-        callbacks=[checkpoint_callback],
+        callbacks=[checkpoint_callback, dump_object_callback],
         num_sanity_val_steps=1,
         logger=wandb_logger,
         log_every_n_steps=50,
         precision="16-mixed",
         enable_checkpointing=True,
         accelerator="gpu",
-        devices=4,
+        devices="auto",
         strategy="ddp",
+        max_steps=10,
     )
 
     manager = spt.Manager(trainer=trainer, module=world_model, data=data)
     manager()
-
-    if trainer.is_global_zero and hasattr(cfg, "dump_object") and cfg.dump_object:
-        output_path = Path(cache_dir, f"{cfg.output_model_name}_object.ckpt")
-        torch.save(world_model.to("cpu"), output_path)
-        print(f"Saved world model object to {output_path}")
 
 
 if __name__ == "__main__":

--- a/stable_worldmodel/data.py
+++ b/stable_worldmodel/data.py
@@ -151,7 +151,7 @@ class WorldInfo(TypedDict):
 
 def get_cache_dir() -> Path:
     """Return the cache directory for stable_worldmodel."""
-    cache_dir = os.getenv("XENOWORLDS_HOME", os.path.expanduser("~/.stable_worldmodel"))
+    cache_dir = os.getenv("STABLEWM_HOME", os.path.expanduser("~/.stable_worldmodel"))
     os.makedirs(cache_dir, exist_ok=True)
     return Path(cache_dir)
 


### PR DESCRIPTION
This pull request introduces improvements to the training workflow for the world model, focusing on model saving and configuration flexibility. The main update is the addition of a custom callback to periodically pickle and save the model object during training, replacing the previous manual save logic. It also updates the cache directory environment variable and refines trainer configuration for better device management.

**Model Saving Enhancements:**

* Added a new `ModelObjectCallBack` class in `scripts/train/dinowm.py` to automatically pickle and save the model object at the end of each epoch, improving reproducibility and checkpointing. The callback saves the model to the cache directory and restores it to the correct device after saving.
* Integrated the new callback into the PyTorch Lightning trainer, replacing the previous manual model save logic after training. The callback is now used alongside the existing `ModelCheckpoint` callback.

**Configuration and Environment Updates:**

* Changed the cache directory environment variable from `XENOWORLDS_HOME` to `STABLEWM_HOME` in `stable_worldmodel/data.py` for consistency and clarity.
* Updated trainer device configuration to use `"auto"` instead of a hardcoded value, improving flexibility across different hardware setups. Also added `max_steps=10` for limiting training steps.

**Imports and Dependency Management:**

* Updated imports in `scripts/train/dinowm.py` to include the new callback and ensure proper usage of PyTorch Lightning components.