### PR TITLE
[Feature] Add stacked wrapper

### DIFF
--- a/examples/example_dryrun.py
+++ b/examples/example_dryrun.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
         num_envs=5,
         image_shape=(224, 224),
         render_mode="rgb_array",
+        extra_wrappers=[lambda env: swm.wrappers.StackedWrapper(env, "pixels", n_stacks=3)],
     )
 
     print("Available variations: ", world.single_variation_space.names())

--- a/stable_worldmodel/world.py
+++ b/stable_worldmodel/world.py
@@ -124,6 +124,7 @@ class World:
         seed: int = 2349867,
         max_episode_steps: int = 100,
         verbose: int = 1,
+        extra_wrappers: list | None = None,
         **kwargs,
     ):
         """Initialize the World with vectorized environments.
@@ -153,6 +154,9 @@ class World:
             max_episode_steps (int, optional): Maximum number of steps per episode
                 before truncation. Episodes terminate early on task success.
                 Defaults to 100.
+            extra_wrappers (list, optional): List of extra wrappers to apply to each
+                environment. Useful for adding custom behavior or modifications.
+                Defaults to None.
             verbose (int, optional): Verbosity level. 0 for silent, 1 for basic info,
                 2+ for detailed debugging information. Defaults to 1.
             **kwargs: Additional keyword arguments passed to gym.make_vec() and
@@ -179,7 +183,8 @@ class World:
             env_name,
             num_envs=num_envs,
             vectorization_mode="sync",
-            wrappers=[lambda x: MegaWrapper(x, image_shape, image_transform, goal_shape, goal_transform)],
+            wrappers=[lambda x: MegaWrapper(x, image_shape, image_transform, goal_shape, goal_transform)]
+            + (extra_wrappers or []),
             max_episode_steps=max_episode_steps,
             **kwargs,
         )


### PR DESCRIPTION
This pull request introduces a new `StackedWrapper` to the codebase, which enables stacking a specified key in the environment info dictionary over the last k steps. The wrapper is integrated into the environment creation process, and comprehensive tests are added to verify its behavior with both numpy arrays and torch tensors. The changes also allow users to specify custom wrappers when initializing the `World` class.

**New feature: StackedWrapper**

* Added the `StackedWrapper` class to `stable_worldmodel/wrappers.py`, which stacks a given key in the info dict over the last k steps, supporting both numpy arrays and torch tensors. Includes buffer management and correct handling for n_stacks=1.

**Integration and API improvements**

* Updated the `World` class in `stable_worldmodel/world.py` to accept an `extra_wrappers` argument, allowing users to provide additional wrappers for environment customization. [[1]](diffhunk://#diff-b5c3adec8c375d3b35a2ed25e0cf52fbbe0283e33b7be29c21c40c8a2bcd456aR127) [[2]](diffhunk://#diff-b5c3adec8c375d3b35a2ed25e0cf52fbbe0283e33b7be29c21c40c8a2bcd456aR157-R159)
* Modified environment instantiation in `World.__init__` to apply any extra wrappers in addition to the default `MegaWrapper`.

**Testing enhancements**

* Added extensive tests for `StackedWrapper` in `stable_worldmodel/tests/test_wrappers.py`, covering stacking behavior for numpy arrays, torch tensors, single-stack cases, and empty buffer states.

**Example usage**

* Updated `examples/example_dryrun.py` to demonstrate usage of `StackedWrapper` via the new `extra_wrappers` argument.

**Dependency and import updates**

* Added necessary imports for `deque` and `torch` in `stable_worldmodel/wrappers.py` to support the new wrapper functionality.