### PR TITLE
[WIP][Feature] Add new categorical cross entropy method solver implementation

### DIFF
--- a/stable_worldmodel/solver/cat_cem.py
+++ b/stable_worldmodel/solver/cat_cem.py
@@ -1,0 +1,441 @@
+import time
+
+import numpy as np
+import torch
+from gymnasium.spaces import Discrete, MultiDiscrete
+
+from .solver import Costable
+
+
+class CategoricalCEMSolver:
+    def __init__(
+        self,
+        model: Costable,
+        batch_size: int = 1,
+        num_samples: int = 300,
+        independence: bool = True,
+        warmstart_eps: float = 0.05,
+        n_steps: int = 30,
+        topk: int = 30,
+        device: str = "cpu",
+        seed: int = 1234,
+    ):
+        """Categorical CEM planner for Discrete/MultiDiscrete action spaces using elite-sample updates.
+        Args:
+            model (Costable): World model used to score candidate action sequences.
+            batch_size (int): Number of envs processed per batch.
+            num_samples (int): Number of candidates sampled per CEM iteration.
+            independence (bool): If True, factorize over MultiDiscrete components; else use joint categorical.
+            warmstart_eps (float): Smoothing factor for warm-start distributions.
+            n_steps (int): Number of CEM refinement iterations.
+            topk (int): Number of elites used to update logits each iteration.
+            device (str): Torch device string (e.g., "cpu", "cuda").
+            seed (int): Random seed for sampling.
+
+        """
+        self.model = model
+        self.batch_size = batch_size
+        self.num_samples = num_samples
+        self.independence = bool(independence)
+        self.warmstart_eps = float(warmstart_eps)
+        self.n_steps = n_steps
+        self.topk = topk
+        self.device = device
+        self.torch_gen = torch.Generator(device=device).manual_seed(seed)
+
+        self._configured = False
+
+    def configure(self, *, action_space, n_envs: int, config) -> None:
+        self._action_space = action_space
+        self._n_envs = int(n_envs)
+        self._config = config
+
+        # Normalize to MultiDiscrete-style nvec
+        if isinstance(action_space, Discrete):
+            nvec = np.array([int(action_space.n)], dtype=np.int64)
+        elif isinstance(action_space, MultiDiscrete):
+            nvec = np.array(action_space.nvec, dtype=np.int64)
+            # VecEnv can sometimes wrap nvec with leading env dim
+            if nvec.ndim == 2:
+                nvec = nvec[0]
+        else:
+            raise ValueError(
+                f"Action space is not Discrete/MultiDiscrete, got {type(action_space)}. "
+                "CategoricalCEMSolver expects discrete actions."
+            )
+
+        assert nvec.ndim == 1 and nvec.size >= 1, f"Expected 1D nvec, got shape {nvec.shape}"
+        assert np.all(nvec > 0), f"All nvec entries must be positive, got {nvec}"
+
+        self._nvec = nvec.tolist()
+        self._k = len(self._nvec)
+        self._action_dim = int(np.sum(self._nvec))
+        self._K_joint = int(np.prod(self._nvec))
+
+        # slices into packed _action_dim
+        self._comp_slices: list[tuple[int, int]] = []
+        off = 0
+        for ni in self._nvec:
+            self._comp_slices.append((off, off + int(ni)))
+            off += int(ni)
+        assert off == self._action_dim
+
+        # offsets for fast scatter into _action_dim
+        self._offsets = torch.tensor([s for (s, _) in self._comp_slices], dtype=torch.long, device=self.device)
+
+        # strides for joint ravel/unravel
+        strides = []
+        prod_tail = 1
+        for i in range(self._k - 1, -1, -1):
+            strides.append(prod_tail)
+            prod_tail *= int(self._nvec[i])
+        strides = list(reversed(strides))
+        self._strides = torch.tensor(strides, dtype=torch.long, device=self.device)
+        self._nvec_t = torch.tensor(self._nvec, dtype=torch.long, device=self.device)
+
+        self._configured = True
+
+    @property
+    def n_envs(self) -> int:
+        return self._n_envs
+
+    @property
+    def horizon(self) -> int:
+        return int(self._config.horizon)
+
+    @property
+    def action_block(self) -> int:
+        return int(self._config.action_block)
+
+    @property
+    def action_dim(self) -> int:
+        # world model sees blocked concatenation per time step
+        return self.action_block * self._action_dim
+
+    def __call__(self, *args, **kwargs):
+        return self.solve(*args, **kwargs)
+
+    def _ravel_joint(self, comp_idx: torch.Tensor) -> torch.Tensor:
+        """Convert per-component MultiDiscrete indices into a single joint index.
+
+        Args:
+            comp_idx (torch.Tensor): Tensor of shape (..., k) with per-component indices.
+
+        Returns:
+            torch.Tensor: Tensor of shape (...) with joint indices in [0, prod(nvec)).
+        """
+        # joint_index = sum_i idx[i] * stride[i]
+        return (comp_idx.long() * self._strides).sum(dim=-1)
+
+    def _unravel_joint(self, joint_idx: torch.Tensor) -> torch.Tensor:
+        """Convert joint indices into per-component MultiDiscrete indices.
+
+        Args:
+            joint_idx (torch.Tensor): Tensor of shape (...) with joint indices in [0, prod(nvec)).
+
+        Returns:
+            torch.Tensor: Tensor of shape (..., k) with per-component indices.
+        """
+        # idx[i] = (joint_idx // stride[i]) % nvec[i]
+        j = joint_idx.long().unsqueeze(-1)  # (..., 1)
+        idx = torch.div(j, self._strides, rounding_mode="floor") % self._nvec_t  # (..., k)
+        return idx
+
+    def _indices_to_onehot_concat(self, idx: torch.Tensor) -> torch.Tensor:
+        """Convert categorical indices into concatenated one-hot vectors over components.
+
+        Args:
+            idx (torch.Tensor): Categorical action indices in canonical form with shape
+                (..., B, k), where B is action_block and k is the number of (Multi)Discrete
+                components (k=1 for Discrete). Values must satisfy idx[..., i] in [0, nvec[i]).
+
+        Returns:
+            torch.Tensor: Concatenated one-hot encoding with shape (..., B, sum(nvec)),
+                matching the input prefix dimensions and replacing the last dim k with
+                self._action_dim = sum(nvec).
+        """
+        B = idx.shape[-2]
+        k = idx.shape[-1]
+
+        if k != self._k:
+            raise ValueError(f"Expected last dim k={self._k}, got {k}")
+
+        # flatten all leading dims into one
+        prefix = idx.shape[:-2]
+        idx2 = idx.reshape(-1, B, k)  # (P, B, k)
+
+        # offsets: (k,) -> (1,1,k)
+        global_idx = idx2 + self._offsets.view(1, 1, k)  # (P,B,k) in [0, self._action_dim)
+
+        out = torch.zeros((idx2.shape[0], B, self._action_dim), device=self.device, dtype=torch.float32)
+        out.scatter_add_(-1, global_idx, torch.ones_like(global_idx, dtype=torch.float32))
+        return out.reshape(*prefix, B, self._action_dim)
+
+    def init_action_distrib(self, actions: torch.Tensor | None = None) -> torch.Tensor:
+        """Initialize logits for the action distribution, optionally warm-started from indices using smoothing.
+
+        Args:
+            actions (torch.Tensor, optional): Warm-start indices. Discrete expects (E,T,B).
+                MultiDiscrete expects (E,T,B*k)
+
+        Returns:
+            torch.Tensor: Initial logits tensor. Shape is (E,H,B,sum(nvec)) if independence=True,
+                else (E,H,B,prod(nvec)).
+        """
+        assert self._configured, "Call configure() first."
+        E, H = self.n_envs, self.horizon
+        B = int(self._config.action_block)
+        eps = float(self.warmstart_eps)
+
+        # Uniform prior everywhere by default: logits = 0
+        if actions is None:
+            if self.independence:
+                return torch.zeros((E, H, B, self._action_dim), device=self.device)
+            else:
+                return torch.zeros((E, H, B, self._K_joint), device=self.device)
+
+        T = int(actions.shape[1])
+        # Normalize action shape:
+        if self._k == 1:
+            # Discrete (E,T,B) -> (E,T,B,1)
+            a = actions.unsqueeze(-1)
+        else:
+            # MultiDiscrete (E,T,B*k) -> (E,T,B,k)
+            a = actions.reshape(E, T, B, self._k)
+
+        a = a.long()
+
+        if self.independence:
+            logits = torch.zeros((E, H, B, self._action_dim), device=self.device)
+
+            # Fill first T steps with smoothed per-component distributions
+            for comp_i, ((s, e), ni) in enumerate(zip(self._comp_slices, self._nvec)):
+                idx = a[:, :T, :, comp_i]  # (E,T,B) categorical indices
+
+                # p = eps/ni everywhere, then scatter chosen index to (1-eps + eps/ni)
+                p = torch.full((E, T, B, int(ni)), eps / float(ni), device=self.device)
+                p.scatter_(-1, idx.unsqueeze(-1), 1.0 - eps + eps / float(ni))
+
+                logits[:, :T, :, s:e] = torch.log(p.clamp_min(1e-12))
+
+            return logits
+
+        # Joint
+        logits_joint = torch.zeros((E, H, B, self._K_joint), device=self.device)
+
+        joint_idx = self._ravel_joint(a[:, :T, :, :])  # (E,T,B)
+        p = torch.full((E, T, B, self._K_joint), eps / float(self._K_joint), device=self.device)
+        p.scatter_(-1, joint_idx.unsqueeze(-1), 1.0 - eps + eps / float(self._K_joint))
+
+        logits_joint[:, :T] = torch.log(p.clamp_min(1e-12))
+        return logits_joint
+
+    def _sample_factorized_indices(self, logits_packed: torch.Tensor, bs: int) -> torch.Tensor:
+        """Sample candidate indices from factorized logits.
+
+        Args:
+            logits_packed (torch.Tensor): Logits of shape (bs,H,B,sum(nvec)).
+            bs (int): Batch size (number of envs).
+
+        Returns:
+            torch.Tensor: Sampled indices of shape (bs,N,H,B,k).
+        """
+        H, B, N = self.horizon, self.action_block, self.num_samples
+        idx = torch.empty((bs, N, H, B, self._k), device=self.device, dtype=torch.long)
+
+        for comp_i, ((s, e), ni) in enumerate(zip(self._comp_slices, self._nvec)):
+            ni = int(ni)
+            probs = torch.softmax(logits_packed[:, :, :, s:e], dim=-1)  # (bs,H,B,ni)
+
+            # Flatten (bs*H*B, ni) and sample N per row -> (bs*H*B, N)
+            probs_flat = probs.reshape(-1, ni)
+            samp = torch.multinomial(
+                probs_flat, num_samples=N, replacement=True, generator=self.torch_gen
+            )  # (bs*H*B, N)
+
+            # Reshape to (bs, H, B, N) then permute to (bs, N, H, B)
+            idx[..., comp_i] = samp.reshape(bs, H, B, N).permute(0, 3, 1, 2)
+
+        return idx
+
+    def _sample_joint_indices(self, logits_joint: torch.Tensor, bs: int) -> torch.Tensor:
+        """Sample candidate indices from joint logits and also return unraveled component indices.
+
+        Args:
+            logits_joint (torch.Tensor): Logits of shape (bs,H,B,prod(nvec)).
+            bs (int): Batch size (number of envs).
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]:
+                - joint_idx: (bs,N,H,B) joint indices
+                - comp_idx: (bs,N,H,B,k) per-component indices
+        """
+        H, B, N = self.horizon, self.action_block, self.num_samples
+        K = self._K_joint
+
+        probs = torch.softmax(logits_joint, dim=-1)  # (bs,H,B,K)
+        probs_flat = probs.reshape(-1, K)  # (bs*H*B, K)
+
+        joint_flat = torch.multinomial(
+            probs_flat, num_samples=N, replacement=True, generator=self.torch_gen
+        )  # (bs*H*B, N)
+
+        # reshape to (bs,N,H,B)
+        joint = joint_flat.reshape(bs, H, B, N).permute(0, 3, 1, 2).contiguous()
+
+        # unravel: flatten (bs*N*H*B,) then reshape back
+        comp = self._unravel_joint(joint.reshape(-1)).reshape(bs, N, H, B, self._k)
+
+        return joint, comp
+
+    def _update_factorized_from_elites_idx(self, elites_idx: torch.Tensor) -> torch.Tensor:
+        """Update packed logits using elite samples (factorized case).
+
+        Args:
+            elites_idx (torch.Tensor): Elite indices of shape (bs,K,H,B,k).
+
+        Returns:
+            torch.Tensor: Updated logits of shape (bs,H,B,sum(nvec)).
+        """
+        bs, K, H, B, k = elites_idx.shape
+        logits_new = torch.zeros((bs, H, B, self._action_dim), device=self.device, dtype=torch.float32)
+
+        for comp_i, ((s, e), ni) in enumerate(zip(self._comp_slices, self._nvec)):
+            ni = int(ni)
+            idx = elites_idx[..., comp_i]  # (bs,K,H,B)
+
+            # Flatten (bs*H*B, K) and build histogram (bs*H*B, ni)
+            flat_idx = idx.permute(0, 2, 3, 1).reshape(-1, K)  # (R, K), R=bs*H*B
+            counts = torch.zeros((flat_idx.shape[0], ni), device=self.device, dtype=torch.float32)
+            counts.scatter_add_(1, flat_idx, torch.ones_like(flat_idx, dtype=torch.float32))
+
+            p = (counts / float(K)).clamp_min(1e-12)
+            p = p / p.sum(dim=-1, keepdim=True)
+            logits_new[:, :, :, s:e] = torch.log(p).reshape(bs, H, B, ni)
+
+        return logits_new
+
+    def _update_joint_from_elites_jointidx(self, elites_joint: torch.Tensor) -> torch.Tensor:
+        """Update joint logits using elite samples (joint case).
+
+        Args:
+            elites_joint (torch.Tensor): Elite joint indices of shape (bs,K,H,B).
+
+        Returns:
+            torch.Tensor: Updated logits of shape (bs,H,B,prod(nvec)).
+        """
+        # elites_joint: (bs,K,H,B)
+        bs, K, H, B = elites_joint.shape
+        flat = elites_joint.permute(0, 2, 3, 1).reshape(-1, K)  # (R,K)
+        counts = torch.zeros((flat.shape[0], self._K_joint), device=self.device, dtype=torch.float32)
+        counts.scatter_add_(1, flat, torch.ones_like(flat, dtype=torch.float32))
+
+        p = (counts / float(K)).clamp_min(1e-12)
+        p = p / p.sum(dim=-1, keepdim=True)
+        return torch.log(p).reshape(bs, H, B, self._K_joint)
+
+    @torch.inference_mode()
+    def solve(self, info_dict: dict, init_action: torch.Tensor | None = None) -> dict:
+        """Solve the planning optimization problem using categorical CEM with batch processing.
+
+        Args:
+            info_dict (dict): Per-env info inputs for the world model.
+                init_action (torch.Tensor, optional): Warm-start indices passed to init_action_distrib().
+
+        Returns:
+            dict: A dictionary containing:
+                - "actions" (torch.Tensor): Mode action indices of shape (E,H,B*k).
+                - "logits" (list[torch.Tensor]): List with final logits tensor.
+                - "costs" (list[float]): Final mean elite cost per environment.
+        """
+        start_time = time.time()
+        outputs = {"costs": [], "logits": []}
+
+        logits = self.init_action_distrib(init_action).to(self.device)
+
+        total_envs = self.n_envs
+        H, B, N = self.horizon, self.action_block, self.num_samples
+
+        for start_idx in range(0, total_envs, self.batch_size):
+            end_idx = min(start_idx + self.batch_size, total_envs)
+            bs = end_idx - start_idx
+
+            batch_logits = logits[start_idx:end_idx]
+
+            # Expand info_dict to (bs,N,...)
+            expanded_infos = {}
+            for k, v in info_dict.items():
+                v_batch = v[start_idx:end_idx]
+                if torch.is_tensor(v):
+                    v_batch = v_batch.unsqueeze(1)
+                    v_batch = v_batch.expand(bs, N, *v_batch.shape[2:])
+                elif isinstance(v, np.ndarray):
+                    v_batch = np.repeat(v_batch[:, None, ...], N, axis=1)
+                expanded_infos[k] = v_batch
+
+            final_batch_cost = None
+
+            for _ in range(self.n_steps):
+                # Sample indices
+                if self.independence:
+                    idx = self._sample_factorized_indices(batch_logits, bs)  # (bs,N,H,B,k)
+
+                    # Force sample 0 to be mode indices
+                    mode = torch.empty((bs, H, B, self._k), device=self.device, dtype=torch.long)
+                    for comp_i, ((s, e), _) in enumerate(zip(self._comp_slices, self._nvec)):
+                        mode[..., comp_i] = batch_logits[:, :, :, s:e].argmax(dim=-1)
+                    idx[:, 0] = mode
+
+                    # Convert to worldmodel candidates one-hot concat
+                    atomic = self._indices_to_onehot_concat(idx)  # (bs,N,H,B,_action_dim)
+                    candidates = atomic.reshape(bs, N, H, B * self._action_dim)
+
+                    costs = self.model.get_cost(expanded_infos.copy(), candidates)
+
+                    topk_vals, topk_inds = torch.topk(costs, k=self.topk, dim=1, largest=False)
+                    batch_ids = torch.arange(bs, device=self.device).unsqueeze(1).expand(-1, self.topk)
+                    elites_idx = idx[batch_ids, topk_inds]  # (bs,K,H,B,k)
+
+                    batch_logits = self._update_factorized_from_elites_idx(elites_idx)
+
+                else:
+                    joint_idx, comp_idx = self._sample_joint_indices(batch_logits, bs)  # (bs,N,H,B), (bs,N,H,B,k)
+
+                    # Force sample 0 to be joint mode
+                    joint_mode = batch_logits.argmax(dim=-1)  # (bs,H,B)
+                    joint_idx[:, 0] = joint_mode
+                    comp_idx[:, 0] = self._unravel_joint(joint_mode.reshape(-1)).reshape(bs, H, B, self._k)
+
+                    atomic = self._indices_to_onehot_concat(comp_idx)  # (bs,N,H,B,_action_dim)
+                    candidates = atomic.reshape(bs, N, H, B * self._action_dim)
+
+                    costs = self.model.get_cost(expanded_infos.copy(), candidates)
+
+                    topk_vals, topk_inds = torch.topk(costs, k=self.topk, dim=1, largest=False)
+                    batch_ids = torch.arange(bs, device=self.device).unsqueeze(1).expand(-1, self.topk)
+                    elites_joint = joint_idx[batch_ids, topk_inds]  # (bs,K,H,B)
+
+                    batch_logits = self._update_joint_from_elites_jointidx(elites_joint)
+
+                final_batch_cost = topk_vals.mean(dim=1).detach().cpu().tolist()
+
+            logits[start_idx:end_idx] = batch_logits
+            outputs["costs"].extend(final_batch_cost)
+
+        # Final mode actions as indices
+        E = total_envs
+        if self.independence:
+            actions_idx = torch.empty((E, H, B, self._k), device=self.device, dtype=torch.long)
+            for comp_i, ((s, e), _) in enumerate(zip(self._comp_slices, self._nvec)):
+                actions_idx[..., comp_i] = logits[:, :, :, s:e].argmax(dim=-1)
+        else:
+            joint_mode = logits.argmax(dim=-1)  # (E,H,B)
+            actions_idx = self._unravel_joint(joint_mode.reshape(-1)).reshape(E, H, B, self._k)
+
+        actions_idx_out = actions_idx.reshape(E, H, B * self._k)
+
+        outputs["actions"] = actions_idx_out.detach().cpu()
+        outputs["logits"] = [logits.detach().cpu()]
+
+        print(f"Categorical CEM solve time: {time.time() - start_time:.4f} seconds")
+        return outputs

