### PR TITLE
[BugFix] Loss Logging in wm_training

### DIFF
--- a/experiments/wm_training/run.py
+++ b/experiments/wm_training/run.py
@@ -252,25 +252,20 @@ def get_world_model(cfg):
 
         start = pixels_dim
         action_dim_range = [0, 0]
+
         for key in self.model.extra_encoders.keys():
             emb_dim = batch[f"{key}_embed"].shape[-1]
+            lo, hi = start, start + emb_dim
+
             if key == "action":
-                action_dim_range = [start, start + emb_dim]
-                continue  # skip action encoding loss
-
-            emb_dim = batch[f"{key}_embed"].shape[-1]
-            pred_embedding[..., start : start + emb_dim]
-            target_embedding[..., start : start + emb_dim]
-
-            if key in self.model.extra_encoders:
-                extra_loss = F.mse_loss(
-                    pred_embedding[..., start : start + emb_dim],
-                    target_embedding[..., start : start + emb_dim].detach(),
+                action_dim_range = [lo, hi]
+            else:
+                batch[f"{key}_loss"] = F.mse_loss(
+                    pred_embedding[..., lo:hi],
+                    target_embedding[..., lo:hi].detach(),
                 )
-                # loss = loss + extra_loss
-                batch[f"{key}_loss"] = extra_loss
 
-            start += emb_dim
+            start = hi
 
         # Total loss
         actionless_pred = torch.cat(


### PR DESCRIPTION
# What does this PR do?

Fixes the logic when looping through the latent embeddings to log losses. Previously, the left pointer was not incremented when processing the action embedding.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/rbalestr-lab/stable-worldmodel/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/rbalestr-lab/stable-worldmodel/tree/main/docs)
- [ ] Did you write any new necessary tests?

## Who can review?
@lucas-maes 