### PR TITLE
[Env] Financial Environment

### DIFF
--- a/docs/envs/financial.md
+++ b/docs/envs/financial.md
@@ -1,0 +1,216 @@
+---
+title: Financial Markets (STONK)
+summary: Daily cross-section portfolio allocation in financial markets
+---
+
+## Description
+
+A daily cross-section financial backtesting environment where the agent allocates a portfolio across a universe of stocks. At each timestep the agent observes a heatmap encoding every stock's daily return and the current portfolio weights, then assigns each stock to a quintile — strong short, short, hold, long, or strong long. The environment is **data-agnostic**: any OHLCV dataset can be plugged in via `register_financial_dataset`.
+
+Unlike standard reinforcement learning benchmarks, state transitions are fully determined by historical price data, making the environment suitable for testing world-model representations of financial cross-sections.
+
+```python
+import stable_worldmodel as swm
+from stable_worldmodel.envs.dataset_registry import register_financial_dataset
+
+# Register your own OHLCV loader first (see Dataset Registration below)
+register_financial_dataset(my_loader, name="default", max_stocks=500)
+
+world = swm.World('swm/STONK-v0', num_envs=4)
+```
+
+## Environment Specs
+
+| Property | Value |
+|----------|-------|
+| Action Space | `MultiDiscrete([5] * n_stocks)` — per-stock quintile assignment |
+| Observation Space | `Box(0, 255, shape=(A, A, 6), dtype=uint8)` — stacked RGB heatmaps |
+| Reward | Portfolio return minus transaction costs (higher is better) |
+| Episode Length | All trading days between `start_date` and `end_date` |
+| Render Size | A×A upscaled to 224×224 (rgb_array mode) |
+| Physics | Tabular price replay (no simulation) |
+| Environment ID | `swm/STONK-v0` |
+
+`A` is the smallest integer satisfying `A × A ≥ max_stocks` across all registered datasets (e.g. A = 23 for 500 stocks).
+
+### Action Space
+
+Each element of the `MultiDiscrete` action vector assigns one stock to a quintile:
+
+| Quintile | Value | Raw weight | Description |
+|----------|-------|------------|-------------|
+| 0 | `strong short` | −1.0 | Maximum short position |
+| 1 | `short` | −0.5 | Partial short position |
+| 2 | `hold` | 0.0 | No position |
+| 3 | `long` | +0.5 | Partial long position |
+| 4 | `strong long` | +1.0 | Maximum long position |
+
+Raw weights are normalized before execution: long weights sum to 1 and short weights sum to −1. Stocks assigned `hold` contribute nothing to the portfolio.
+
+### Observation Details
+
+The observation is a `(A, A, 6)` uint8 tensor formed by stacking two RGB heatmaps along the channel axis:
+
+| Channels | Image | Encoding |
+|----------|-------|----------|
+| 0–2 | Market heatmap | Each pixel = one stock's daily return |
+| 3–5 | Portfolio heatmap | Each pixel = one stock's current portfolio weight |
+
+In both images, pixel intensity encodes magnitude and colour encodes direction:
+
+- **Green** — positive return / long position (intensity ∝ magnitude)
+- **Red** — negative return / short position (intensity ∝ |magnitude|)
+- **Black** — zero return or no position
+
+For the market heatmap, intensity saturates at `agent.return_clip` (default ±5%). For the portfolio heatmap, intensity saturates at a weight magnitude of 1.0.
+
+Stocks are sorted alphabetically and arranged row-major in the grid. Unused pixels (when `n_stocks < A²`) are black.
+
+### Info Dictionary
+
+The `info` dict returned by `step()` and `reset()` contains:
+
+| Key | Description |
+|-----|-------------|
+| `date` | Current trading date string (`'YYYY-MM-DD'`) |
+| `portfolio_value` | Current portfolio value in currency units |
+| `daily_return` | Portfolio return for the last step (before costs) |
+| `benchmark_return` | Equal-weight benchmark return for the last step |
+| `drawdown` | Current drawdown from episode peak portfolio value |
+| `universe` | Name of the active registered dataset universe |
+| `n_stocks` | Number of stocks active in the current episode |
+| `goal` | Zero array matching observation shape (placeholder) |
+
+## Variation Space
+
+All variation factors are randomized by default at each `reset()`.
+
+| Factor | Type | Default | Description |
+|--------|------|---------|-------------|
+| `market.start_date_idx` | `Discrete(n_dates)` | `0` | Index into the list of annual episode start dates |
+| `market.universe_idx` | `Discrete(n_universes)` | last | Index of the registered dataset universe to use |
+| `agent.starting_balance` | `Box(10000, 1000000)` | `100000` | Initial portfolio value in currency units |
+| `agent.transaction_cost` | `Box(0.0, 0.01)` | `0.001` | Cost per unit of L1 portfolio turnover |
+| `agent.return_clip` | `Box(0.01, 0.20)` | `0.05` | Daily return threshold for full colour saturation (±5%) |
+
+Episode start dates are derived automatically from the registered dataset's `start_date` / `end_date`, with at least one year of data reserved before `end_date`. The set of available universes is the list of registered dataset names.
+
+To fix specific factors rather than randomizing them:
+
+```python
+# Fix the starting balance and transaction cost; randomize the rest
+world.reset(options={
+    'variation': ['market.start_date_idx', 'market.universe_idx', 'agent.return_clip'],
+})
+
+# Randomize everything (default behaviour)
+world.reset(options={'variation': ['all']})
+```
+
+## Dataset Registration
+
+`FinancialEnvironment` requires at least one dataset to be registered before calling `reset()`. Register a loader once at startup:
+
+```python
+from stable_worldmodel.envs.dataset_registry import register_financial_dataset
+
+def my_loader(
+    symbols=None,
+    start_date: str = '2015-01-01',
+    end_date: str = '2024-12-31',
+    universe: str = 'default',
+) -> pd.DataFrame:
+    """Return daily OHLCV data as a MultiIndex DataFrame."""
+    ...
+
+register_financial_dataset(
+    my_loader,
+    name='default',      # registry key / universe name
+    start_date='2015-01-01',
+    end_date='2024-12-31',
+    max_stocks=500,       # maximum stocks across all universes
+)
+```
+
+### Loader Contract
+
+The loader callable must satisfy:
+
+| Requirement | Detail |
+|-------------|--------|
+| **Signature** | `loader(symbols, start_date, end_date, universe) -> pd.DataFrame` |
+| **Index** | `pd.MultiIndex` with levels `date` (str, `'YYYY-MM-DD'`) and `symbol` (str) |
+| **Columns** | `open`, `high`, `low`, `close`, `volume` (all numeric, daily frequency) |
+| **Sort order** | Chronological (the environment will re-sort if needed) |
+| **Empty data** | Raises `ValueError` inside the environment — loader must return non-empty data |
+
+Multiple loaders can be registered under different names to create several universes that the variation space samples from:
+
+```python
+register_financial_dataset(sp500_loader,  name='sp500',  max_stocks=500)
+register_financial_dataset(russell_loader, name='russell', max_stocks=2000)
+# market.universe_idx will sample uniformly from ['sp500', 'russell']
+```
+
+## Performance Metrics
+
+`stable_worldmodel.envs.fin_env.metrics` provides utility functions for evaluating trained agents. These are **not** called inside the environment itself — use them in evaluation scripts.
+
+```python
+from stable_worldmodel.envs.fin_env.metrics import (
+    calculate_sharpe_ratio,
+    calculate_sortino_ratio,
+    calculate_max_drawdown,
+    calculate_information_ratio,
+    calculate_annualized_return,
+    calculate_annualized_volatility,
+    calculate_ic,
+    calculate_icir,
+    calculate_rank_ic,
+    calculate_rank_icir,
+    calculate_ic_series,
+)
+```
+
+### Return-Based Metrics
+
+| Function | Description |
+|----------|-------------|
+| `calculate_sharpe_ratio(returns)` | Annualized Sharpe ratio (risk-free rate = 2%) |
+| `calculate_sortino_ratio(returns)` | Annualized Sortino ratio (downside deviation only) |
+| `calculate_max_drawdown(portfolio_values)` | Maximum peak-to-trough drawdown fraction |
+| `calculate_annualized_return(total_return, n_periods)` | Compound annual growth rate |
+| `calculate_annualized_volatility(returns)` | Annualized standard deviation of daily returns |
+| `calculate_information_ratio(returns, benchmark_returns, ...)` | Active return / tracking error; returns `(IR, tracking_error)` |
+
+All functions assume 252 trading periods per year (configurable via `periods_per_year`).
+
+### Cross-Sectional Ranking Metrics
+
+Cross-sectional metrics measure how well the agent ranks stocks relative to realized outcomes at each timestep, regardless of position sizing.
+
+| Function | Description |
+|----------|-------------|
+| `calculate_ic(predicted, realized)` | Pearson correlation between predicted and realized returns at one step |
+| `calculate_icir(ic_series)` | IC Information Ratio — mean IC / std IC over time |
+| `calculate_rank_ic(predicted, realized)` | Spearman rank correlation between predicted and realized returns at one step |
+| `calculate_rank_icir(rank_ic_series)` | Rank ICIR — mean Rank IC / std Rank IC; preferred ranking metric |
+| `calculate_ic_series(predicted_seq, realized_seq)` | Compute IC, ICIR, Rank IC, and Rank ICIR in one call |
+
+**IC > 0** means predictions are positively correlated with outcomes. **Rank IC** is preferred over IC because it is insensitive to outliers and does not assume a linear relationship between predictions and realized returns.
+
+```python
+# Collect per-step arrays during an episode
+predicted_list, realized_list = [], []
+obs, _ = env.reset()
+for _ in range(len(env._dates) - 1):
+    action = policy(obs)                        # MultiDiscrete quintile action
+    obs, reward, terminated, _, info = env.step(action)
+
+    # Map quintile actions to predicted weights for IC calculation
+    predicted_list.append(weights_from_action(action))
+    realized_list.append(get_realized_returns(info))
+
+metrics = calculate_ic_series(predicted_list, realized_list)
+print(metrics)  # {'ic_mean': ..., 'icir': ..., 'rank_ic_mean': ..., 'rank_icir': ...}
+```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -24,6 +24,7 @@ nav:
       - envs/dmc.md
       - envs/ogb.md
       - envs/tworoom.md
