### PR TITLE
Remove stable-pretraining from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dev = [
     "codecov",
     "pre-commit",
     "ruff",
-    "stable-pretraining[all]",
 ]
 
 # Documentation tools


### PR DESCRIPTION
Removed 'stable-pretraining[all]' from dependencies.

# What does this PR do?

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/rbalestr-lab/stable-worldmodel/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/rbalestr-lab/stable-worldmodel/tree/main/docs)
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @
If you know how to use git blame, that is the easiest way, otherwise, please tag @lucas-maes or @RandallBalestriero -->

<!-- Some tips on docstring writing https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation -->
