### PR TITLE
fixing rollout to return the full trajectory

### DIFF
--- a/stable_worldmodel/wm/dinowm.py
+++ b/stable_worldmodel/wm/dinowm.py
@@ -246,7 +246,7 @@ class DINOWM(torch.nn.Module):
         # predict the last state (n+t+1)
         pred_embed = self.predict(z_flat[:, -self.history_size :])[:, -1:]  # (B, 1, P, D)
         z_flat = torch.cat([z_flat, pred_embed], dim=1)
-        z = rearrange(pred_embed, "(b n) ... -> b n ...", b=B, n=N)
+        z = rearrange(z_flat, "(b n) ... -> b n ...", b=B, n=N)
         # == update info dict with predicted embeddings
         info["predicted_embedding"] = z
         # get the dimension of each part of the embedding

--- a/stable_worldmodel/wm/pyro.py
+++ b/stable_worldmodel/wm/pyro.py
@@ -252,8 +252,7 @@ class PYRO(torch.nn.Module):
         # predict the last state (n+t+1)
         pred_embed = self.predict(z_flat[:, -self.history_size :])[:, -1:]  # (B, 1, P, D)
         z_flat = torch.cat([z_flat, pred_embed], dim=1)
-        z = rearrange(pred_embed, "(b n) ... -> b n ...", b=B, n=N)
-
+        z = rearrange(z_flat, "(b n) ... -> b n ...", b=B, n=N)
         # == update info dict with predicted embeddings
         info["predicted_embedding"] = z
 


### PR DESCRIPTION
This pull request makes a small but important fix to the rollout logic in both the `dinowm.py` and `pyro.py` modules. The change ensures that the predicted embeddings are correctly reshaped by including all embeddings (not just the last prediction), which improves the accuracy of the predicted state sequence.

- Bug fix in rollout embedding reshaping:
  * Changed the `rearrange` operation in both `stable_worldmodel/wm/dinowm.py` and `stable_worldmodel/wm/pyro.py` to reshape the concatenated embeddings (`z_flat`) instead of only the last predicted embedding (`pred_embed`), ensuring the `predicted_embedding` in the `info` dict contains the full sequence of embeddings. [[1]](diffhunk://#diff-672666403ff527422937ed958eb66d388a880f55aca4cdec716440621160134aL249-R249) [[2]](diffhunk://#diff-e3386feee8c79111cd0bf8c18d96e8afd850c81baa9ab0e123e7e49a5871b8e9L255-R255)