+      - envs/financial.md
   - cli.md
   # - Tutorial:
   #     - tutorial/collect_data.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,6 @@ quote-style = "single"
 
 [tool.coverage.run]
 omit = ["stable_worldmodel/envs/*"]
+
+[tool.codespell]
+ignore-words-list = "reacher"

--- a/scripts/examples/financial.py
+++ b/scripts/examples/financial.py
@@ -1,0 +1,311 @@
+"""Smoke-test the STONK financial environment with a random policy.
+
+Generates a dummy OHLCV dataset, rolls out a random policy across
+4 parallel environments, saves per-step images to ./output/, records
+a video, and prints a full metrics report at the end.
+
+Usage:
+    python scripts/examples/financial.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from PIL import Image
+
+import stable_worldmodel as swm
+from stable_worldmodel.envs.dataset_registry import register_financial_dataset
+from stable_worldmodel.envs.fin_env.metrics import (
+    calculate_annualized_return,
+    calculate_annualized_volatility,
+    calculate_ic_series,
+    calculate_information_ratio,
+    calculate_max_drawdown,
+    calculate_sharpe_ratio,
+    calculate_sortino_ratio,
+)
+from stable_worldmodel.policy import RandomPolicy
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+
+N_STOCKS = 50
+START_DATE = '2018-01-01'
+END_DATE = '2020-12-31'
+NUM_ENVS = 4
+IMAGE_SHAPE = (224, 224)
+MAX_EPISODE_STEPS = 252  # roughly one trading year
+OUTPUT_DIR = Path('output/financial')
+
+# --------------------------------------------------------------------------- #
+# Dummy OHLCV loader
+# --------------------------------------------------------------------------- #
+
+_RNG = np.random.default_rng(42)
+
+
+def _generate_dummy_ohlcv(
+    n_stocks: int, start_date: str, end_date: str
+) -> pd.DataFrame:
+    """Generate synthetic daily OHLCV data with a random-walk close price."""
+    dates = (
+        pd.bdate_range(start=start_date, end=end_date)
+        .strftime('%Y-%m-%d')
+        .tolist()
+    )
+    symbols = [f'STOCK_{i:03d}' for i in range(n_stocks)]
+
+    records = []
+    for sym in symbols:
+        # Random-walk log-prices seeded per symbol
+        log_returns = _RNG.normal(0.0003, 0.015, size=len(dates))
+        log_prices = np.cumsum(log_returns) + np.log(100.0)
+        close = np.exp(log_prices).astype(np.float32)
+        open_ = close * (1.0 + _RNG.uniform(-0.005, 0.005, size=len(dates)))
+        high = np.maximum(close, open_) * (
+            1.0 + _RNG.uniform(0.0, 0.01, size=len(dates))
+        )
+        low = np.minimum(close, open_) * (
+            1.0 - _RNG.uniform(0.0, 0.01, size=len(dates))
+        )
+        volume = _RNG.integers(100_000, 10_000_000, size=len(dates)).astype(
+            np.float32
+        )
+
+        for i, date in enumerate(dates):
+            records.append(
+                (date, sym, open_[i], high[i], low[i], close[i], volume[i])
+            )
+
+    df = pd.DataFrame(
+        records,
+        columns=['date', 'symbol', 'open', 'high', 'low', 'close', 'volume'],
+    )
+    df = df.set_index(['date', 'symbol']).sort_index()
+    return df
+
+
+def my_loader(
+    symbols=None,
+    start_date: str = START_DATE,
+    end_date: str = END_DATE,
+    universe: str = 'default',
+) -> pd.DataFrame:
+    return _generate_dummy_ohlcv(N_STOCKS, start_date, end_date)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _save_observation_image(
+    obs: np.ndarray, path: Path, env_idx: int, step: int
+) -> None:
+    """Save the 6-channel (A,A,6) observation as two side-by-side RGB images."""
+    market_rgb = obs[:, :, :3]
+    portfolio_rgb = obs[:, :, 3:]
+
+    a = obs.shape[0]
+    canvas = np.zeros((a, a * 2, 3), dtype=np.uint8)
+    canvas[:, :a, :] = market_rgb
+    canvas[:, a:, :] = portfolio_rgb
+
+    img = Image.fromarray(canvas, mode='RGB').resize((448, 224), Image.NEAREST)
+    img.save(path / f'env{env_idx}_step{step:04d}.png')
+
+
+def _weights_from_action(
+    action: np.ndarray, n_quintiles: int = 5
+) -> np.ndarray:
+    """Map quintile action vector → raw weights for IC calculation."""
+    # 0=−1, 1=−0.5, 2=0, 3=+0.5, 4=+1
+    quintile_map = np.array([-1.0, -0.5, 0.0, 0.5, 1.0], dtype=np.float32)
+    return quintile_map[action]
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    img_dir = OUTPUT_DIR / 'frames'
+    img_dir.mkdir(exist_ok=True)
+
+    # ── 1. Register dataset ──────────────────────────────────────────────────
+    print('Registering dummy dataset …')
+    register_financial_dataset(
+        my_loader,
+        name='default',
+        start_date=START_DATE,
+        end_date=END_DATE,
+        max_stocks=N_STOCKS,
+    )
+
+    # ── 2. Build world ───────────────────────────────────────────────────────
+    world = swm.World(
+        'swm/STONK-v0',
+        num_envs=NUM_ENVS,
+        image_shape=IMAGE_SHAPE,
+        max_episode_steps=MAX_EPISODE_STEPS,
+        goal_conditioned=False,
+    )
+
+    policy = RandomPolicy(seed=0)
+    world.set_policy(policy)
+
+    # ── 3. Record a video ────────────────────────────────────────────────────
+    video_path = OUTPUT_DIR / 'videos'
+    video_path.mkdir(exist_ok=True)
+    print(f'Recording rollout video → {video_path}')
+    world.record_video(str(video_path), max_steps=MAX_EPISODE_STEPS, fps=5)
+
+    # ── 4. Manual rollout for metrics + frame saving ─────────────────────────
+    print('\nRunning manual rollout for metrics …')
+    world.reset(seed=1)
+
+    # Per-env accumulators
+    daily_returns = [[] for _ in range(NUM_ENVS)]
+    bench_returns = [[] for _ in range(NUM_ENVS)]
+    portfolio_vals = [[] for _ in range(NUM_ENVS)]
+    predicted_lists = [[] for _ in range(NUM_ENVS)]
+    realized_lists = [[] for _ in range(NUM_ENVS)]
+
+    # Record the initial frame
+    for env_idx in range(NUM_ENVS):
+        # pixels live in world.infos, not world.states
+        world.infos.get('pixels', None)
+
+    step = 0
+    while True:
+        # Sample actions from each environment's action space individually
+        actions = world.envs.action_space.sample()
+
+        # Save a frame every 10 steps from the raw observation channels
+        if step % 10 == 0:
+            raw_pixels = world.infos.get('pixels')
+            if raw_pixels is not None:
+                for env_idx in range(NUM_ENVS):
+                    frame = raw_pixels[env_idx]
+                    # frame may have a history dim: (T, H, W, C) → take last
+                    if frame.ndim == 4:
+                        frame = frame[-1]
+                    # If it's already (H, W, C) with C=6 it came from the env directly;
+                    # if it's (H, W, 3) it's the rendered pixel — save as-is
+                    if frame.shape[-1] == 6:
+                        _save_observation_image(frame, img_dir, env_idx, step)
+                    else:
+                        img = Image.fromarray(frame, mode='RGB')
+                        img.save(img_dir / f'env{env_idx}_step{step:04d}.png')
+
+        world.step()
+        step += 1
+
+        # Accumulate per-env metrics from infos
+        for env_idx in range(NUM_ENVS):
+            dr = world.infos.get('daily_return', [0.0] * NUM_ENVS)[env_idx]
+            br = world.infos.get('benchmark_return', [0.0] * NUM_ENVS)[env_idx]
+            pv = world.infos.get('portfolio_value', [100000.0] * NUM_ENVS)[
+                env_idx
+            ]
+            daily_returns[env_idx].append(float(dr))
+            bench_returns[env_idx].append(float(br))
+            portfolio_vals[env_idx].append(float(pv))
+
+            # Store predicted (action-weights) and realized (daily returns per stock)
+            # for cross-sectional IC metrics — use the vectorised action for this env
+            if actions is not None and hasattr(actions, '__len__'):
+                n_stocks_env = world.envs.single_action_space.nvec.shape[0]
+                env_action = (
+                    actions[
+                        env_idx * n_stocks_env : (env_idx + 1) * n_stocks_env
+                    ]
+                    if actions.ndim == 1
+                    else actions[env_idx]
+                )
+                predicted_lists[env_idx].append(
+                    _weights_from_action(env_action)
+                )
+                realized_lists[env_idx].append(
+                    np.array([float(dr)] * len(env_action), dtype=np.float32)
+                )
+
+        if np.all(world.terminateds) or np.all(world.truncateds):
+            break
+
+    # ── 5. Print metrics ─────────────────────────────────────────────────────
+    print('\n' + '=' * 60)
+    print('  METRICS REPORT')
+    print('=' * 60)
+
+    for env_idx in range(NUM_ENVS):
+        ret = np.array(daily_returns[env_idx], dtype=np.float32)
+        bench = np.array(bench_returns[env_idx], dtype=np.float32)
+        pvals = np.array(portfolio_vals[env_idx], dtype=np.float32)
+        n = len(ret)
+        if n == 0:
+            continue
+
+        total_return = (
+            float(pvals[-1] / pvals[0] - 1.0) if pvals[0] > 0 else 0.0
+        )
+        ann_ret = calculate_annualized_return(total_return, n)
+        ann_vol = calculate_annualized_volatility(ret)
+        sharpe = calculate_sharpe_ratio(ret)
+        sortino = calculate_sortino_ratio(ret)
+        mdd = calculate_max_drawdown(pvals)
+
+        bench_total = float(np.prod(1.0 + bench) - 1.0)
+        bench_ann = calculate_annualized_return(bench_total, n)
+        ir, tracking_err = calculate_information_ratio(
+            ret, bench, ann_ret, bench_ann
+        )
+
+        ic_metrics: dict = {}
+        if predicted_lists[env_idx] and realized_lists[env_idx]:
+            ic_metrics = calculate_ic_series(
+                predicted_lists[env_idx], realized_lists[env_idx]
+            )
+
+        print(f'\n  Env {env_idx}')
+        print(f'    Steps          : {n}')
+        print(f'    Final PV       : {pvals[-1]:>12.2f}')
+        print(f'    Total return   : {total_return * 100:>+8.2f}%')
+        print(f'    Ann. return    : {ann_ret * 100:>+8.2f}%')
+        print(f'    Ann. vol       : {ann_vol * 100:>8.2f}%')
+        print(f'    Sharpe         : {sharpe:>8.3f}')
+        print(f'    Sortino        : {sortino:>8.3f}')
+        print(f'    Max drawdown   : {mdd * 100:>8.2f}%')
+        print(
+            f'    Info. ratio    : {ir:>8.3f}  (tracking err {tracking_err * 100:.2f}%)'
+        )
+        if ic_metrics:
+            print(
+                f'    IC mean        : {ic_metrics.get("ic_mean", float("nan")):>8.4f}'
+            )
+            print(
+                f'    ICIR           : {ic_metrics.get("icir", float("nan")):>8.4f}'
+            )
+            print(
+                f'    Rank IC mean   : {ic_metrics.get("rank_ic_mean", float("nan")):>8.4f}'
+            )
+            print(
+                f'    Rank ICIR      : {ic_metrics.get("rank_icir", float("nan")):>8.4f}'
+            )
+
+    print('\n' + '=' * 60)
+    print(f'  Frame images saved to : {img_dir}')
+    print(f'  Videos saved to       : {video_path}')
+    print('=' * 60)
+
+    world.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/stable_worldmodel/envs/__init__.py
+++ b/stable_worldmodel/envs/__init__.py
@@ -127,3 +127,10 @@ register(
     id='swm/PushT-Discrete-v1',
     entry_point='stable_worldmodel.envs.pusht:PushTDiscrete',
 )
+
+register(
+    id='swm/STONK-v0',
+    entry_point='stable_worldmodel.envs.fin_env.financial:FinancialEnvironment',
+)
+
+from stable_worldmodel.envs.dataset_registry import register_financial_dataset  # noqa: E402,F401

--- a/stable_worldmodel/envs/dataset_registry.py
+++ b/stable_worldmodel/envs/dataset_registry.py
@@ -1,0 +1,114 @@
+"""Registry for pluggable financial dataset loaders.
+
+Usage::
+
+    from stable_worldmodel.envs.dataset_registry import register_financial_dataset
+
+    def my_loader(symbols, start_date, end_date):
+        # Return a pd.DataFrame with MultiIndex (date, symbol) and
+        # columns: open, high, low, close, volume  (daily frequency)
+        ...
+
+    register_financial_dataset(my_loader)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+_REGISTRY: dict[str, dict] = {}
+
+# Used when no dataset with date-range metadata has been registered yet.
+_FALLBACK_START_DATES = [
+    '2015-01-01',
+    '2016-01-01',
+    '2017-01-01',
+    '2018-01-01',
+    '2019-01-01',
+]
+
+
+def register_financial_dataset(
+    loader: Callable,
+    name: str = 'default',
+    start_date: str | None = None,
+    end_date: str | None = None,
+    max_stocks: int | None = None,
+) -> None:
+    """Register a dataset loader function under *name*.
+
+    Args:
+        loader: A callable with signature
+            ``loader(symbols, start_date, end_date, universe) -> pd.DataFrame``.
+            The returned DataFrame must have a MultiIndex ``(date, symbol)``
+            sorted chronologically and columns
+            ``open``, ``high``, ``low``, ``close``, ``volume``.
+        name: Registry key (default ``'default'``).
+        start_date: Earliest date the dataset covers (``'YYYY-MM-DD'``).  Used
+            to auto-derive episode start dates in :class:`FinancialEnvironment`.
+        end_date: Latest date the dataset covers (``'YYYY-MM-DD'``).
+        max_stocks: Maximum number of stocks this dataset can contain across all
+            universes.  Used by :class:`FinancialEnvironment` to compute the
+            smallest square observation grid that fits all stocks.
+    """
+    _REGISTRY[name] = {
+        'loader': loader,
+        'start_date': start_date,
+        'end_date': end_date,
+        'max_stocks': max_stocks,
+    }
+
+
+def get_registered_dataset(name: str = 'default') -> Callable | None:
+    """Return the loader registered under *name*, or ``None`` if absent."""
+    entry = _REGISTRY.get(name)
+    return entry['loader'] if entry else None
+
+
+def get_registered_max_stocks() -> int | None:
+    """Return the maximum ``max_stocks`` value across all registered datasets.
+
+    Returns ``None`` when no dataset has been registered with an explicit
+    ``max_stocks`` value.
+    """
+    values = [
+        e['max_stocks']
+        for e in _REGISTRY.values()
+        if e.get('max_stocks') is not None
+    ]
+    return max(values) if values else None
+
+
+def get_registered_universes() -> list[str]:
+    """Return the names of all currently registered dataset loaders.
+
+    These names are used as the universe list in :class:`FinancialEnvironment`.
+    """
+    return list(_REGISTRY.keys())
+
+
+def get_registered_start_dates(reserve_years: int = 1) -> list[str]:
+    """Derive annual episode start dates from registered dataset metadata.
+
+    Generates one ``'YYYY-01-01'`` entry per year starting from the earliest
+    registered ``start_date`` up to ``latest end_date - reserve_years``,
+    leaving at least *reserve_years* of data for each episode.
+
+    Falls back to :data:`_FALLBACK_START_DATES` when no dataset has been
+    registered with explicit date-range metadata.
+    """
+    starts = [
+        e['start_date'] for e in _REGISTRY.values() if e.get('start_date')
+    ]
+    ends = [e['end_date'] for e in _REGISTRY.values() if e.get('end_date')]
+
+    if not starts or not ends:
+        return list(_FALLBACK_START_DATES)
+
+    start_year = int(min(starts)[:4])
+    end_year = int(max(ends)[:4]) - reserve_years
+
+    if end_year < start_year:
+        return list(_FALLBACK_START_DATES)
+
+    return [f'{year}-01-01' for year in range(start_year, end_year + 1)]

