### PR TITLE
add script for tworoom dataset

### DIFF
--- a/scripts/data/collect_tworooms.py
+++ b/scripts/data/collect_tworooms.py
@@ -1,0 +1,35 @@
+import hydra
+import numpy as np
+from loguru import logger as logging
+
+import stable_worldmodel as swm
+from stable_worldmodel.envs.two_room import ExpertPolicy
+
+
+@hydra.main(version_base=None, config_path="./", config_name="config")
+def run(cfg):
+    """Run data collection script"""
+
+    world = swm.World("swm/TwoRoom-v0", **cfg.world, render_mode="rgb_array")
+    world.set_policy(ExpertPolicy())
+
+    options = cfg.get("options")
+    traj_per_shard = cfg.num_traj // cfg.num_shards
+
+    rng = np.random.default_rng(cfg.seed)
+
+    for i in range(cfg.num_shards):
+        world.record_dataset(
+            f"tworoom_noisy/shard_{i}",
+            episodes=traj_per_shard,
+            seed=rng.integers(0, 1_000_000).item(),
+            cache_dir=cfg.cache_dir,
+            mode=cfg.ds_type,
+            options=options,
+        )
+
+    logging.success(f" 🎉🎉🎉 Completed data collection for {cfg.dataset_name} 🎉🎉🎉")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/data/config.yaml
+++ b/scripts/data/config.yaml
@@ -1,0 +1,33 @@
+defaults:
+  - _self_
+  - override hydra/launcher: submitit_slurm
+
+hydra:
+  output_subdir: null
+  mode: MULTIRUN
+  launcher:
+    max_num_timeout: 999
+    cpus_per_task: 8
+    mem_gb: 512
+    timeout_min: 1440
+    partition: long-cpu
+    signal_delay_s: 120
+  run:
+    dir: .
+
+cache_dir: null
+dataset_name: debug_tworoom
+
+world:
+  num_envs: 10
+  max_episode_steps: 1000
+  image_shape: [224, 224]
+
+num_workers: 16
+seed: 3072
+
+ds_type: video # frame
+num_traj: 20000
+num_shards: 50
+
+options: null

--- a/stable_worldmodel/envs/two_room/env.py
+++ b/stable_worldmodel/envs/two_room/env.py
@@ -15,7 +15,7 @@ import stable_worldmodel as swm
 from ..utils import DrawOptions, light_color, pymunk_to_shapely, to_pygame
 
 
-DEFAULT_VARIATIONS = ("agent.position", "goal.position")
+DEFAULT_VARIATIONS = ("agent.position", "goal.position", "door.number", "door.size", "door.position")
 
 
 class TwoRoomEnv(gym.Env):


### PR DESCRIPTION
This pull request introduces a new data collection script for the TwoRoom environment, adds a Hydra configuration for flexible experiment management, and expands the environment's default variations. The main focus is on enabling large-scale, configurable data collection using expert policies and supporting distributed execution.

**Data collection and configuration improvements:**

* Added a new script `collect_tworooms.py` using Hydra to automate and parallelize data collection for the TwoRoom environment, including sharding and expert policy integration.
* Introduced a comprehensive Hydra configuration file `config.yaml` to manage experiment parameters, resource allocation, and Slurm job scheduling for scalable data collection.

**Environment enhancements:**

* Expanded `DEFAULT_VARIATIONS` in `env.py` to include `door.number`, `door.size`, and `door.position`, allowing for more diverse environment configurations in collected datasets.