### PR TITLE
[Bug Fix] Modified dataset chunk loading in `evaluate_from_dataset()`

### DIFF
--- a/stable_worldmodel/world.py
+++ b/stable_worldmodel/world.py
@@ -788,7 +788,9 @@ class World:
 
         ep_idx_arr = np.array(episodes_idx)
         start_steps_arr = np.array(start_steps)
-        end_steps = start_steps_arr + goal_offset_steps
+        # We add +1 so that the last loaded frame will align with the last frame we encounter
+        # when stepping through the rollout.
+        end_steps = start_steps_arr + goal_offset_steps + 1
 
         if not (len(ep_idx_arr) == len(start_steps_arr)):
             raise ValueError(


### PR DESCRIPTION
Updated `end_steps` in `World.evaluate_from_dataset()`.

Justification: If, for example, `start_steps_arr = [34, 55]` and `goal_offset_steps = 25`, then for the first env we want to load the chunk from step 34 to step 59 (inclusive), so then the last loaded frame will align with the last frame we encounter when stepping through the rollout. Also, if `goal_offset_steps == 1`, then we need 1 actual frame of time to pass; otherwise, the goal state is set to the start state.