### PR TITLE
[BugFix] Fix expert policy in simple_nav

### DIFF
--- a/stable_worldmodel/envs/simple_nav/expert_policy.py
+++ b/stable_worldmodel/envs/simple_nav/expert_policy.py
@@ -28,8 +28,8 @@ class ExpertPolicy(BasePolicy):
 
         for i, env in enumerate(self.env.unwrapped.envs):
             if len(self._action_buffer[i]) == 0:
-                agent_pos = info_dict["pos_agent"].squeeze()[i]
-                goal_pos = info_dict["pos_goal"].squeeze()[i]
+                agent_pos = info_dict["pos_agent"].squeeze(axis=1)[i]
+                goal_pos = info_dict["pos_goal"].squeeze(axis=1)[i]
                 agent_dir = info_dict["dir_agent"][i]
 
                 path = self._shortest_path(agent_pos, goal_pos, env.unwrapped.grid)


### PR DESCRIPTION
# What does this PR do?
Makes explicit the squeezed dimension simple_nav's expert policy. Previously, the n_envs dimension would get incorrectly squeezed when n_envs=1.

## Who can review?
@lucas-maes 