--- a/stable_worldmodel/envs/fin_env/financial.py
+++ b/stable_worldmodel/envs/fin_env/financial.py
@@ -1,0 +1,494 @@
+"""STONK — financial market cross-section environment for stable-worldmodel.
+
+Observation: A×A RGB heatmap where each pixel encodes one stock's daily
+return (green = positive, red = negative, black = zero/missing).  A is the
+smallest integer satisfying A*A >= max_stocks across all registered datasets.
+
+Action: portfolio weight vector over all stocks (long/short).
+
+Data: pluggable via ``register_financial_dataset``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import cv2
+import gymnasium as gym
+import numpy as np
+import pandas as pd
+from gymnasium import spaces
+
+from stable_worldmodel import spaces as swm_spaces
+from stable_worldmodel.envs.dataset_registry import (
+    get_registered_dataset,
+    get_registered_max_stocks,
+    get_registered_start_dates,
+    get_registered_universes,
+    register_financial_dataset as register_financial_dataset,
+)
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+DEFAULT_VARIATIONS = (
+    'market.start_date_idx',
+    'market.universe_idx',
+    'agent.starting_balance',
+    'agent.transaction_cost',
+    'agent.return_clip',
+)
+
+_FALLBACK_IMG_SIZE = 64
+_MAX_RETURN_CLIP = 0.05  # ±5 % daily return → full colour saturation
+
+
+def _compute_grid_size(n_stocks: int) -> int:
+    """Return the side length of the smallest square grid that fits *n_stocks* pixels."""
+    return max(1, math.ceil(math.sqrt(n_stocks)))
+
+
+# Quintile action values: strong short, short, hold, long, strong long
+_N_QUINTILES = 5
+_QUINTILE_WEIGHTS = np.array([-1.0, -0.5, 0.0, 0.5, 1.0], dtype=np.float32)
+
+# Maximum portfolio colour saturation at this weight magnitude
+_MAX_WEIGHT_CLIP = 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Environment
+# --------------------------------------------------------------------------- #
+
+
+class FinancialEnvironment(gym.Env):
+    """Daily cross-section financial backtesting environment.
+
+    Observation space: ``(A, A, 6)`` uint8 — two stacked RGB images (market
+    heatmap and portfolio heatmap), where A is the smallest integer satisfying
+    ``A*A >= max_stocks`` across all registered datasets.
+    Action space:      ``MultiDiscrete([5] * n_stocks)`` — per-stock quintile
+    assignment (0=strong short … 4=strong long).
+    """
+
+    metadata = {'render_modes': ['rgb_array'], 'render_fps': 1}
+    reward_range = (-np.inf, np.inf)
+
+    def __init__(
+        self,
+        end_date: str | None = None,
+        render_mode: str | None = 'rgb_array',
+    ) -> None:
+        super().__init__()
+        self.render_mode = render_mode
+        self.end_date = end_date or '2024-12-31'
+
+        # Compute the smallest square grid that fits all registered stocks.
+        _max_stocks = get_registered_max_stocks()
+        self._img_size: int = (
+            _compute_grid_size(_max_stocks)
+            if _max_stocks is not None
+            else _FALLBACK_IMG_SIZE
+        )
+
+        # Observation space: two stacked RGB images (market + portfolio heatmap).
+        self.observation_space = spaces.Box(
+            low=0,
+            high=255,
+            shape=(self._img_size, self._img_size, 6),
+            dtype=np.uint8,
+        )
+        # Placeholder action space; replaced in reset() once n_stocks is known.
+        self.action_space = spaces.MultiDiscrete(
+            np.full(1, _N_QUINTILES, dtype=np.int64)
+        )
+
+        self._start_dates: list[str] = get_registered_start_dates()
+        self.variation_space = self._build_variation_space()
+
+        assert self.variation_space.check(), 'Invalid default variation values'
+
+        # Episode state (populated by reset)
+        self._data: pd.DataFrame | None = None
+        self._dates: list[str] = []
+        self._symbols: list[str] = []
+        self._current_date_idx: int = 0
+        self._portfolio_value: float = 100000.0
+        self._prev_weights: np.ndarray | None = None
+        self._transaction_cost: float = 0.001
+        self._starting_balance: float = 100000.0
+        self._return_clip: float = _MAX_RETURN_CLIP
+        self._close_pivot: pd.DataFrame | None = None
+        self._current_weights: np.ndarray | None = (
+            None  # current normalised weights (n_stocks,)
+        )
+        self._universe: str = 'full'  # active universe name
+        self._max_portfolio_value: float = 100000.0  # for drawdown tracking
+
+    # ------------------------------------------------------------------
+    # Gymnasium API
+    # ------------------------------------------------------------------
+
+    def _build_variation_space(self) -> swm_spaces.Dict:
+        """Build the variation space from ``self._start_dates`` and registered universes."""
+        universes = get_registered_universes()
+        n_universes = max(
+            len(universes), 1
+        )  # avoid n=0 before any dataset is registered
+        default_universe_idx = max(n_universes - 1, 0)
+
+        n_start_dates = max(
+            len(self._start_dates), 1
+        )  # avoid n=0 if list is empty
+
+        return swm_spaces.Dict(
+            {
+                'market': swm_spaces.Dict(
+                    {
+                        'start_date_idx': swm_spaces.Discrete(
+                            n=n_start_dates,
+                            start=0,
+                            init_value=0,
+                        ),
+                        'universe_idx': swm_spaces.Discrete(
+                            n=n_universes,
+                            start=0,
+                            init_value=default_universe_idx,
+                        ),
+                    }
+                ),
+                'agent': swm_spaces.Dict(
+                    {
+                        'starting_balance': swm_spaces.Box(
+                            low=10000.0,
+                            high=1000000.0,
+                            init_value=np.array(100000.0, dtype=np.float32),
+                            shape=(),
+                            dtype=np.float32,
+                        ),
+                        'transaction_cost': swm_spaces.Box(
+                            low=0.0,
+                            high=0.01,
+                            init_value=np.array(0.001, dtype=np.float32),
+                            shape=(),
+                            dtype=np.float32,
+                        ),
+                        'return_clip': swm_spaces.Box(
+                            low=0.01,
+                            high=0.20,
+                            init_value=np.array(
+                                _MAX_RETURN_CLIP, dtype=np.float32
+                            ),
+                            shape=(),
+                            dtype=np.float32,
+                        ),
+                    }
+                ),
+            },
+            sampling_order=['market', 'agent'],
+        )
+
+    def reset(self, seed: int | None = None, options: dict | None = None):
+        super().reset(seed=seed, options=options)
+        options = options or {}
+
+        swm_spaces.reset_variation_space(
+            self.variation_space, seed, options, DEFAULT_VARIATIONS
+        )
+
+        start_date: str = self._start_dates[
+            int(self.variation_space['market']['start_date_idx'].value)
+        ]
+        end_date: str = self.end_date
+        universes = get_registered_universes()
+        self._universe = universes[
+            int(self.variation_space['market']['universe_idx'].value)
+        ]
+        self._starting_balance = float(
+            self.variation_space['agent']['starting_balance'].value
+        )
+        self._transaction_cost = float(
+            self.variation_space['agent']['transaction_cost'].value
+        )
+        self._return_clip = float(
+            self.variation_space['agent']['return_clip'].value
+        )
+
+        loader = get_registered_dataset('default')
+        if loader is None:
+            raise ValueError(
+                'No financial dataset has been registered. Register one with:\n\n'
+                '    from stable_worldmodel.envs.dataset_registry import register_financial_dataset\n'
+                '    register_financial_dataset(your_loader)\n\n'
+                'The loader must accept (symbols, start_date, end_date, universe) keyword arguments\n'
+                'and return a pd.DataFrame with MultiIndex (date, symbol) and columns\n'
+                'open, high, low, close, volume (daily frequency).'
+            )
+
+        df = loader(
+            symbols=None,
+            start_date=start_date,
+            end_date=end_date,
+            universe=self._universe,
+        )
+        self._validate_data(df)
+
+        df = df.sort_index()
+        self._data = df
+        self._dates = sorted(
+            df.index.get_level_values('date').unique().tolist()
+        )
+        self._symbols = sorted(
+            df.index.get_level_values('symbol').unique().tolist()
+        )
+
+        self._close_pivot = (
+            df['close']
+            .unstack(level='symbol')
+            .reindex(columns=self._symbols)
+            .sort_index()
+        )
+
+        n_stocks = len(self._symbols)
+
+        # Action space: per-stock quintile assignment
+        # Each stock gets assigned to one of 5 quintiles: {0,1,2,3,4}
+        # = {strong short, short, hold, long, strong long}
+        self.action_space = spaces.MultiDiscrete(
+            np.full(n_stocks, _N_QUINTILES, dtype=np.int64)
+        )
+
+        self._current_date_idx = 1
+        self._portfolio_value = self._starting_balance
+        self._max_portfolio_value = self._starting_balance
+        self._current_weights = np.zeros(n_stocks, dtype=np.float32)
+        self._prev_weights = np.zeros(n_stocks, dtype=np.float32)
+
+        observation = self._get_observation()
+        info = self._get_info()
+        return observation, info
+
+    def step(self, action: np.ndarray):
+        if self._data is None:
+            raise RuntimeError(
+                'Environment not initialised — call reset() first.'
+            )
+
+        # Convert quintile assignments to normalised portfolio weights
+        action = np.asarray(action, dtype=np.int64)
+        weights = self._quintiles_to_weights(action)
+
+        returns = self._get_daily_returns(self._current_date_idx)
+
+        # Portfolio return
+        portfolio_return = float(np.dot(weights, returns))
+        benchmark_return = float(np.nanmean(returns))
+
+        # Transaction cost proportional to L1 turnover
+        turnover = float(np.sum(np.abs(weights - self._prev_weights)))
+        cost = turnover * self._transaction_cost
+        reward = portfolio_return - cost
+
+        self._portfolio_value *= 1.0 + reward
+        self._max_portfolio_value = max(
+            self._max_portfolio_value, self._portfolio_value
+        )
+        self._prev_weights = weights.copy()
+        self._current_weights = weights.copy()
+
+        self._current_date_idx += 1
+        terminated = self._current_date_idx >= len(self._dates)
+        truncated = False
+
+        observation = (
+            self._get_observation() if not terminated else self._black_frame()
+        )
+        info = self._get_info(
+            daily_return=portfolio_return, benchmark_return=benchmark_return
+        )
+        return observation, reward, terminated, truncated, info
+
+    def render(self):
+        if self.render_mode != 'rgb_array':
+            return None
+        obs = self._get_observation()
+        market_img = obs[:, :, :3]  # first three channels only
+        return cv2.resize(
+            market_img, (224, 224), interpolation=cv2.INTER_NEAREST
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def close(self):
+        """Clean up resources. Called by SWM when the world is torn down."""
+        self._data = None
+        self._close_pivot = None
+        self._dates = []
+        self._symbols = []
+
+    @staticmethod
+    def _validate_data(df: pd.DataFrame) -> None:
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(
+                f'Dataset loader must return pd.DataFrame, got {type(df).__name__}'
+            )
+        if not isinstance(df.index, pd.MultiIndex):
+            raise ValueError(
+                'DataFrame must have a MultiIndex with levels (date, symbol)'
+            )
+        index_names = [n or '' for n in df.index.names]
+        if 'date' not in index_names or 'symbol' not in index_names:
+            raise ValueError(
+                f"MultiIndex must have levels named 'date' and 'symbol', got {df.index.names}"
+            )
+        required = {'open', 'high', 'low', 'close', 'volume'}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(f'Missing required columns: {missing}')
+        if df.empty:
+            raise ValueError('Dataset loader returned an empty DataFrame')
+
+    def _get_daily_returns(self, date_idx: int) -> np.ndarray:
+        """Vectorised close-to-close daily return for the given date index."""
+        if date_idx <= 0 or self._close_pivot is None:
+            return np.zeros(len(self._symbols), dtype=np.float32)
+
+        cur = self._close_pivot.iloc[date_idx].values
+        prev = self._close_pivot.iloc[date_idx - 1].values
+
+        with np.errstate(divide='ignore', invalid='ignore'):
+            returns = np.where(prev != 0.0, (cur - prev) / prev, 0.0)
+
+        return np.nan_to_num(returns, nan=0.0, posinf=0.0, neginf=0.0).astype(
+            np.float32
+        )
+
+    def _get_observation(self) -> np.ndarray:
+        """Return the stacked RGB observation for the current date index."""
+        if self._close_pivot is None or self._current_date_idx >= len(
+            self._dates
+        ):
+            return self._black_frame()
+
+        returns = self._get_daily_returns(self._current_date_idx)
+
+        # Clip and normalise to [-1, 1]
+        clipped = np.clip(returns / self._return_clip, -1.0, 1.0)
+
+        # Pad to exactly img_size*img_size pixels
+        n_pixels = self._img_size * self._img_size
+        padded = np.zeros(n_pixels, dtype=np.float32)
+        n = min(len(clipped), n_pixels)
+        padded[:n] = clipped[:n]
+
+        # Build RGB channels vectorised
+        image = np.zeros((n_pixels, 3), dtype=np.uint8)
+        pos_mask = padded > 0.0
+        neg_mask = padded < 0.0
+        image[pos_mask, 1] = (padded[pos_mask] * 255).astype(
+            np.uint8
+        )  # green channel
+        image[neg_mask, 0] = (-padded[neg_mask] * 255).astype(
+            np.uint8
+        )  # red channel
+
+        market_img = image.reshape(self._img_size, self._img_size, 3)
+        portfolio_img = self._get_portfolio_heatmap()
+
+        # Stack along channel axis: (A, A, 6)
+        return np.concatenate([market_img, portfolio_img], axis=2)
+
+    def _black_frame(self) -> np.ndarray:
+        return np.zeros((self._img_size, self._img_size, 6), dtype=np.uint8)
+
+    def _get_info(
+        self,
+        daily_return: float = 0.0,
+        benchmark_return: float = 0.0,
+    ) -> dict:
+        idx = min(self._current_date_idx, len(self._dates) - 1)
+        current_date = self._dates[idx] if self._dates else ''
+
+        drawdown = 0.0
+        if self._max_portfolio_value > 0:
+            drawdown = (
+                self._max_portfolio_value - self._portfolio_value
+            ) / self._max_portfolio_value
+
+        return {
+            'date': current_date,
+            'portfolio_value': float(self._portfolio_value),
+            'daily_return': daily_return,
+            'benchmark_return': benchmark_return,
+            'drawdown': float(drawdown),
+            'universe': self._universe,
+            'n_stocks': len(self._symbols),
+            'goal': np.zeros(
+                (self._img_size, self._img_size, 6), dtype=np.uint8
+            ),
+        }
+
+    @staticmethod
+    def _quintiles_to_weights(action: np.ndarray) -> np.ndarray:
+        """Convert per-stock quintile assignments to normalised portfolio weights.
+
+        Quintile mapping:
+            0 = strong short  (-1.0)
+            1 = short         (-0.5)
+            2 = hold          ( 0.0)
+            3 = long          (+0.5)
+            4 = strong long   (+1.0)
+
+        Long positions are normalised to sum to 1.
+        Short positions are normalised to sum to -1.
+        """
+        raw = _QUINTILE_WEIGHTS[action]  # map quintile indices to raw weights
+
+        long_w = np.where(raw > 0.0, raw, 0.0)
+        short_w = np.where(raw < 0.0, raw, 0.0)
+
+        long_sum = float(long_w.sum())
+        short_sum = float(abs(short_w.sum()))
+
+        if long_sum > 0.0:
+            long_w /= long_sum
+        if short_sum > 0.0:
+            short_w /= short_sum
+
+        return (long_w + short_w).astype(np.float32)
+
+    def _get_portfolio_heatmap(self) -> np.ndarray:
+        """Return AxAx3 RGB image encoding current portfolio weights.
+
+        Green = long position, intensity proportional to weight magnitude.
+        Red   = short position, intensity proportional to weight magnitude.
+        Black = no position.
+        """
+        if not self._symbols:
+            return np.zeros(
+                (self._img_size, self._img_size, 3), dtype=np.uint8
+            )
+
+        weights = (
+            self._current_weights
+            if self._current_weights is not None
+            else np.zeros(len(self._symbols), dtype=np.float32)
+        )
+
+        clipped = np.clip(weights / _MAX_WEIGHT_CLIP, -1.0, 1.0)
+
+        n_pixels = self._img_size * self._img_size
+        padded = np.zeros(n_pixels, dtype=np.float32)
+        n = min(len(clipped), n_pixels)
+        padded[:n] = clipped[:n]
+
+        image = np.zeros((n_pixels, 3), dtype=np.uint8)
+        pos_mask = padded > 0.0
+        neg_mask = padded < 0.0
+        image[pos_mask, 1] = (padded[pos_mask] * 255).astype(np.uint8)  # green
+        image[neg_mask, 0] = (-padded[neg_mask] * 255).astype(np.uint8)  # red
+
+        return image.reshape(self._img_size, self._img_size, 3)

--- a/stable_worldmodel/envs/fin_env/financial.py
+++ b/stable_worldmodel/envs/fin_env/financial.py
@@ -100,8 +100,10 @@ class FinancialEnvironment(gym.Env):
             dtype=np.uint8,
         )
         # Placeholder action space; replaced in reset() once n_stocks is known.
+        # Use max_stocks if available so the vectorised env caches the correct shape.
+        _placeholder_stocks = _max_stocks if _max_stocks is not None else 1
         self.action_space = spaces.MultiDiscrete(
-            np.full(1, _N_QUINTILES, dtype=np.int64)
+            np.full(_placeholder_stocks, _N_QUINTILES, dtype=np.int64)
         )
 
         self._start_dates: list[str] = get_registered_start_dates()
@@ -375,7 +377,7 @@ class FinancialEnvironment(gym.Env):
 
         returns = self._get_daily_returns(self._current_date_idx)
 
-        # Clip and normalise to [-1, 1]
+        # Clip and normalise to [-1, 1] using fixed scale (preserves magnitude across days)
         clipped = np.clip(returns / self._return_clip, -1.0, 1.0)
 
         # Pad to exactly img_size*img_size pixels
@@ -426,9 +428,7 @@ class FinancialEnvironment(gym.Env):
             'drawdown': float(drawdown),
             'universe': self._universe,
             'n_stocks': len(self._symbols),
-            'goal': np.zeros(
-                (self._img_size, self._img_size, 6), dtype=np.uint8
-            ),
+            'goal': self._get_portfolio_heatmap(relative_scale=True),
         }
 
     @staticmethod
@@ -460,12 +460,18 @@ class FinancialEnvironment(gym.Env):
 
         return (long_w + short_w).astype(np.float32)
 
-    def _get_portfolio_heatmap(self) -> np.ndarray:
+    def _get_portfolio_heatmap(
+        self, relative_scale: bool = False
+    ) -> np.ndarray:
         """Return AxAx3 RGB image encoding current portfolio weights.
 
         Green = long position, intensity proportional to weight magnitude.
         Red   = short position, intensity proportional to weight magnitude.
         Black = no position.
