### PR TITLE
Fix #174: Add world checker

### DIFF
--- a/stable_worldmodel/world.py
+++ b/stable_worldmodel/world.py
@@ -298,6 +298,42 @@ class World:
             o.close()
         print(f'Video saved to {video_path}')
 
+    def record_video_from_dataset(
+        self,
+        video_path: str | Path,
+        dataset_name: str,
+        episode_idx: int | list[int] = 0,
+        max_steps: int = 500,
+        fps: int = 30,
+        viewname: str | list[str] = 'pixels',
+        cache_dir: os.PathLike | str | None = None,
+    ) -> None:
+        """Record videos by replaying stored dataset episodes.
+
+        Args:
+            video_path: Directory path to save the videos.
+            dataset_name: Name of the HDF5 dataset to load.
+            episode_idx: Episode index or list of indices to record.
+            max_steps: Maximum frames per video.
+            fps: Frames per second for the output video.
+            viewname: Key(s) in the dataset to use as video frames.
+            cache_dir: Directory containing the dataset. Defaults to standard cache.
+        """
+        from stable_worldmodel.data.dataset import HDF5Dataset
+        from stable_worldmodel.utils import (
+            record_video_from_dataset as _record_video_from_dataset,
+        )
+
+        dataset = HDF5Dataset(dataset_name, cache_dir=cache_dir)
+        _record_video_from_dataset(
+            video_path,
+            dataset,
+            episode_idx=episode_idx,
+            max_steps=max_steps,
+            fps=fps,
+            viewname=viewname,
+        )
+
     def record_dataset(
         self,
         dataset_name: str,


### PR DESCRIPTION
Closes #174

Adds `record_video_from_dataset` to the `World` class, enabling video recording by replaying stored dataset episodes rather than live environment rollouts.

## Changes

- **`stable_worldmodel/world.py`** — New method `World.record_video_from_dataset` (after line 298, between `record_video` and `record_dataset`). Accepts a `video_path` directory, `dataset_name`, one or more `episode_idx` values, `max_steps`, `fps`, `viewname` key(s), and an optional `cache_dir`. Lazily imports `HDF5Dataset` and the standalone `record_video_from_dataset` utility, constructs the dataset, then delegates to the utility function.

## Motivation

Previously, generating a video required running a live environment rollout. There was no way to replay and visualize episodes already captured in an HDF5 dataset without writing custom glue code outside the `World` API. This method closes that gap by surfacing dataset-based video recording as a first-class operation on `World`, consistent with the existing `record_video` and `record_dataset` methods.

## Testing

- Instantiate a `World`, call `world.record_video_from_dataset(video_path, dataset_name, episode_idx=[0, 1], fps=30)` against an existing HDF5 dataset, and confirm MP4 files are written to the target directory with the correct frame count and frame rate.
- Verify that passing a single integer to `episode_idx` (e.g., `episode_idx=0`) produces a single video without error.
- Confirm lazy imports do not break environments where `HDF5Dataset` is unavailable at module load time.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*