### PR TITLE
add eval_backbone code

### DIFF
--- a/experiments/eval_backbone/config.yaml
+++ b/experiments/eval_backbone/config.yaml
@@ -1,0 +1,29 @@
+defaults:
+  - launcher: local
+  - solver: cem
+  - _self_
+
+world:
+  env_name: swm/PushT-v1
+  num_envs: ${eval.num_eval}
+  max_episode_steps: ??? # make sure it's >= eval_budget
+  history_size: 1
+  frame_skip: 1
+
+seed: 42
+policy: random # ckpt name or random
+
+plan_config:
+  horizon: 5
+  receding_horizon: 5
+  action_block: 5 # frameskip
+
+# evaluation from dataset (replay expert trajectories)
+eval:
+  num_eval: 10
+  goal_offset_steps: 25
+  eval_budget: 25
+  dataset_name: pusht_expert_train
+
+output:
+  filename: results.txt

--- a/experiments/eval_backbone/launcher/basile.yaml
+++ b/experiments/eval_backbone/launcher/basile.yaml
@@ -1,0 +1,27 @@
+# @package _global_
+
+defaults:
+  - override /hydra/launcher: submitit_slurm
+
+n_gpus: 8
+cpus_per_gpu: 16
+cpus_per_task: ${n_gpus} * ${cpus_per_gpu}
+mem_per_gpu_gb: 64
+cache_dir: null # Use stable-worldmodel default cache
+
+wandb_entity: stable-wm
+wandb_project: stable-wm
+
+hydra:
+  mode: MULTIRUN
+
+  launcher:
+    timeout_min: 4320 # 72 hours
+    cpus_per_task: ${cpus_per_task}
+    mem_gb: ${n_gpus} * ${mem_per_gpu_gb}
+    gpus_per_node: ${n_gpus}
+    tasks_per_node: 8
+    nodes: 1
+    partition: long
+    account: fair_amaia_cw_video
+    qos: explore,lowest

--- a/experiments/eval_backbone/launcher/local.yaml
+++ b/experiments/eval_backbone/launcher/local.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+# Local launcher configuration (no SLURM)
+
+defaults:
+  - override /hydra/launcher: basic
+
+n_gpus: 1
+cpus_per_task: 4
+cache_dir: null # Use stable-worldmodel default cache
+wandb:
+  use_wandb: false
+  entity: stable-wm
+  project: stable-wm

--- a/experiments/eval_backbone/launcher/lucas.yaml
+++ b/experiments/eval_backbone/launcher/lucas.yaml
@@ -1,0 +1,22 @@
+# @package _global_
+
+defaults:
+  - override /hydra/launcher: submitit_slurm
+
+n_gpus: 4
+cpus_per_task: 4
+cache_dir: /network/scratch/l/lucas.maes/datasets/datasets/
+
+wandb_entity: simon-lacoste-julien
+wandb_project: stable-wm
+
+hydra:
+  mode: MULTIRUN
+
+  launcher:
+    timeout_min: 10080 # 1 week
+    cpus_per_task: ${cpus_per_task}
+    mem_gb: 256
+    gpus_per_node: ${n_gpus}
+    tasks_per_node: ${n_gpus}
+    partition: long

--- a/experiments/eval_backbone/launcher/mark.yaml
+++ b/experiments/eval_backbone/launcher/mark.yaml
@@ -1,0 +1,27 @@
+# @package _global_
+
+defaults:
+  - override /hydra/launcher: submitit_slurm
+
+n_gpus: 8
+cpus_per_gpu: 12
+cpus_per_task: ${n_gpus} * ${cpus_per_gpu}
+mem_per_gpu_gb: 64
+cache_dir: null # Use stable-worldmodel default cache
+
+wandb_entity: stable-wm
+wandb_project: stable-wm
+
+hydra:
+  mode: MULTIRUN
+
+  launcher:
+    timeout_min: 4320 # 72 hours
+    cpus_per_task: ${cpus_per_task}
+    mem_gb: ${n_gpus} * ${mem_per_gpu_gb}
+    gpus_per_node: ${n_gpus}
+    tasks_per_node: 1
+    nodes: 1
+    partition: long
+    account: memorization
+    qos: h200_alignment_shared,h200_lowest,h200_memorization_high,lowest,h100_alignment_share,h100_lowest