+
+        Args:
+            relative_scale: If True, normalize to max weight (for visualization).
+                            If False, normalize to _MAX_WEIGHT_CLIP (for learning).
         """
         if not self._symbols:
             return np.zeros(
@@ -478,7 +484,11 @@ class FinancialEnvironment(gym.Env):
             else np.zeros(len(self._symbols), dtype=np.float32)
         )
 
-        clipped = np.clip(weights / _MAX_WEIGHT_CLIP, -1.0, 1.0)
+        if relative_scale:
+            max_abs = float(np.abs(weights).max())
+            clipped = weights / max_abs if max_abs > 0.0 else weights.copy()
+        else:
+            clipped = np.clip(weights / _MAX_WEIGHT_CLIP, -1.0, 1.0)
 
         n_pixels = self._img_size * self._img_size
         padded = np.zeros(n_pixels, dtype=np.float32)

--- a/stable_worldmodel/envs/fin_env/financial.py
+++ b/stable_worldmodel/envs/fin_env/financial.py
@@ -197,6 +197,17 @@ class FinancialEnvironment(gym.Env):
             self.variation_space, seed, options, DEFAULT_VARIATIONS
         )
 
+        loader = get_registered_dataset('default')
+        if loader is None:
+            raise ValueError(
+                'No financial dataset has been registered. Register one with:\n\n'
+                '    from stable_worldmodel.envs.dataset_registry import register_financial_dataset\n'
+                '    register_financial_dataset(your_loader)\n\n'
+                'The loader must accept (symbols, start_date, end_date, universe) keyword arguments\n'
+                'and return a pd.DataFrame with MultiIndex (date, symbol) and columns\n'
+                'open, high, low, close, volume (daily frequency).'
+            )
+
         start_date: str = self._start_dates[
             int(self.variation_space['market']['start_date_idx'].value)
         ]
@@ -214,17 +225,6 @@ class FinancialEnvironment(gym.Env):
         self._return_clip = float(
             self.variation_space['agent']['return_clip'].value
         )
-
-        loader = get_registered_dataset('default')
-        if loader is None:
-            raise ValueError(
-                'No financial dataset has been registered. Register one with:\n\n'
-                '    from stable_worldmodel.envs.dataset_registry import register_financial_dataset\n'
-                '    register_financial_dataset(your_loader)\n\n'
-                'The loader must accept (symbols, start_date, end_date, universe) keyword arguments\n'
-                'and return a pd.DataFrame with MultiIndex (date, symbol) and columns\n'
-                'open, high, low, close, volume (daily frequency).'
-            )
 
         df = loader(
             symbols=None,

--- a/stable_worldmodel/envs/fin_env/metrics.py
+++ b/stable_worldmodel/envs/fin_env/metrics.py
@@ -1,0 +1,227 @@
+"""Financial performance metric utility functions.
+
+These functions are used externally by benchmark eval scripts.
+They are NOT called inside FinancialEnvironment itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+from scipy import stats as scipy_stats
+
+PERIODS_PER_YEAR: int = 252
+
+
+def calculate_sharpe_ratio(
+    returns: np.ndarray,
+    risk_free_rate: float = 0.02,
+    periods_per_year: int = PERIODS_PER_YEAR,
+) -> float:
+    if len(returns) < 2:
+        return 0.0
+    risk_free_period = risk_free_rate / periods_per_year
+    excess_returns = returns - risk_free_period
+    std = np.std(excess_returns, ddof=1)
+    if std == 0:
+        return 0.0
+    return float(np.mean(excess_returns) / std * np.sqrt(periods_per_year))
+
+
+def calculate_sortino_ratio(
+    returns: np.ndarray,
+    risk_free_rate: float = 0.02,
+    periods_per_year: int = PERIODS_PER_YEAR,
+) -> float:
+    if len(returns) < 2:
+        return 0.0
+    risk_free_period = risk_free_rate / periods_per_year
+    excess_returns = returns - risk_free_period
+    downside_returns = returns[returns < 0]
+    if len(downside_returns) == 0:
+        return 0.0
+    downside_std = np.std(downside_returns, ddof=1)
+    if downside_std == 0:
+        return 0.0
+    downside_volatility = downside_std * np.sqrt(periods_per_year)
+    return float(
+        np.mean(excess_returns) * periods_per_year / downside_volatility
+    )
+
+
+def calculate_max_drawdown(portfolio_values: Sequence[float]) -> float:
+    if len(portfolio_values) < 2:
+        return 0.0
+    values = np.array(portfolio_values)
+    cumulative_max = np.maximum.accumulate(values)
+    drawdowns = (values - cumulative_max) / cumulative_max
+    return float(abs(np.min(drawdowns)))
+
+
+def calculate_information_ratio(
+    returns: np.ndarray,
+    benchmark_returns: np.ndarray,
+    annualized_return: float,
+    benchmark_annualized: float,
+    periods_per_year: int = PERIODS_PER_YEAR,
+) -> tuple[float, float]:
+    if len(returns) != len(benchmark_returns) or len(returns) < 2:
+        return 0.0, 0.0
+    active_returns = returns - benchmark_returns
+    tracking_error = np.std(active_returns, ddof=1) * np.sqrt(periods_per_year)
+    if tracking_error == 0:
+        return 0.0, 0.0
+    information_ratio = (
+        annualized_return - benchmark_annualized
+    ) / tracking_error
+    return float(information_ratio), float(tracking_error)
+
+
+def calculate_annualized_return(
+    total_return: float,
+    total_periods: int,
+    periods_per_year: int = PERIODS_PER_YEAR,
+) -> float:
+    if total_periods == 0:
+        return 0.0
+    years = total_periods / periods_per_year
+    if years < 1 / periods_per_year:
+        years = 1 / periods_per_year
+    return float((1 + total_return) ** (1 / years) - 1)
+
+
+def calculate_annualized_volatility(
+    returns: np.ndarray,
+    periods_per_year: int = PERIODS_PER_YEAR,
+) -> float:
+    """Annualized standard deviation of returns (AVol)."""
+    if len(returns) < 2:
+        return 0.0
+    return float(np.std(returns, ddof=1) * np.sqrt(periods_per_year))
+
+
+def calculate_ic(
+    predicted_returns: np.ndarray,
+    realized_returns: np.ndarray,
+) -> float:
+    """Information Coefficient — Pearson correlation between predicted and
+    realized cross-sectional returns at a single timestep.
+
+    IC > 0 means predictions are positively correlated with outcomes.
+    IC = 1 means perfect prediction.
+    """
+    if (
+        len(predicted_returns) != len(realized_returns)
+        or len(predicted_returns) < 2
+    ):
+        return 0.0
+    std_p = np.std(predicted_returns)
+    std_r = np.std(realized_returns)
+    if std_p == 0 or std_r == 0:
+        return 0.0
+    return float(np.corrcoef(predicted_returns, realized_returns)[0, 1])
+
+
+def calculate_icir(
+    ic_series: np.ndarray,
+) -> float:
+    """IC Information Ratio — mean IC divided by std of IC over time.
+
+    Measures consistency of prediction skill.
+    A high ICIR means the model's IC is stable across time, not just
+    occasionally lucky.
+
+    Args:
+        ic_series: Array of per-timestep IC values computed via calculate_ic.
+    """
+    if len(ic_series) < 2:
+        return 0.0
+    std = np.std(ic_series, ddof=1)
+    if std == 0:
+        return 0.0
+    return float(np.mean(ic_series) / std)
+
+
+def calculate_rank_ic(
+    predicted_returns: np.ndarray,
+    realized_returns: np.ndarray,
+) -> float:
+    """Rank IC — Spearman rank correlation between predicted and realized
+    cross-sectional returns at a single timestep.
+
+    More robust than IC because it is insensitive to outliers and does not
+    assume a linear relationship between predictions and outcomes. This is
+    the primary ranking metric for cross-sectional models.
+    """
+    if (
+        len(predicted_returns) != len(realized_returns)
+        or len(predicted_returns) < 2
+    ):
+        return 0.0
+    correlation, _ = scipy_stats.spearmanr(predicted_returns, realized_returns)
+    if np.isnan(correlation):
+        return 0.0
+    return float(correlation)
+
+
+def calculate_rank_icir(
+    rank_ic_series: np.ndarray,
+) -> float:
+    """Rank ICIR — mean Rank IC divided by std of Rank IC over time.
+
+    Measures consistency of cross-sectional ranking skill.
+    Analogous to ICIR but based on Spearman correlation, making it more
+    robust to outlier days.
+
+    Args:
+        rank_ic_series: Array of per-timestep Rank IC values computed
+            via calculate_rank_ic.
+    """
+    if len(rank_ic_series) < 2:
+        return 0.0
+    std = np.std(rank_ic_series, ddof=1)
+    if std == 0:
+        return 0.0
+    return float(np.mean(rank_ic_series) / std)
+
+
+def calculate_ic_series(
+    predicted_returns_sequence: Sequence[np.ndarray],
+    realized_returns_sequence: Sequence[np.ndarray],
+) -> dict[str, float]:
+    """Compute IC, ICIR, RankIC, RankICIR from sequences of per-timestep arrays.
+
+    This is the primary entry point for ranking metric computation in eval
+    scripts. Pass in one array of predicted returns per timestep and one array
+    of realized returns per timestep.
+
+    Returns a dict with keys: ic_mean, icir, rank_ic_mean, rank_icir.
+
+    Example::
+
+        results = calculate_ic_series(
+            predicted_returns_sequence=model_predictions,  # list of (n_stocks,) arrays
+            realized_returns_sequence=actual_returns,      # list of (n_stocks,) arrays
+        )
+    """
+    ic_vals = []
+    rank_ic_vals = []
+
+    for pred, real in zip(
+        predicted_returns_sequence, realized_returns_sequence
+    ):
+        pred = np.asarray(pred, dtype=np.float32)
+        real = np.asarray(real, dtype=np.float32)
+        ic_vals.append(calculate_ic(pred, real))
+        rank_ic_vals.append(calculate_rank_ic(pred, real))
+
+    ic_arr = np.array(ic_vals, dtype=np.float32)
+    rank_ic_arr = np.array(rank_ic_vals, dtype=np.float32)
+
+    return {
+        'ic_mean': float(np.mean(ic_arr)),
+        'icir': calculate_icir(ic_arr),
+        'rank_ic_mean': float(np.mean(rank_ic_arr)),
+        'rank_icir': calculate_rank_icir(rank_ic_arr),
+    }

