### PR TITLE
adding methods to set init and current values pf variation spaces

### DIFF
--- a/stable_worldmodel/envs/pusht/env.py
+++ b/stable_worldmodel/envs/pusht/env.py
@@ -36,6 +36,7 @@ class PushT(gym.Env):
         render_mode="rgb_array",
         fix_action_sample=True,
         relative=True,
+        init_value=None,
     ):
         self._seed = None
         self.window_size = ws = 512  # The size of the PyGame window
@@ -175,6 +176,8 @@ class PushT(gym.Env):
             },
             sampling_order=["background", "goal", "block", "agent"],
         )
+        if init_value is not None:
+            self.variation_space.set_init_value(init_value)
 
         # TODO ADD CONSTRAINT TO NOT SAMPLE OVERLAPPING START POSITIONS (block and agent)
 
@@ -222,6 +225,9 @@ class PushT(gym.Env):
             raise ValueError("variation option must be a Sequence containing variations names to sample")
 
         self.variation_space.update(variations)
+
+        if options is not None and "variation_values" in options:
+            self.variation_space.set_value(options["variation_values"])
 
         assert self.variation_space.check(debug=True), "Variation values must be within variation space!"
 

--- a/stable_worldmodel/envs/two_room/env.py
+++ b/stable_worldmodel/envs/two_room/env.py
@@ -30,6 +30,7 @@ class TwoRoomEnv(gym.Env):
         self,
         render_size=224,
         render_mode="rgb_array",
+        init_value=None,
     ):
         # gym
         assert render_mode in self.metadata["render_modes"]
@@ -172,6 +173,9 @@ class TwoRoomEnv(gym.Env):
             sampling_order=["background", "wall", "agent", "door", "goal"],
         )
 
+        if init_value is not None:
+            self.variation_space.set_init_value(init_value)
+
         self.window = None
         self.clock = None
         self.screen = None
@@ -194,6 +198,9 @@ class TwoRoomEnv(gym.Env):
             raise ValueError("variation option must be a Sequence containing variations names to sample")
 
         self.variation_space.update(variations)
+
+        if options is not None and "variation_values" in options:
+            self.variation_space.set_value(options["variation_values"])
 
         assert self.variation_space.check(debug=True), "Variation values must be within variation space!"
 


### PR DESCRIPTION
This pull request introduces enhanced support for initializing and setting values in environment variation spaces, improving control over environment state initialization and reset behavior. It adds new methods to the custom Gym space classes (`Discrete`, `MultiDiscrete`, `Box`, and `Dict`) to allow setting initial and current values, and updates the `pusht` and `two_room` environments to leverage these capabilities. This enables more flexible and deterministic environment setups, which is particularly useful for reproducibility and testing.

**Environment API Improvements:**

* Added an `init_value` parameter to the constructors of both `PushTEnv` (`pusht/env.py`) and `TwoRoomEnv` (`two_room/env.py`), allowing users to specify initial variation values when creating the environment. If provided, these values are set in the environment's variation space. [[1]](diffhunk://#diff-eaeaa7f1075a4c90a54d7ced9a75a1220b8018c5d87a1102358b64d820d07135R39) [[2]](diffhunk://#diff-be3a8e57d853e8f111bc4e3f16e4adfcb636a555822d9b1391229ced1c86b10dR33) [[3]](diffhunk://#diff-eaeaa7f1075a4c90a54d7ced9a75a1220b8018c5d87a1102358b64d820d07135R179-R180) [[4]](diffhunk://#diff-be3a8e57d853e8f111bc4e3f16e4adfcb636a555822d9b1391229ced1c86b10dR176-R178)
* Updated the `reset` method in both environments to accept an `options` dictionary. If `variation_values` are provided in `options`, the environment's variation space is set to these values before the episode starts, enabling per-episode control. [[1]](diffhunk://#diff-eaeaa7f1075a4c90a54d7ced9a75a1220b8018c5d87a1102358b64d820d07135R229-R231) [[2]](diffhunk://#diff-be3a8e57d853e8f111bc4e3f16e4adfcb636a555822d9b1391229ced1c86b10dR202-R204)

**Gym Space Extensions:**

* Added `set_init_value` and `set_value` methods to the custom `Discrete`, `MultiDiscrete`, and `Box` space classes. These methods allow setting and validating initial and current values, with appropriate error handling if the values are invalid. [[1]](diffhunk://#diff-151259304801df4c4947aaf897e070eabcc8732b8da13cb558b7b8faacf272c2R131-R156) [[2]](diffhunk://#diff-151259304801df4c4947aaf897e070eabcc8732b8da13cb558b7b8faacf272c2R285-R311) [[3]](diffhunk://#diff-151259304801df4c4947aaf897e070eabcc8732b8da13cb558b7b8faacf272c2R444-R470)
* Extended the custom `Dict` space to support `set_init_value` and `set_value` for nested keys using dot notation, enabling fine-grained control over complex, hierarchical variation spaces.