### PR TITLE
fix(pgd): sample action noise on batch tensor device to avoid cuda generator mismatch

### DIFF
--- a/stable_worldmodel/solver/discrete_solvers.py
+++ b/stable_worldmodel/solver/discrete_solvers.py
@@ -192,8 +192,14 @@ class PGDSolver(torch.nn.Module):
 
                 # Add noise
                 if self.action_noise > 0:
-                    batch_init.data += torch.randn(batch_init.shape, generator=self.torch_gen) * self.action_noise
-
+                    batch_init.data += (
+                        torch.randn(
+                            batch_init.shape,
+                            generator=self.torch_gen,
+                            device=batch_init.device,
+                        )
+                        * self.action_noise
+                    )
                 # projection onto simplex
                 with torch.no_grad():
                     batch_init.copy_(self._project_action_simplex(batch_init))


### PR DESCRIPTION
### PR Description
This PR fixes a CUDA device mismatch in `PGDSolver` when `action_noise` is greater than zero.

### Problem
`PGDSolver` creates a device-specific `torch.Generator` using the configured solver device.  
In the action noise branch inside `solve()`, noise was sampled without explicitly setting the tensor device.  
On CUDA, this can cause a generator/device mismatch error at runtime.

### Change
In the action noise block, noise sampling now uses the same device as `batch_init`.

**Before:**
- Noise sampling did not set device in this branch

**After:**
- Noise sampling explicitly uses `batch_init.device`