### PR TITLE
envs/pusht: change observation velocity range

### DIFF
--- a/stable_worldmodel/envs/pusht/env.py
+++ b/stable_worldmodel/envs/pusht/env.py
@@ -52,15 +52,17 @@ class PushT(gym.Env):
 
         self.shapes = ['o', 'L', 'T', 'Z', 'square', 'I', 'small_tee', '+']
 
+        # Velocities are last two components of proprio and state; they can be negative
+        # (Pymunk). Declaring low=0 made passive_env_checker reject valid observations.
         self.observation_space = spaces.Dict(
             {
                 'proprio': spaces.Box(
-                    low=np.array([0, 0, 0, 0]),
+                    low=np.array([0, 0, -ws, -ws]),
                     high=np.array([ws, ws, ws, ws]),
                     dtype=np.float64,
                 ),
                 'state': spaces.Box(
-                    low=np.array([0, 0, 0, 0, 0, 0, 0]),
+                    low=np.array([0, 0, 0, 0, 0, -ws, -ws]),
                     high=np.array([ws, ws, ws, ws, np.pi * 2, ws, ws]),
                     dtype=np.float64,
                 ),


### PR DESCRIPTION
[Problem]
In PushT._get_obs(), the last two components are linear velocity, which can be negative on both axes. But observation_space used low=0 for those velocity dimensions (both in state and in proprio, which is [x, y, vx, vy]).

Any step with vx < 0 or vy < 0 makes obs not in observation_space, which triggers warnings.

[Solution]
Extend the lower bound of observation_space.