### PR TITLE
Update docs for correct stoarge location

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ source .venv/bin/activate
 uv sync --all-extras --group dev
 ```
 
-> **Note:** All datasets and models will be saved in the `$STABLEWM_HOME` environment variable. By default this is `~/.stable-wm/`. Adapt this directory according to your storage needs.
+> **Note:** All datasets and models will be saved in the `$STABLEWM_HOME` environment variable. By default this is `~/.stable_worldmodel/`. Adapt this directory according to your storage needs.
 
 
 ### Questions

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,14 +8,14 @@ After installing `stable-worldmodel`, the `swm` command is available to inspect 
 
 ## `swm datasets`
 
-List all datasets stored in your cache directory (`$STABLEWM_HOME`, defaults to `~/.stable-wm/`).
+List all datasets stored in your cache directory (`$STABLEWM_HOME`, defaults to `~/.stable_worldmodel/`).
 
 ```bash
 swm datasets
 ```
 
 ```
-               Datasets in ~/.stable-wm/
+               Datasets in ~/.stable_worldmodel/
 ┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┓
 ┃ Name                   ┃ Format ┃    Size ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━┩
@@ -35,7 +35,7 @@ swm inspect pusht_expert_train
 ```
 Name:      pusht_expert_train
 Format:    HDF5
-Path:      ~/.stable-wm/pusht_expert_train.h5
+Path:      ~/.stable_worldmodel/pusht_expert_train.h5
 Size:      812.3 MB
 Episodes:  2000
 Steps:     297806

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ uv sync --all-extras --group dev
 
 !!! warning ""
     All datasets and models will be saved in the `$STABLEWM_HOME` environment variable.
-    By default the corresponding location is `~/.stable-wm/`. We encourage every user to adapt that directory according to their need and storage.
+    By default the corresponding location is `~/.stable_worldmodel/`. We encourage every user to adapt that directory according to their need and storage.
 
 ## Example
 ---

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -192,7 +192,7 @@ Stable World-Model provides utilities for recording and loading episode datasets
 
 ### Recording a Dataset
 
-Use `world.record_dataset()` to collect episodes and save them in HDF5 format. The dataset is saved to `$STABLEWM_HOME` (defaults to `~/.stable-wm/`). This is useful for collecting expert demonstrations, random exploration data, or rollouts from a trained policy.
+Use `world.record_dataset()` to collect episodes and save them in HDF5 format. The dataset is saved to `$STABLEWM_HOME` (defaults to `~/.stable_worldmodel/`). This is useful for collecting expert demonstrations, random exploration data, or rollouts from a trained policy.
 
 ```python
 world = swm.World('swm/PushT-v1', num_envs=8, image_shape=(224, 224))


### PR DESCRIPTION
Changes references of storage path `~/.stable-wm/` $\rightarrow$ `~/.stable_worldmodel/` as per `get_cache_dir` in https://github.com/anthonyprinaldi/stable-worldmodel/blob/3b2568d852832167bd647a0170dd4a2821ccebc9/stable_worldmodel/data/utils.py