### PR TITLE
adding a task with position target for reacher env

### DIFF
--- a/stable_worldmodel/envs/dmcontrol/custom_tasks/reacher.py
+++ b/stable_worldmodel/envs/dmcontrol/custom_tasks/reacher.py
@@ -1,0 +1,33 @@
+import numpy as np
+from dm_control.suite import reacher
+
+_DEFAULT_QPOS_THRESHOLD = 0.1
+
+
+class ReacherQPosMatchTask(reacher.Reacher):
+    """Reacher task that terminates (success) when qpos matches a target qpos.
+
+    The target qpos is set externally via the env's `set_target_qpos()`. Until
+    it is set, the task never terminates early.
+
+    Args:
+        target_size: Tolerance radius for the standard finger-to-target reward.
+        random: Random seed or RandomState.
+        qpos_threshold: Per-joint absolute tolerance (in radians) used to
+            determine whether the current qpos matches the target qpos.
+    """
+
+    def __init__(
+        self, target_size, random=None, qpos_threshold=_DEFAULT_QPOS_THRESHOLD
+    ):
+        super().__init__(target_size=target_size, random=random)
+        self.target_qpos = None
+        self.qpos_threshold = qpos_threshold
+
+    def get_termination(self, physics):
+        if self.target_qpos is None:
+            return None
+        diff = np.abs(physics.data.qpos - self.target_qpos)
+        if np.all(diff < self.qpos_threshold):
+            return 0.0
+        return None

--- a/stable_worldmodel/envs/dmcontrol/dmcontrol.py
+++ b/stable_worldmodel/envs/dmcontrol/dmcontrol.py
@@ -93,18 +93,33 @@ class DMControlWrapper(gym.Env):
             obs = self.env.task.get_observation(self.env.physics)
         return self._obs_to_array(obs), self.info
 
+    def _is_terminated(self, step) -> bool:
+        """Return True if the current step should end the episode as a success.
+
+        Override in subclasses to implement custom termination conditions.
+        The base implementation always returns False (no early termination).
+
+        Args:
+            step: The dm_control TimeStep returned by the environment.
+        """
+        return False
+
     def step(self, action):
         reward = 0
         action = action.astype(self.action_spec_dtype)
+        terminated = False
         for _ in range(self.action_repeat):
             step = self.env.step(action)
             reward += step.reward or 0
+            if self._is_terminated(step):
+                terminated = True
+                break
         self._cumulative_reward += reward
 
         return (
             self._obs_to_array(step.observation),
             reward,
-            False,
+            terminated,
             False,
             self.info,
         )

--- a/stable_worldmodel/envs/dmcontrol/reacher.py
+++ b/stable_worldmodel/envs/dmcontrol/reacher.py
@@ -9,6 +9,9 @@ from dm_control.suite.wrappers import action_scale
 
 from stable_worldmodel import spaces as swm_spaces
 from stable_worldmodel.envs.dmcontrol.dmcontrol import DMControlWrapper
+from stable_worldmodel.envs.dmcontrol.custom_tasks.reacher import (
+    ReacherQPosMatchTask,
+)
 
 
 _DEFAULT_TIME_LIMIT = 20
@@ -16,11 +19,12 @@ _DEFAULT_TIME_LIMIT = 20
 _BIG_TARGET = 0.05
 _SMALL_TARGET = 0.015
 
-_TASKS = ('easy', 'hard')
+_TASKS = ('easy', 'hard', 'qpos_match')
 
 _TASK_TARGET_SIZES = {
     'easy': _BIG_TARGET,
     'hard': _SMALL_TARGET,
+    'qpos_match': _SMALL_TARGET,
 }
 
 
@@ -30,6 +34,7 @@ class ReacherDMControlWrapper(DMControlWrapper):
             raise ValueError(
                 f"Unknown task '{task}'. Must be one of {list(_TASKS)}"
             )
+        self._task_name = task
         self._target_size = _TASK_TARGET_SIZES[task]
         xml, assets = reacher.get_model_and_assets()
         xml = xml.replace(b'file="./common/', b'file="common/')