--- a/stable_worldmodel/world.py
+++ b/stable_worldmodel/world.py
@@ -269,6 +269,24 @@ class World:
                 goal_data = self.infos['goal'][i]
                 if goal_data.ndim > 3:
                     goal_data = goal_data[-1]
+                if (
+                    goal_data.ndim == 3
+                    and goal_data.shape[-1] != frame.shape[-1]
+                ):
+                    n_ch = frame.shape[-1]
+                    strips = [
+                        goal_data[..., j * n_ch : (j + 1) * n_ch]
+                        for j in range(goal_data.shape[-1] // n_ch)
+                    ]
+                    goal_data = np.hstack(strips)
+                if goal_data.shape[1] != frame.shape[1]:
+                    import cv2
+
+                    goal_data = cv2.resize(
+                        goal_data,
+                        (frame.shape[1], goal_data.shape[0]),
+                        interpolation=cv2.INTER_NEAREST,
+                    )
                 frame = np.vstack([frame, goal_data])
             o.append_data(frame)
 
@@ -292,6 +310,24 @@ class World:
                     goal_data = self.infos['goal'][i]
                     if goal_data.ndim > 3:
                         goal_data = goal_data[-1]
+                    if (
+                        goal_data.ndim == 3
+                        and goal_data.shape[-1] != frame.shape[-1]
+                    ):
+                        n_ch = frame.shape[-1]
+                        strips = [
+                            goal_data[..., j * n_ch : (j + 1) * n_ch]
+                            for j in range(goal_data.shape[-1] // n_ch)
+                        ]
+                        goal_data = np.hstack(strips)
+                    if goal_data.shape[1] != frame.shape[1]:
+                        import cv2
+
+                        goal_data = cv2.resize(
+                            goal_data,
+                            (frame.shape[1], goal_data.shape[0]),
+                            interpolation=cv2.INTER_NEAREST,
+                        )
                     frame = np.vstack([frame, goal_data])
                 o.append_data(frame)
         for o in out:

--- a/stable_worldmodel/wrapper.py
+++ b/stable_worldmodel/wrapper.py
@@ -3,7 +3,8 @@ import re
 import time
 from collections import deque
 from collections.abc import Callable, Iterable
-from typing import Any, Sequence
+from typing import Any
+from collections.abc import Sequence
 
 import gymnasium as gym
 import numpy as np
@@ -455,15 +456,22 @@ class ResizeGoalWrapper(gym.Wrapper):
         Returns:
             The processed goal image.
         """
-        # Convert to PIL Image for resizing
-        pil_img = self.Image.fromarray(img)
         height, width = self.pixels_shape
-        pil_img = pil_img.resize((width, height), self.Image.BILINEAR)
-        # Optionally apply torchvision transform
-        if self.torchvision_transform is not None:
-            pixels = self.torchvision_transform(pil_img)
+        n_channels = img.shape[-1] if img.ndim == 3 else 1
+        # PIL only supports 1/2/3/4-channel images; fall back to cv2 for others
+        if n_channels in (1, 2, 3, 4):
+            pil_img = self.Image.fromarray(img)
+            pil_img = pil_img.resize((width, height), self.Image.NEAREST)
+            if self.torchvision_transform is not None:
+                pixels = self.torchvision_transform(pil_img)
+            else:
+                pixels = np.array(pil_img)
         else:
-            pixels = np.array(pil_img)
+            import cv2
+
+            pixels = cv2.resize(
+                img, (width, height), interpolation=cv2.INTER_NEAREST
+            )
         return pixels
 
     def reset(self, *args: Any, **kwargs: Any) -> tuple[Any, dict]:

--- a/tests/envs/test_financial.py
+++ b/tests/envs/test_financial.py
@@ -1,0 +1,358 @@
+"""Tests for the financial environment and dataset registry.
+
+Covers:
+  - stable_worldmodel.envs.dataset_registry  (register, retrieve, metadata helpers)
+  - stable_worldmodel.envs.fin_env.financial  (FinancialEnvironment lifecycle)
+
+The tests use a small, fully-deterministic dummy dataset (4 stocks, 30 business
+days starting 2020-01-03) so they run quickly without any external data.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import stable_worldmodel.envs.dataset_registry as _registry_module
+from stable_worldmodel.envs.dataset_registry import (
+    get_registered_dataset,
+    get_registered_max_stocks,
+    get_registered_start_dates,
+    get_registered_universes,
+    register_financial_dataset,
+)
+from stable_worldmodel.envs.fin_env.financial import FinancialEnvironment
+
+# --------------------------------------------------------------------------- #
+# Shared test data
+# --------------------------------------------------------------------------- #
+
+_N_STOCKS = 4
+_SYMBOLS = ['AAAA', 'BBBB', 'CCCC', 'DDDD']
+_DATASET_START = '2020-01-01'
+_DATASET_END = '2021-12-31'
+_N_DAYS = 30  # number of business days the dummy data spans
+
+
+def _make_dummy_df(
+    start: str = '2020-01-03',
+    n_days: int = _N_DAYS,
+    symbols: list[str] = _SYMBOLS,
+    seed: int = 42,
+) -> pd.DataFrame:
+    """Return a minimal deterministic OHLCV DataFrame with MultiIndex (date, symbol)."""
+    rng = np.random.default_rng(seed)
+    dates = pd.bdate_range(start=start, periods=n_days)
+    rows = []
+    for date in dates:
+        for sym in symbols:
+            close = float(rng.uniform(50.0, 200.0))
+            rows.append(
+                {
+                    'date': date.strftime('%Y-%m-%d'),
+                    'symbol': sym,
+                    'open': close * float(rng.uniform(0.98, 1.02)),
+                    'high': close * float(rng.uniform(1.00, 1.03)),
+                    'low': close * float(rng.uniform(0.97, 1.00)),
+                    'close': close,
+                    'volume': float(rng.integers(100_000, 10_000_000)),
+                }
+            )
+    df = pd.DataFrame(rows).set_index(['date', 'symbol'])
+    df.index.names = ['date', 'symbol']
+    return df
+
+
+def _dummy_loader(
+    symbols=None,
+    start_date: str = _DATASET_START,
+    end_date: str = _DATASET_END,
+    universe: str = 'default',
+) -> pd.DataFrame:
+    """Deterministic loader: ignores arguments, always returns the same dummy data."""
+    return _make_dummy_df()
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def clean_registry(monkeypatch):
+    """Replace the global dataset registry with an empty dict for the test."""
+    monkeypatch.setattr(_registry_module, '_REGISTRY', {})
+
+
+@pytest.fixture()
+def registered_default(clean_registry):
+    """Register the dummy loader as 'default'. Depends on clean_registry."""
+    register_financial_dataset(
+        _dummy_loader,
+        name='default',
+        start_date=_DATASET_START,
+        end_date=_DATASET_END,
+        max_stocks=_N_STOCKS,
+    )
+
+
+@pytest.fixture()
+def env(registered_default):
+    """Create a FinancialEnvironment backed by the dummy dataset."""
+    fin_env = FinancialEnvironment(end_date=_DATASET_END)
+    yield fin_env
+    fin_env.close()
+
+
+# --------------------------------------------------------------------------- #
+# Dataset registry tests
+# --------------------------------------------------------------------------- #
+
+
+class TestDatasetRegistry:
+    def test_register_and_retrieve_loader(self, clean_registry):
+        register_financial_dataset(_dummy_loader, name='mydata')
+        assert get_registered_dataset('mydata') is _dummy_loader
+
+    def test_get_unknown_dataset_returns_none(self, clean_registry):
+        assert get_registered_dataset('nonexistent') is None
+
+    def test_get_max_stocks_none_when_empty(self, clean_registry):
+        assert get_registered_max_stocks() is None
+
+    def test_get_max_stocks_single_dataset(self, clean_registry):
+        register_financial_dataset(_dummy_loader, name='a', max_stocks=10)
+        assert get_registered_max_stocks() == 10
+
+    def test_get_max_stocks_returns_max_across_datasets(self, clean_registry):
+        register_financial_dataset(_dummy_loader, name='a', max_stocks=10)
+        register_financial_dataset(_dummy_loader, name='b', max_stocks=25)
+        assert get_registered_max_stocks() == 25
+
+    def test_get_universes_empty(self, clean_registry):
+        assert get_registered_universes() == []
+
+    def test_get_universes_lists_all_names(self, clean_registry):
+        register_financial_dataset(_dummy_loader, name='u1')
+        register_financial_dataset(_dummy_loader, name='u2')
+        assert set(get_registered_universes()) == {'u1', 'u2'}
+
+    def test_get_start_dates_fallback_when_empty(self, clean_registry):
+        dates = get_registered_start_dates()
+        assert len(dates) > 0
+        assert all(d.endswith('-01-01') for d in dates)
+
+    def test_get_start_dates_derived_from_metadata(self, clean_registry):
+        # start=2020, end=2022, reserve_years=1  →  range 2020..2021
+        register_financial_dataset(
+            _dummy_loader,
+            name='dated',
+            start_date='2020-01-01',
+            end_date='2022-12-31',
+        )
+        dates = get_registered_start_dates(reserve_years=1)
+        assert '2020-01-01' in dates
+        assert '2021-01-01' in dates
+        assert '2022-01-01' not in dates
+
+    def test_re_register_overwrites_entry(self, clean_registry):
+        register_financial_dataset(_dummy_loader, name='default', max_stocks=5)
+
+        def alt_loader(**kw):
+            return _make_dummy_df()
+
+        register_financial_dataset(alt_loader, name='default', max_stocks=9)
+        assert get_registered_dataset('default') is alt_loader
+        assert get_registered_max_stocks() == 9
+
+
+# --------------------------------------------------------------------------- #
+# FinancialEnvironment tests
+# --------------------------------------------------------------------------- #
+
+
+class TestFinancialEnvironment:
+    # ------------------------------------------------------------------ #
+    # reset()
+    # ------------------------------------------------------------------ #
+
+    def test_reset_returns_ndarray_observation(self, env):
+        obs, _ = env.reset(seed=0)
+        assert isinstance(obs, np.ndarray)
+        assert obs.ndim == 3
+        assert obs.shape[2] == 6  # two stacked RGB images → 6 channels
+        assert obs.dtype == np.uint8
+
+    def test_reset_observation_within_observation_space(self, env):
+        obs, _ = env.reset(seed=0)
+        assert env.observation_space.contains(obs)
+
+    def test_reset_info_contains_required_keys(self, env):
+        _, info = env.reset(seed=0)
+        for key in (
+            'date',
+            'portfolio_value',
+            'daily_return',
+            'benchmark_return',
+            'goal',
+        ):
+            assert key in info, f"Missing key '{key}' in reset info"
+
+    def test_reset_sets_action_space_to_n_stocks(self, env):
+        env.reset(seed=0)
+        assert hasattr(env.action_space, 'nvec'), (
+            'Expected MultiDiscrete action space'
+        )
+        assert len(env.action_space.nvec) == _N_STOCKS
+        # Each stock has 5 quintile choices
+        assert np.all(env.action_space.nvec == 5)
+
+    def test_reset_portfolio_value_equals_starting_balance(self, env):
+        _, info = env.reset(seed=0)
+        assert info['portfolio_value'] > 0.0
+
+    def test_reset_goal_shape_matches_observation(self, env):
+        obs, info = env.reset(seed=0)
+        assert info['goal'].shape == obs.shape
+
+    def test_reset_is_reproducible_with_same_seed(self, env):
+        obs1, _ = env.reset(seed=42)
+        obs2, _ = env.reset(seed=42)
+        np.testing.assert_array_equal(obs1, obs2)
+
+    # ------------------------------------------------------------------ #
+    # step()
+    # ------------------------------------------------------------------ #
+
+    def test_step_returns_five_tuple(self, env):
+        env.reset(seed=0)
+        action = env.action_space.sample()
+        result = env.step(action)
+        assert len(result) == 5
+
+    def test_step_returns_valid_types(self, env):
+        env.reset(seed=0)
+        obs, reward, terminated, truncated, info = env.step(
+            env.action_space.sample()
+        )
+        assert isinstance(obs, np.ndarray)
+        assert isinstance(reward, float)
+        assert isinstance(terminated, bool)
+        assert isinstance(truncated, bool)
+        assert isinstance(info, dict)
+
+    def test_step_obs_is_uint8_with_six_channels(self, env):
+        env.reset(seed=0)
+        obs, *_ = env.step(env.action_space.sample())
+        assert obs.dtype == np.uint8
+        assert obs.shape[2] == 6
+
+    def test_step_without_reset_raises_runtime_error(self, env):
+        with pytest.raises(RuntimeError, match='reset'):
+            env.step(np.zeros(_N_STOCKS, dtype=np.int64))
+
+    def test_step_all_hold_gives_zero_reward(self, env):
+        """Hold (quintile 2) with no prior position should have zero turnover cost."""
+        env.reset(seed=0)
+        hold_action = np.full(
+            _N_STOCKS, 2, dtype=np.int64
+        )  # quintile 2 = hold
+        _, reward, _, _, _ = env.step(hold_action)
+        # reward = portfolio_return - cost; hold has all-zero weights → both terms 0
+        assert reward == pytest.approx(0.0, abs=1e-6)
+
+    # ------------------------------------------------------------------ #
+    # render()
+    # ------------------------------------------------------------------ #
+
+    def test_render_returns_rgb_array(self, env):
+        env.reset(seed=0)
+        frame = env.render()
+        assert isinstance(frame, np.ndarray)
+        assert frame.ndim == 3
+        assert frame.shape[2] == 3  # RGB
+
+    def test_render_has_positive_spatial_dimensions(self, env):
+        env.reset(seed=0)
+        frame = env.render()
+        assert frame.shape[0] > 0
+        assert frame.shape[1] > 0
+
+    # ------------------------------------------------------------------ #
+    # Full episode
+    # ------------------------------------------------------------------ #
+
+    def test_full_episode_terminates(self, env):
+        env.reset(seed=0)
+        terminated = False
+        steps = 0
+        while not terminated:
+            _, _, terminated, _, _ = env.step(env.action_space.sample())
+            steps += 1
+            assert steps < 500, 'Episode did not terminate within 500 steps'
+        assert terminated
+
+    def test_episode_length_matches_dataset_days_minus_one(self, env):
+        """Episode length should be len(dates) - 1 (first date is the baseline)."""
+        env.reset(seed=0)
+        steps = 0
+        terminated = False
+        while not terminated:
+            _, _, terminated, _, _ = env.step(env.action_space.sample())
+            steps += 1
+        assert steps == _N_DAYS - 1
+
+    def test_portfolio_value_changes_during_episode(self, env):
+        env.reset(seed=0)
+        # Use a non-trivial action to ensure weight changes
+        action = np.array(
+            [4, 4, 0, 0], dtype=np.int64
+        )  # long AAAA/BBBB, short CCCC/DDDD
+        _, _, _, _, info = env.step(action)
+        # Portfolio value should still be positive and finite
+        assert np.isfinite(info['portfolio_value'])
+        assert info['portfolio_value'] > 0.0
+
+    # ------------------------------------------------------------------ #
+    # Variation space
+    # ------------------------------------------------------------------ #
+
+    def test_variation_space_has_market_and_agent_keys(self, env):
+        vspace = env.variation_space
+        assert 'market' in vspace.spaces
+        assert 'agent' in vspace.spaces
+
+    def test_variation_space_market_has_expected_subkeys(self, env):
+        market = env.variation_space['market']
+        assert 'start_date_idx' in market.spaces
+        assert 'universe_idx' in market.spaces
+
+    def test_variation_space_agent_has_expected_subkeys(self, env):
+        agent = env.variation_space['agent']
+        for key in ('starting_balance', 'transaction_cost', 'return_clip'):
+            assert key in agent.spaces, f"Missing agent variation key '{key}'"
+
+    # ------------------------------------------------------------------ #
+    # Error handling
+    # ------------------------------------------------------------------ #
+
+    def test_reset_raises_when_no_dataset_registered(self, clean_registry):
+        """reset() must raise a clear ValueError when no loader is registered."""
+        fin_env = FinancialEnvironment()
+        try:
+            with pytest.raises(ValueError, match='No financial dataset'):
+                fin_env.reset()
+        finally:
+            fin_env.close()
+
+    # ------------------------------------------------------------------ #
+    # close()
+    # ------------------------------------------------------------------ #
+
+    def test_close_clears_internal_state(self, env):
+        env.reset(seed=0)
+        env.close()
+        assert env._data is None
+        assert env._dates == []
+        assert env._symbols == []

--- a/tests/envs/test_financial.py
+++ b/tests/envs/test_financial.py
@@ -214,7 +214,8 @@ class TestFinancialEnvironment:
 
     def test_reset_goal_shape_matches_observation(self, env):
         obs, info = env.reset(seed=0)
-        assert info['goal'].shape == obs.shape
+        # goal is a single RGB heatmap (3 channels); obs stacks two heatmaps (6 channels)
+        assert info['goal'].shape == (obs.shape[0], obs.shape[1], 3)
 
     def test_reset_is_reproducible_with_same_seed(self, env):
         obs1, _ = env.reset(seed=42)


### PR DESCRIPTION
Adds the `swm/STONK-v0` financial markets environment, which uses a daily cross-sectional portfolio allocation environment where an agent assigns stocks to quintile positions (strong short → strong long) based on heatmap observations of market returns and current portfolio weights.

Key additions:
- FinancialEnvironment with pluggable OHLCV dataset support via register_financial_dataset
- Performance metrics module (Sharpe, Sortino, max drawdown, IC/ICIR, Rank IC/ICIR)
- Full test suite and docs
- Example smoke-test script with video recording and metrics report
- Fixes to wrapper.py and world.py to handle 6-channel observations; doesn't change any old functionality