### PR TITLE
docs: fix mkdocs build broken by #197 wrapper removals

### DIFF
--- a/docs/api/wrapper.md
+++ b/docs/api/wrapper.md
@@ -44,22 +44,3 @@ summary: Custom environment wrappers
         heading_level: 2
         members: false
         show_source: false
-
-::: stable_worldmodel.wrapper.StackedWrapper
-    options:
-        heading_level: 2
-        members: false
-        show_source: false
-
-
-::: stable_worldmodel.wrapper.VariationWrapper
-    options:
-        heading_level: 2
-        members: false
-        show_source: false
-
-::: stable_worldmodel.wrapper.SyncWorld
-    options:
-        heading_level: 2
-        members: false
-        show_source: false

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -36,6 +36,7 @@ Quick start::
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable
 from copy import deepcopy
 from functools import partial
 from pathlib import Path
@@ -100,9 +101,9 @@ class World:
         max_episode_steps: int = 100,
         goal_conditioned: bool = True,
         extra_wrappers: list | None = None,
-        image_transform=None,
-        goal_transform=None,
-        **kwargs,
+        image_transform: Callable | None = None,
+        goal_transform: Callable | None = None,
+        **kwargs: Any,
     ):
         wrappers = [
             partial(


### PR DESCRIPTION
## Summary
- #197 removed \`StackedWrapper\`, \`VariationWrapper\`, and \`SyncWorld\`, but \`docs/api/wrapper.md\` still had \`:::\` directives for them. \`mkdocs build\` aborted with \`Could not collect 'stable_worldmodel.wrapper.StackedWrapper'\`. Removed the dead refs.
- Annotated \`World.__init__\`'s \`image_transform\`, \`goal_transform\`, and \`**kwargs\` to clear the griffe "no type or annotation" warnings.

## Test plan
- [x] \`uv run --group dev mkdocs build\` succeeds locally with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)