@@ -141,7 +146,12 @@ class ReacherDMControlWrapper(DMControlWrapper):
         )
         xml_path = os.path.join(self._mjcf_tempdir.name, 'reacher.xml')
         physics = reacher.Physics.from_xml_path(xml_path)
-        task = reacher.Reacher(target_size=self._target_size, random=seed)
+        if self._task_name == 'qpos_match':
+            task = ReacherQPosMatchTask(
+                target_size=self._target_size, random=seed
+            )
+        else:
+            task = reacher.Reacher(target_size=self._target_size, random=seed)
         environment_kwargs = environment_kwargs or {}
         env = control.Environment(
             physics, task, time_limit=_DEFAULT_TIME_LIMIT, **environment_kwargs
@@ -150,6 +160,36 @@ class ReacherDMControlWrapper(DMControlWrapper):
         self.env = env
         # Mark the environment as clean.
         self._dirty = False
+
+    def set_target_qpos(self, target_qpos):
+        """Set the target qpos for the qpos_match task.
+
+        Args:
+            target_qpos: Array of joint positions to match (shape matching
+                physics.data.qpos).
+        """
+        assert self._task_name == 'qpos_match', (
+            "set_target_qpos() is only valid for the 'qpos_match' task."
+        )
+        self.env.task.target_qpos = np.asarray(target_qpos, dtype=np.float64)
+
+    def reset(self, seed=None, options=None):
+        obs, info = super().reset(seed=seed, options=options)
+        if self._task_name == 'qpos_match' and options is not None:
+            target_qpos = options.get('target_qpos')
+            if target_qpos is not None:
+                self.env.task.target_qpos = np.asarray(
+                    target_qpos, dtype=np.float64
+                )
+        return obs, info
+
+    def _is_terminated(self, step) -> bool:
+        if self._task_name != 'qpos_match':
+            return False
+        return (
+            step.last()
+            and self.env.task.get_termination(self.env.physics) is not None
+        )
 
     def modify_mjcf_model(self, mjcf_model):
         """Apply visual variations to the MuJoCo model based on variation space.


### PR DESCRIPTION
This pull request introduces a new variant of the Reacher task, called `qpos_match`, to the `dmcontrol` environment suite. The new task allows for early termination when the robot's joint positions (`qpos`) match a specified target, and provides an interface to set this target both programmatically and during environment reset. The changes also generalize the episode termination logic in the environment wrapper to support custom success conditions.

**New task and environment support:**

* Added a new `ReacherQPosMatchTask` class in `custom_tasks/reacher.py`, which terminates the episode successfully when the robot's joint positions match a target within a configurable threshold. The target can be set externally.
* Registered the new `qpos_match` task in the Reacher environment, including its target size in `_TASK_TARGET_SIZES` and `_TASKS`.

**Environment integration and control:**

* Updated the Reacher environment to instantiate `ReacherQPosMatchTask` when the `qpos_match` task is selected, and to store the task name for later use. [[1]](diffhunk://#diff-c4f44f82c712fa72c689081ee1d6179224f4ef2b451d9d163fa9ea377fc37b5aR37) [[2]](diffhunk://#diff-c4f44f82c712fa72c689081ee1d6179224f4ef2b451d9d163fa9ea377fc37b5aR149-R153)
* Added a `set_target_qpos` method for externally setting the target joint positions, and extended the `reset` method to allow specifying `target_qpos` via the `options` argument.

**Generalized termination logic:**

* Introduced an overridable `_is_terminated` method in the base DMControl wrapper, and implemented task-specific early termination for the `qpos_match` task based on the new success condition. [[1]](diffhunk://#diff-370998597826c31e7d8f1f5b2dd2091fb4878a2ee1399a364520fde64bca7ffdR96-R122) [[2]](diffhunk://#diff-c4f44f82c712fa72c689081ee1d6179224f4ef2b451d9d163fa9ea377fc37b5aR164-R193)…pper