--- a/stable_worldmodel/tests/solver/test_cat_cem.py
+++ b/stable_worldmodel/tests/solver/test_cat_cem.py
@@ -1,0 +1,495 @@
+"""Tests for RandomSolver class."""
+
+import torch
+from gymnasium import spaces as gym_spaces
+
+from stable_worldmodel.policy import PlanConfig
+from stable_worldmodel.solver.cat_cem import CategoricalCEMSolver
+
+
+class DummyCostModel:
+    """Simple Costable implementation for tests."""
+
+    def get_cost(
+        self,
+        info_dict: dict,
+        action_candidates: torch.Tensor,
+    ) -> torch.Tensor:
+        # w = torch.randn_like(action_candidates)
+        w = torch.zeros_like(action_candidates)
+        # Quadratic cost: sum over horizon and action dims
+        cost = (action_candidates - w).pow(2).sum(dim=(-1, -2))
+
+        # shape: (batch_envs, num_samples)
+        return cost
+
+
+###########################
+## Configuration Tests   ##
+###########################
+
+
+def test_cat_cem_solver_configure_discrete_action_space():
+    """Test CategoricalCEMSolver configuration with discrete action space."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.Discrete(5)
+    config = PlanConfig(horizon=8, receding_horizon=4, action_block=2)
+
+    solver.configure(action_space=action_space, n_envs=3, config=config)
+
+    assert solver._configured is True
+    assert solver.n_envs == 3
+    assert solver._action_dim == 5
+
+
+def test_cat_cem_solver_configure_multi_discrete_action_space():
+    """Test CategoricalCEMSolver configuration with multi-discrete action space."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([5, 3, 2])
+    config = PlanConfig(horizon=8, receding_horizon=4, action_block=2)
+
+    solver.configure(action_space=action_space, n_envs=3, config=config)
+
+    assert solver._configured is True
+    assert solver.n_envs == 3
+    assert solver._action_dim == 10  # Empty shape[1:] = 1
+
+
+def test_cat_cem_solver_configure_multi_env():
+    """Test CategoricalCEMSolver configuration with multiple environments."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=5, receding_horizon=3, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=16, config=config)
+
+    assert solver.n_envs == 16
+
+
+def test_cat_cem_solver_properties_after_configure():
+    """Test that properties work correctly after configuration."""
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=True)
+    action_space = gym_spaces.Discrete(5)
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=2)
+
+    solver.configure(action_space=action_space, n_envs=4, config=config)
+
+    assert solver.n_envs == 4
+    assert solver.action_dim == 10
+    assert solver.horizon == 10
+
+    # check logits
+    logits = solver.init_action_distrib()
+    assert logits.shape == (4, 10, 2, 5)
+    assert torch.allclose(logits, torch.zeros_like(logits))
+
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=False)
+    solver.configure(action_space=action_space, n_envs=4, config=config)
+
+    logits = solver.init_action_distrib()
+    assert logits.shape == (4, 10, 2, 5)
+    assert torch.allclose(logits, torch.zeros_like(logits))
+
+
+###########################
+## Solve Method Tests    ##
+###########################
+
+
+def test_cat_cem_solver_solve_full_horizon():
+    """Test solving generates full action sequence."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=4, config=config)
+    result = solver.solve(info_dict={})
+
+    assert "actions" in result
+    actions = result["actions"]
+    assert isinstance(actions, torch.Tensor)
+    assert actions.shape == (4, 10, 2)  # (n_envs, horizon, action_dim)
+
+
+def test_cat_cem_solver_solve_with_action_block():
+    """Test solving with action blocking."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=5, receding_horizon=3, action_block=3)
+
+    solver.configure(action_space=action_space, n_envs=2, config=config)
+    result = solver.solve(info_dict={})
+
+    actions = result["actions"]
+    assert actions.shape == (2, 5, 3 * 2)
+
+
+def test_cat_cem_solver_solve_single_env():
+    """Test solving with a single environment."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=7, receding_horizon=3, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=1, config=config)
+    result = solver.solve(info_dict={})
+
+    actions = result["actions"]
+    assert actions.shape == (1, 7, 2)
+
+
+def test_cat_cem_solver_solve_ignores_info_dict():
+    """Test that solve ignores info_dict content."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=5, receding_horizon=3, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=2, config=config)
+
+    # Should produce same shape regardless of info_dict content
+    result1 = solver.solve(info_dict={})
+    result2 = solver.solve(info_dict={"state": torch.randn(2, 10)})
+
+    assert result1["actions"].shape == result2["actions"].shape == (2, 5, 2)
+
+
+###########################
+## Warm-Start Tests      ##
+###########################
+
+
+def test_cat_cem_solver_configure_with_init_action_independence():
+    """Test warm-starting with partial action sequence."""
+    horizon = 10
+    receding_horizon = 5
+    action_block = 2
+    n_envs = 2
+    n = 5
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=True)
+    action_space = gym_spaces.Discrete(n)
+    config = PlanConfig(horizon=horizon, receding_horizon=receding_horizon, action_block=action_block)
+
+    solver.configure(action_space=action_space, n_envs=n_envs, config=config)
+
+    # Provide first 5 steps
+    init_action = torch.randint(0, n, size=(n_envs, horizon - receding_horizon, action_block))
+
+    logits = solver.init_action_distrib(init_action)
+    assert logits.shape == (n_envs, horizon, action_block, n)
+    assert torch.allclose(
+        logits[:, horizon - receding_horizon :, :, :], torch.zeros_like(logits[:, horizon - receding_horizon :, :, :])
+    )
+    assert not torch.allclose(
+        logits[:, : horizon - receding_horizon, :, :], torch.zeros_like(logits[:, : horizon - receding_horizon, :, :])
+    )
+
+    action_space = gym_spaces.MultiDiscrete([6, 7, 8])
+    solver.configure(action_space=action_space, n_envs=n_envs, config=config)
+
+    init_action_1 = torch.randint(0, 6, size=(n_envs, horizon - receding_horizon, action_block))
+    init_action_2 = torch.randint(0, 7, size=(n_envs, horizon - receding_horizon, action_block))
+    init_action_3 = torch.randint(0, 8, size=(n_envs, horizon - receding_horizon, action_block))
+    init_action = torch.stack([init_action_1, init_action_2, init_action_3], dim=-1)
+    logits = solver.init_action_distrib(init_action)
+
+    assert logits.shape == (n_envs, horizon, action_block, 6 + 7 + 8)
+    assert solver._action_dim == 6 + 7 + 8
+    assert torch.allclose(
+        logits[:, horizon - receding_horizon :, :, :], torch.zeros_like(logits[:, horizon - receding_horizon :, :, :])
+    )
+    assert not torch.allclose(
+        logits[:, : horizon - receding_horizon, :, :], torch.zeros_like(logits[:, : horizon - receding_horizon, :, :])
+    )
+
+
+def test_cat_cem_solver_configure_with_init_action_coupled():
+    """Test warm-starting with partial action sequence."""
+    horizon = 10
+    receding_horizon = 5
+    action_block = 2
+    n_envs = 3
+    n = 5
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=False)
+    action_space = gym_spaces.Discrete(n)
+    config = PlanConfig(horizon=horizon, receding_horizon=receding_horizon, action_block=action_block)
+
+    solver.configure(action_space=action_space, n_envs=n_envs, config=config)
+
+    # Provide first 5 steps
+    init_action = torch.randint(0, n, size=(n_envs, horizon - receding_horizon, action_block))
+
+    logits = solver.init_action_distrib(init_action)
+    assert logits.shape == (n_envs, horizon, action_block, n)
+    assert torch.allclose(
+        logits[:, horizon - receding_horizon :, :, :], torch.zeros_like(logits[:, horizon - receding_horizon :, :, :])
+    )
+    assert not torch.allclose(
+        logits[:, : horizon - receding_horizon, :, :], torch.zeros_like(logits[:, : horizon - receding_horizon, :, :])
+    )
+
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=False)
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    solver.configure(action_space=action_space, n_envs=n_envs, config=config)
+
+    init_action_1 = torch.randint(0, 2, size=(n_envs, horizon - receding_horizon, action_block))
+    init_action_2 = torch.randint(0, 3, size=(n_envs, horizon - receding_horizon, action_block))
+
+    init_action = torch.stack([init_action_1, init_action_2], dim=-1)
+
+    logits = solver.init_action_distrib(init_action)
+    assert logits.shape == (n_envs, horizon, action_block, 2 * 3)
+    assert solver._action_dim == 2 + 3
+    assert torch.allclose(
+        logits[:, horizon - receding_horizon :, :, :], torch.zeros_like(logits[:, horizon - receding_horizon :, :, :])
+    )
+    assert not torch.allclose(
+        logits[:, : horizon - receding_horizon, :, :], torch.zeros_like(logits[:, : horizon - receding_horizon, :, :])
+    )
+
+
+###########################
+## Callable Tests        ##
+###########################
+
+
+def test_cat_cem_solver_callable():
+    """Test that solver is callable via __call__."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=5, receding_horizon=3, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=2, config=config)
+
+    # Test both calling methods produce same shape
+    result1 = solver(info_dict={})
+    result2 = solver.solve(info_dict={})
+
+    assert result1["actions"].shape == result2["actions"].shape == (2, 5, 2)
+
+
+###########################
+## Edge Cases & Errors   ##
+###########################
+
+
+def test_cat_cem_solver_horizon_1():
+    """Test solver with horizon of 1."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=1, receding_horizon=1, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=2, config=config)
+    result = solver.solve(info_dict={})
+
+    assert result["actions"].shape == (2, 1, 2)
+
+
+def test_cat_cem_solver_large_horizon():
+    """Test solver with large horizon."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=100, receding_horizon=50, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=2, config=config)
+    result = solver.solve(info_dict={})
+
+    assert result["actions"].shape == (2, 100, 2)
+
+
+def test_cat_cem_solver_many_envs():
+    """Test solver with many parallel environments."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=64, config=config)
+    result = solver.solve(info_dict={})
+
+    assert result["actions"].shape == (64, 10, 2)
+
+
+def test_cat_cem_solver_multidimensional_action():
+    """Test solver with multi-dimensional action space."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=5, receding_horizon=3, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=2, config=config)
+    result = solver.solve(info_dict={})
+
+    # action_dim should be product of shape[1:] = 2 + 3 = 5
+    assert result["actions"].shape == (2, 5, 2)
+
+
+###########################
+## Integration Tests     ##
+###########################
+
+
+def test_cat_cem_solver_deterministic_with_seed():
+    """Test that results are reproducible with numpy seed."""
+    solver1 = CategoricalCEMSolver(model=DummyCostModel())
+    solver2 = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=5, receding_horizon=3, action_block=1)
+
+    solver1.configure(action_space=action_space, n_envs=2, config=config)
+    solver2.configure(action_space=action_space, n_envs=2, config=config)
+
+    # Set seed and sample
+    action_space.seed(42)
+    result1 = solver1.solve(info_dict={})
+
+    # Reset seed and sample again
+    action_space.seed(42)
+    result2 = solver2.solve(info_dict={})
+
+    print(result1["actions"])
+    print(result2["actions"])
+
+    # Results should be identical
+    assert torch.allclose(result1["actions"], result2["actions"])
+
+
+def test_cat_cem_solver_multiple_solves():
+    """Test multiple solve calls produce different results."""
+    solver = CategoricalCEMSolver(model=DummyCostModel())
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=2, config=config)
+
+    result1 = solver.solve(info_dict={})
+    result2 = solver.solve(info_dict={})
+
+    # Results should be different (with very high probability)
+    assert not torch.allclose(result1["actions"], result2["actions"])
+
+
+def test_cat_cem_solver_receding_horizon_pattern():
+    """Test typical receding horizon planning pattern."""
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=False)
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=1)
+
+    solver.configure(action_space=action_space, n_envs=4, config=config)
+
+    # First planning step
+    result1 = solver.solve(info_dict={})
+    actions1 = result1["actions"]
+    assert actions1.shape == (4, 10, 2)
+
+    # Execute first 5 steps, keep remaining 5
+    remaining = actions1[:, 5:, :]
+    assert remaining.shape == (4, 5, 2)
+
+    # Second planning step with warm-start
+    result2 = solver.solve(info_dict={}, init_action=remaining)
+    actions2 = result2["actions"]
+    assert actions2.shape == (4, 10, 2)
+
+
+def test_cat_cem_solver_sample_indices_factorized():
+    """Test that the solver samples indices from the action distribution."""
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=True, num_samples=1)
+    action_space = gym_spaces.Discrete(5)
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=1)
+    solver.configure(action_space=action_space, n_envs=1, config=config)
+
+    logits = solver.init_action_distrib()
+    sample = solver._sample_factorized_indices(logits, 1)
+    onehot = solver._indices_to_onehot_concat(sample)
+
+    assert sample.shape == (1, 1, 10, 1, 1)
+    assert onehot.shape == (1, 1, 10, 1, 5)
+
+    n_envs = 4
+    horizon = 10
+    receding_horizon = 5
+    action_block = 3
+    num_samples = 5
+
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=True, num_samples=num_samples)
+    config = PlanConfig(horizon=horizon, receding_horizon=receding_horizon, action_block=action_block)
+    solver.configure(action_space=action_space, n_envs=n_envs, config=config)
+
+    init_action_1 = torch.randint(0, 2, size=(n_envs, horizon - receding_horizon, action_block))
+    init_action_2 = torch.randint(0, 3, size=(n_envs, horizon - receding_horizon, action_block))
+    init_action = torch.stack([init_action_1, init_action_2], dim=-1)
+
+    logits = solver.init_action_distrib(init_action)
+    sample = solver._sample_factorized_indices(logits, n_envs)
+    onehot = solver._indices_to_onehot_concat(sample)
+
+    assert sample.shape == (n_envs, num_samples, horizon, action_block, 2)
+    assert onehot.shape == (n_envs, num_samples, horizon, action_block, 5)
+
+
+def test_cat_cem_solver_sample_indices_joint():
+    """Test that the solver samples indices from the action distribution."""
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=False, num_samples=1)
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=1)
+    solver.configure(action_space=action_space, n_envs=1, config=config)
+
+    logits = solver.init_action_distrib()
+    joint, comp = solver._sample_joint_indices(logits, 1)
+    onehot = solver._indices_to_onehot_concat(comp)
+
+    assert joint.shape == (1, 1, 10, 1)
+    assert comp.shape == (1, 1, 10, 1, 2)
+    assert onehot.shape == (1, 1, 10, 1, 5)
+
+    n_envs = 4
+    horizon = 10
+    receding_horizon = 5
+    action_block = 3
+    num_samples = 5
+
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=False, num_samples=num_samples)
+    config = PlanConfig(horizon=horizon, receding_horizon=receding_horizon, action_block=action_block)
+    solver.configure(action_space=action_space, n_envs=n_envs, config=config)
+
+    init_action_1 = torch.randint(0, 2, size=(n_envs, horizon - receding_horizon, action_block))
+    init_action_2 = torch.randint(0, 3, size=(n_envs, horizon - receding_horizon, action_block))
+    init_action = torch.stack([init_action_1, init_action_2], dim=-1)
+    logits = solver.init_action_distrib(init_action)
+    joint, comp = solver._sample_joint_indices(logits, n_envs)
+    onehot = solver._indices_to_onehot_concat(comp)
+
+    assert joint.shape == (n_envs, num_samples, horizon, action_block)
+    assert comp.shape == (n_envs, num_samples, horizon, action_block, 2)
+    assert onehot.shape == (n_envs, num_samples, horizon, action_block, 5)
+
+
+def test_cat_cem_solver_update_logits_factorized():
+    """Test that the solver updates logits using elite samples (factorized case)."""
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=True, num_samples=2)
+    action_space = gym_spaces.Discrete(5)
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=1)
+    solver.configure(action_space=action_space, n_envs=1, config=config)
+
+    logits = solver.init_action_distrib()
+    sample = solver._sample_factorized_indices(logits, 1)
+    new_logits = solver._update_factorized_from_elites_idx(sample)
+
+    assert new_logits.shape == (1, 10, 1, 5)
+
+
+def test_cat_cem_solver_update_logits_joint():
+    """Test that the solver updates logits using elite samples (joint case)."""
+    solver = CategoricalCEMSolver(model=DummyCostModel(), independence=False, num_samples=2)
+    action_space = gym_spaces.MultiDiscrete([2, 3])
+    config = PlanConfig(horizon=10, receding_horizon=5, action_block=1)
+    solver.configure(action_space=action_space, n_envs=1, config=config)
+
+    logits = solver.init_action_distrib()
+    joint, comp = solver._sample_joint_indices(logits, 1)
+    new_logits = solver._update_joint_from_elites_jointidx(joint)
+
+    assert new_logits.shape == (1, 10, 1, 6)
+
+
+if __name__ == "__main__":
+    test_cat_cem_solver_deterministic_with_seed()


### PR DESCRIPTION
# What does this PR do?
Implements the categorical cross entropy method solver using categorical distributions over discrete actions. 

Note: warm start uses laplace smoothing over all actions, making probability mass high for warm start actions — this is the only workaround without being able to pass logits from the previous solve.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/rbalestr-lab/stable-worldmodel/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/rbalestr-lab/stable-worldmodel/tree/main/docs)
- [ ] Did you write any new necessary tests?

## Who can review?
@lucas-maes 
