### PR TITLE
Adding checks for load_chunk method

### DIFF
--- a/stable_worldmodel/data/dataset.py
+++ b/stable_worldmodel/data/dataset.py
@@ -118,6 +118,11 @@ class Dataset:
         if not (self.frameskip == 1 and self.num_steps == 1):
             raise NotImplementedError("Dataset.load_chunk need only be have frameskip=1 and num_steps=1")
 
+        # check that the episode was not filtered out when loading the dataset in __init__
+        for ep in episode:
+            if ep not in self.episodes:
+                raise ValueError(f"Episode {ep} was filtered out due to insufficient length")
+
         chunks = []
 
         for ep, s, en in zip(episode, start, end):


### PR DESCRIPTION
This pull request adds a validation step to the `load_chunk` method in `stable_worldmodel/data/dataset.py` to ensure that only episodes present in the dataset (i.e., not filtered out for insufficient length) are processed. This helps prevent errors from attempting to load invalid or unavailable episodes.

Validation improvements:

* Added a check in `load_chunk` to raise a `ValueError` if any requested episode was filtered out during dataset initialization due to insufficient length.