### PR TITLE
add seed for dinowm data split

### DIFF
--- a/scripts/train/config.yaml
+++ b/scripts/train/config.yaml
@@ -47,6 +47,7 @@ trainer:
 batch_size: 64
 num_workers: 8
 train_split: 0.9
+seed: 42
 
 image_size: 224
 patch_size: 16

--- a/scripts/train/dinowm.py
+++ b/scripts/train/dinowm.py
@@ -77,8 +77,10 @@ def get_data(cfg):
     )
 
     dataset.transform = transform
-
-    train_set, val_set = spt.data.random_split(dataset, lengths=[cfg.train_split, 1 - cfg.train_split])
+    rnd_gen = torch.Generator().manual_seed(cfg.seed)
+    train_set, val_set = spt.data.random_split(
+        dataset, lengths=[cfg.train_split, 1 - cfg.train_split], generator=rnd_gen
+    )
     logging.info(f"Train: {len(train_set)}, Val: {len(val_set)}")
 
     train = DataLoader(
@@ -89,6 +91,7 @@ def get_data(cfg):
         persistent_workers=True,
         pin_memory=True,
         shuffle=True,
+        generator=rnd_gen,
     )
     val = DataLoader(val_set, batch_size=cfg.batch_size, num_workers=cfg.num_workers, pin_memory=True)
 


### PR DESCRIPTION
This pull request introduces deterministic behavior to the training pipeline by adding a seed parameter and ensuring that data splitting and shuffling are reproducible. The main changes are focused on configuration and data handling in the training scripts.

Deterministic training setup:

* Added a `seed` parameter to the `trainer` section in `config.yaml`, enabling control over random operations for reproducibility.
* Updated the `norm_col_transform` function in `dinowm.py` to use the seed for both dataset splitting and data loader shuffling by creating a seeded `torch.Generator` and passing it to `random_split` and `DataLoader`. [[1]](diffhunk://#diff-596752bdac1388b1095b300811d91d8d77b7b1615c8500ec37eb485492e254d4L80-R83) [[2]](diffhunk://#diff-596752bdac1388b1095b300811d91d8d77b7b1615c8500ec37eb485492e254d4R94)