--- a/experiments/eval_backbone/run.py
+++ b/experiments/eval_backbone/run.py
@@ -1,0 +1,148 @@
+import time
+from pathlib import Path
+
+import datasets
+import hydra
+import numpy as np
+import stable_pretraining as spt
+import torch
+from omegaconf import DictConfig
+from sklearn import preprocessing
+from torchvision.transforms import v2 as transforms
+
+import stable_worldmodel as swm
+import wandb
+
+
+def img_transform():
+    transform = transforms.Compose(
+        [
+            transforms.ToImage(),
+            transforms.ToDtype(torch.float32, scale=True),
+            transforms.Normalize(**spt.data.dataset_stats.ImageNet),
+            transforms.Resize(size=196),
+            transforms.CenterCrop(size=196),
+        ]
+    )
+    return transform
+
+
+def get_episodes_length(dataset, episodes):
+    episode_idx = dataset["episode_idx"][:]
+    step_idx = dataset["step_idx"][:]
+    lengths = []
+    for ep_id in episodes:
+        lengths.append(np.max(step_idx[episode_idx == ep_id]) + 1)
+    return np.array(lengths)
+
+
+@hydra.main(version_base=None, config_path=".", config_name="config")
+def run(cfg: DictConfig):
+    """Run evaluation of dinowm vs random policy."""
+    assert cfg.plan_config.horizon * cfg.plan_config.action_block <= cfg.eval.eval_budget, (
+        "Planning horizon must be smaller than or equal to eval_budget"
+    )
+    if cfg.wandb.use_wandb:
+        # Initialize wandb
+        wandb.init(project=cfg.wandb.project, entity=cfg.wandb.entity, config=dict(cfg))
+
+    # create world environment
+    cfg.world.max_episode_steps = 2 * cfg.eval.eval_budget
+    world = swm.World(**cfg.world, image_shape=(224, 224), render_mode="rgb_array")
+
+    # create the transform
+    transform = {
+        "pixels": img_transform(),
+        "goal": img_transform(),
+    }
+
+    dataset_path = Path(cfg.cache_dir or swm.data.utils.get_cache_dir(), cfg.eval.dataset_name)
+    dataset = datasets.load_from_disk(dataset_path).with_format("numpy")
+    ep_indices, _ = np.unique(dataset["episode_idx"][:], return_index=True)
+
+    # create the processing
+    action_process = preprocessing.StandardScaler()
+    action_process.fit(dataset["action"][:])
+
+    proprio_process = preprocessing.StandardScaler()
+    proprio_process.fit(dataset["proprio"][:])
+
+    process = {
+        "action": action_process,
+        "proprio": proprio_process,
+        "goal_proprio": proprio_process,
+    }
+
+    # -- run evaluation
+    model = swm.policy.AutoCostModel(cfg.policy)
+    model = model.to("cuda")
+    model = model.eval()
+    model.requires_grad_(False)
+    model.interpolate_pos_encoding = True
+
+    config = swm.PlanConfig(**cfg.plan_config)
+    solver = hydra.utils.instantiate(cfg.solver, model=model)
+    policy = swm.policy.WorldModelPolicy(solver=solver, config=config, process=process, transform=transform)
+
+    # sample the episodes and the starting indices
+    episode_len = get_episodes_length(dataset, ep_indices)
+    max_start_idx = episode_len - cfg.eval.goal_offset_steps - 1
+    max_start_idx_dict = {ep_id: max_start_idx[i] for i, ep_id in enumerate(ep_indices)}
+    # Map each dataset row’s episode_idx to its max_start_idx
+    max_start_per_row = np.array([max_start_idx_dict[ep_id] for ep_id in dataset["episode_idx"]])
+
+    # remove all the lines of dataset for which dataset['step_idx'] > max_start_per_row
+    valid_mask = dataset["step_idx"] <= max_start_per_row
+    dataset_start = dataset.select(np.nonzero(valid_mask)[0])
+
+    g = np.random.default_rng(cfg.seed)
+    random_episode_indices = g.choice(len(dataset_start) - 1, size=cfg.eval.num_eval, replace=False)
+    eval_episodes = dataset_start[random_episode_indices]["episode_idx"]
+    eval_start_idx = dataset_start[random_episode_indices]["step_idx"]
+
+    if len(eval_episodes) < cfg.eval.num_eval:
+        raise ValueError("Not enough episodes with sufficient length for evaluation.")
+
+    world.set_policy(policy)
+
+    dataset = swm.data.FrameDataset(cfg.eval.dataset_name)
+
+    start_time = time.time()
+    metrics = world.evaluate_from_dataset(
+        dataset,
+        start_steps=eval_start_idx.tolist(),
+        goal_offset_steps=cfg.eval.goal_offset_steps,
+        eval_budget=cfg.eval.eval_budget,
+        episodes_idx=eval_episodes.tolist(),
+        callables={
+            "_set_state": "state",
+            "_set_goal_state": "goal_state",
+        },
+    )
+    end_time = time.time()
+
+    if cfg.wandb.use_wandb:
+        # Log metrics to wandb
+        wandb.log(metrics)
+        # Finish wandb run
+        wandb.finish()
+
+    # dump results
+    print(metrics)
+    # ---- dump results to a txt file ----
+    results_path = Path(__file__).parent / cfg.output.filename
+    with results_path.open("a") as f:
+        f.write("\n")  # separate from previous runs
+        f.write(f"policy: {cfg.policy}\n")
+        f.write(f"dataset_name: {cfg.eval.dataset_name}\n")
+        f.write(f"goal_offset_steps: {cfg.eval.goal_offset_steps}\n")
+        f.write(f"eval_budget: {cfg.eval.eval_budget}\n")
+        f.write(f"horizon: {cfg.plan_config.horizon}\n")
+        f.write(f"receding_horizon: {cfg.plan_config.receding_horizon}\n")
+        f.write(f"seed: {cfg.seed}\n")
+        f.write(f"metrics: {metrics}\n")
+        f.write(f"evaluation_time: {end_time - start_time} seconds\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/experiments/eval_backbone/run_experiment.md
+++ b/experiments/eval_backbone/run_experiment.md
@@ -1,0 +1,9 @@
+# run
+
+```
+python experiments/eval_backbone/run.py policy=pyro_test_epoch_20 world.max_episode_steps=200
+```
+
+```
+python experiments/eval_backbone/run.py policy=resnet50_epoch_10,vit_mae_base_epoch_10,vit_base_epoch_10,siglip2_base16_224_epoch_10,dinov2_small_epoch_10,dino_vits16_epoch_10,dinov3_vits16_epoch_10 world.max_episode_steps=200
+```

--- a/experiments/eval_backbone/solver/cem.yaml
+++ b/experiments/eval_backbone/solver/cem.yaml
@@ -1,0 +1,9 @@
+_target_: stable_worldmodel.solver.CEMSolver
+model: ???
+batch_size: 1
+num_samples: 300
+var_scale: 1.0
+n_steps: 30
+topk: 30
+device: "cuda"
+seed: ${seed}

--- a/experiments/eval_backbone/solver/gd.yaml
+++ b/experiments/eval_backbone/solver/gd.yaml
@@ -1,0 +1,8 @@
+_target_: stable_worldmodel.solver.GDSolver
+model: ???
+n_steps: 30
+batch_size: 1
+num_samples: 100
+action_noise: 0
+device: "cuda"
+seed: ${seed}


### PR DESCRIPTION
This pull request introduces a new evaluation pipeline for backbone policies in the `experiments/eval_backbone` directory. It adds configuration files for various launch environments, solver definitions for planning algorithms, and a main script to run and log evaluation experiments. The changes enable flexible evaluation of different policies on the PushT-v1 environment, supporting both local and SLURM-based distributed runs, and integrate logging with wandb.

**Experiment configuration and launch setup:**

* Added a central experiment configuration file `config.yaml` specifying environment, evaluation, planning, and output parameters for backbone policy evaluation.
* Added launcher configuration files for different users/environments (`local.yaml`, `basile.yaml`, `lucas.yaml`, `mark.yaml`) to support both local and SLURM-based distributed execution, with resource and wandb settings. [[1]](diffhunk://#diff-d8922419d4e8f9038f455d0a9b1f124365f1bce794a296da8008d8a009a3429fR1-R13) [[2]](diffhunk://#diff-d7daadb888f6247fd7f33bf77209e52ec5047854868fbafca15a8564bd2b7a61R1-R27) [[3]](diffhunk://#diff-8511a0ba3ce080414ce6167bbc2de7544e32fe268640e38391cd3c76c0ef8713R1-R22) [[4]](diffhunk://#diff-853020c4365df1bbb18243936cf746e11aec854a8068e864fc399fd4b71bff17R1-R27)

**Solver definitions for planning:**

* Added configuration files for CEM and GD solvers (`cem.yaml`, `gd.yaml`) to allow flexible selection of planning algorithms during evaluation. [[1]](diffhunk://#diff-b90bfc429727347b20cec1a6285b0d8e32eb713aefdd1d7e539561f03e85ec74R1-R9) [[2]](diffhunk://#diff-a701062942ee126c3acde912bfa843e6d94598ace57b491422fc41aacba691b6R1-R8)

**Main evaluation script and documentation:**

* Added `run.py`, a comprehensive script for running backbone policy evaluation, including environment setup, data preprocessing, policy instantiation, evaluation loop, and logging of results to wandb and text files.
* Added `run_experiment.md` with example commands for running evaluation experiments using different policies and configuration overrides.