### PR TITLE
Rework Data Format Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,16 @@
 
 ```python
 import stable_worldmodel as swm
-from stable_worldmodel.data import HDF5Dataset
 from stable_worldmodel.policy import WorldModelPolicy, PlanConfig
 from stable_worldmodel.solver import CEMSolver
 
-# collect a dataset
+# collect a dataset (default writer is hdf5; pass format='video' for MP4 episodes)
 world = swm.World('swm/PushT-v1', num_envs=8)
 world.set_policy(your_expert_policy)
-world.record_dataset(dataset_name='pusht_demo', episodes=100)
+world.collect('data/pusht_demo.h5', episodes=100, seed=0)
 
-# load dataset and train your world model
-dataset = HDF5Dataset(name='pusht_demo', num_steps=16)
+# load dataset and train your world model — format is autodetected
+dataset = swm.data.load_dataset('data/pusht_demo.h5', num_steps=16)
 world_model = ...  # your world-model
 
 # evaluate with model predictive control
@@ -49,9 +48,33 @@ print(f"Success Rate: {results['success_rate']:.1f}%")
 stable-worldmodel eases reproducibility by already implementing several baselines: [`scripts/train/prejepa.py`](scripts/train/prejepa.py) reproduces results from the [DINO-WM paper](https://arxiv.org/abs/2411.04983) and [`scripts/train/gcivl.py`](scripts/train/gcivl.py) implements several [goal-conditioned RL algorithms](https://arxiv.org/abs/2410.20092).
 To foster research in MPC for world models, several planning solvers are already implemented, including zeroth-order ([CEM](stable_worldmodel/solver/cem.py), [MPPI](stable_worldmodel/solver/mppi.py)), gradient-based ([GradientSolver](stable_worldmodel/solver/gd.py), [PGD](stable_worldmodel/solver/discrete_solvers.py)), and constrained gradient approaches ([LagrangianSolver](stable_worldmodel/solver/lagrangian.py)).
 
-### Efficiency
+### Data Formats
 
-We support multiple dataset formats to optimize efficiency: MP4 enables fast and convenient visualization, while HDF5 ensures high-performance data loading, reduces CPU bottlenecks, and improves overall GPU utilization.
+All datasets — recording, loading, and conversion — go through a small
+**format registry**. Pick a backend that suits the trade-off you care about,
+or [register your own](https://galilai-group.github.io/stable-worldmodel/api/dataset/#registering-a-custom-format):
+
+| Format     | On-disk layout                                  | Best for                                          |
+|------------|-------------------------------------------------|---------------------------------------------------|
+| `hdf5`     | single `.h5` file (one dataset per column)      | training — fast indexed reads, low CPU overhead   |
+| `folder`   | `.npz` columns + one JPEG per step              | inspection, partial-key streaming                 |
+| `video`    | `.npz` columns + one MP4 per episode (`decord`) | long episodes, compact image storage              |
+| `lerobot`  | `lerobot://<repo_id>` (read-only adapter)       | training/eval directly on LeRobot Hub datasets    |
+
+```python
+import stable_worldmodel as swm
+
+world.collect('data/pusht.h5', episodes=100)                    # default: hdf5
+world.collect('data/pusht_video', episodes=100, format='video') # mp4 episodes
+
+ds = swm.data.load_dataset('data/pusht.h5', num_steps=16)       # autodetect
+swm.data.convert('data/pusht.h5', 'data/pusht_video',
+                 dest_format='video', fps=30)                   # one-shot migration
+```
+
+HDF5 ensures high-performance data loading, reduces CPU bottlenecks, and
+improves overall GPU utilization; MP4 is convenient for visualization and
+keeps long-horizon datasets small.
 
 <p align="center">
   <img src="docs/assets/dinowm-gpu-usage.png" alt="GPU utilization comparison" width="60%">

--- a/docs/api/dataset.md
+++ b/docs/api/dataset.md
@@ -2,155 +2,285 @@ title: Dataset
 summary: Dataset handling
 ---
 
-`stable_worldmodel` provides a flexible dataset API that supports HDF5, folder-backed media datasets, and read-only LeRobot datasets.
+`stable_worldmodel` ships a small, pluggable data layer built around a
+**format registry**. A *format* is a recipe for reading and writing a
+particular on-disk layout (HDF5, a folder of frames, MP4 episodes, …). All
+built-in datasets — and any custom one you write — go through the same
+registry, so the rest of the library (e.g. `World.collect`, `swm.data.load_dataset`,
+`swm.data.convert`) doesn't care which backend you pick.
+
+```text
+                  ┌──────────────────────────────────────────────┐
+                  │              FORMAT REGISTRY                 │
+                  │  hdf5 │ folder │ video │ lerobot │  custom…  │
+                  └──────────────────────────────────────────────┘
+                          ▲                       ▲
+              detect ─────┘                       └───── @register_format
+       open_reader / open_writer
+                          │
+            ┌─────────────┴─────────────┐
+            ▼                           ▼
+     load_dataset(...)          World.collect(..., format=)
+     convert(src, dst)
+```
+
+## **[ Quick Tour ]**
+
+```python
+import stable_worldmodel as swm
+
+# 1) Record some episodes — World picks the writer registered under `format`.
+world = swm.World('swm/PushT-v1', num_envs=4, image_shape=(64, 64))
+world.set_policy(swm.policy.RandomPolicy(seed=0))
+world.collect('data/pusht.h5', episodes=20, seed=0)              # hdf5 (default)
+world.collect('data/pusht_video', episodes=20, format='video')   # mp4 + npz
+
+# 2) Load any dataset — format is autodetected from the path.
+ds = swm.data.load_dataset('data/pusht.h5', num_steps=4, frameskip=1)
+sample = ds[0]
+print(sample['pixels'].shape, sample['action'].shape)   # (4, 3, H, W) (4, A)
+
+# 3) Switch backends without changing your collection code.
+swm.data.convert('data/pusht.h5', 'data/pusht_video', dest_format='video', fps=30)
+```
+
+`load_dataset` accepts:
+
+  - a **local path** (file or directory),
+  - a **HuggingFace dataset repo** (`<user>/<repo>`) — auto-downloaded and
+    cached under `$STABLEWM_HOME/datasets/`,
+  - a **scheme-prefixed identifier** (e.g. `lerobot://lerobot/pusht`) handed
+    straight to the matching format.
+
+```python
+ds = swm.data.load_dataset('lerobot://lerobot/pusht',
+                           primary_camera_key='observation.images.top',
+                           num_steps=8)
+```
 
 ## **[ Storage Formats ]**
 
-/// tab | HDF5 Format (Recommended)
-The **`HDF5Dataset`** stores all data in a single `.h5` file. This is the default format for recording rollouts using `World.collect`.
+All built-in formats expose the same `Dataset` API: each item is a dict of
+tensors stacked across `num_steps`, with image columns transposed to
+`(T, C, H, W)`.
 
-**File Structure:**
-```
-dataset_name.h5
-├── pixels          # (Total_Steps, C, H, W) or (Total_Steps, H, W, C)
-├── action          # (Total_Steps, Action_Dim)
-├── reward          # (Total_Steps,)
-├── terminated      # (Total_Steps,)
-├── ep_len          # (Num_Episodes,) - Length of each episode
-└── ep_offset       # (Num_Episodes,) - Start index of each episode
+/// tab | HDF5 (recommended)
+The **`hdf5`** format stores everything in a single `.h5` file with one
+dataset per column plus the `ep_len`/`ep_offset` index. It's the fastest for
+training and the default for `World.collect`.
+
+**Layout:**
+
+```text
+dataset.h5
+├── pixels      # (Total_Steps, H, W, C) uint8
+├── action      # (Total_Steps, Action_Dim) float32
+├── reward      # (Total_Steps,) float32
+├── ep_len      # (Num_Episodes,) int32
+└── ep_offset   # (Num_Episodes,) int64
 ```
 
-**Usage:**
+**Read:**
+
 ```python
-from stable_worldmodel.data import HDF5Dataset
+import stable_worldmodel as swm
 
-dataset = HDF5Dataset(
-    name="my_dataset",
-    frameskip=1,
-    num_steps=50  # Sequence length for training
-)
+ds = swm.data.load_dataset('data/pusht.h5', num_steps=16, frameskip=1,
+                           keys_to_load=['pixels', 'action'])
 ```
+
+**Write:**
+
+```python
+from stable_worldmodel.data import HDF5Writer
+
+with HDF5Writer('data/pusht.h5') as w:
+    for ep in episodes:                      # ep = {col: [step_arr, ...]}
+        w.write_episode(ep)
+```
+
+`World.collect(path, episodes=...)` is the recommended way to produce one of these.
 ///
 
-/// tab | Folder Format
-The **`FolderDataset`** stores metadata in `.npz` files and heavy media (images) as individual files.
+/// tab | Folder
+The **`folder`** format keeps tabular columns as `.npz` arrays and image
+columns as one JPEG per step. It's great when you want to inspect frames
+on disk or stream a few keys without paying HDF5's open cost.
 
-**File Structure:**
-```
-dataset_name/
-├── ep_len.npz      # Contains 'arr_0': Array of episode lengths
-├── ep_offset.npz   # Contains 'arr_0': Array of episode start offsets
-├── action.npz      # Contains 'arr_0': Full array of actions
-├── reward.npz      # Contains 'arr_0': Full array of rewards
-└── pixels/         # Folder for image data
-    ├── ep_0_step_0.jpg
-    ├── ep_0_step_1.jpg
-    └── ...
-```
+**Layout:**
 
-**Usage:**
-```python
-from stable_worldmodel.data import FolderDataset
-
-dataset = FolderDataset(
-    name="my_image_dataset",
-    folder_keys=["pixels"]  # Keys to load from folders instead of .npz
-)
-```
-///
-
-/// tab | Video Format
-The **`VideoDataset`** is a specialized `FolderDataset` that reads frames directly from MP4 files using `decord`. This saves significant disk space compared to storing individual images.
-
-**File Structure:**
-```
-dataset_name/
-├── ep_len.npz
-├── ep_offset.npz
-├── action.npz
-└── video/          # Folder for video files
-    ├── ep_0.mp4
-    ├── ep_1.mp4
-    └── ...
-```
-
-**Usage:**
-```python
-from stable_worldmodel.data import VideoDataset
-
-dataset = VideoDataset(
-    name="my_video_dataset",
-    video_keys=["video"]
-)
-```
-///
-
-/// tab | Image Format
-The **`ImageDataset`** is a convenience alias for `FolderDataset` with image defaults. It assumes 'pixels' is stored as individual image files.
-
-**File Structure:**
-```
-dataset_name/
-├── ep_len.npz
-├── ep_offset.npz
-├── action.npz
-└── pixels/         # Folder for image files
+```text
+dataset/
+├── ep_len.npz              # (N,)  int32
+├── ep_offset.npz           # (N,)  int64
+├── action.npz              # (Total_Steps, A)
+├── reward.npz              # (Total_Steps,)
+└── pixels/                 # one image per step
     ├── ep_0_step_0.jpeg
     ├── ep_0_step_1.jpeg
     └── ...
 ```
 
-**Usage:**
-```python
-from stable_worldmodel.data import ImageDataset
+**Read:** image columns are inferred from subdirectories, so `folder_keys`
+is rarely needed.
 
-dataset = ImageDataset(
-    name="my_image_dataset",
-    image_keys=["pixels"]  # Default
-)
+```python
+ds = swm.data.load_dataset('data/pusht_folder/', num_steps=4)
+```
+
+**Write:** any uint8 `(H, W, 3)` or `(H, W, 1)` array is auto-detected
+as an image column and saved as JPEG.
+
+```python
+from stable_worldmodel.data import FolderWriter
+
+with FolderWriter('data/pusht_folder') as w:
+    w.write_episode({'pixels': frames, 'action': actions})
 ```
 ///
 
-/// tab | LeRobot Format
-The **`LeRobotAdapter`** wraps lerobot's read-only `LeRobotDataset` and exposes the same episode-based API as the native SWM datasets. By default, it maps (only one) camera view to `pixels`, `action` to `action`, and `observation.state` to `proprio`.
+/// tab | Video
+The **`video`** format is identical to `folder` for tabular columns, but
+encodes each image column as one MP4 per episode. Frames are decoded with
+[`decord`](https://github.com/dmlc/decord), which makes it a good fit for
+long episodes where storing raw JPEGs is wasteful.
 
-LeRobot support is feature-gated to Python 3.12+ because the official `lerobot` package currently requires it.
+**Layout:**
 
-**Usage:**
+```text
+dataset/
+├── ep_len.npz, ep_offset.npz, action.npz, ...
+└── video/
+    ├── ep_0.mp4
+    └── ep_1.mp4
+```
+
+**Read / Write:**
+
 ```python
-from stable_worldmodel.data import LeRobotAdapter
+ds = swm.data.load_dataset('data/pusht_video/', num_steps=8)
 
-dataset = LeRobotAdapter(
-    repo_id="your-org/your-lerobot-dataset",
-    primary_camera_key="observation.images.front",  # will be mapped to `pixels`
+# direct write
+from stable_worldmodel.data import VideoWriter
+with VideoWriter('data/pusht_video', fps=30, codec='libx264') as w:
+    w.write_episode(episode)
+
+# or via World
+world.collect('data/pusht_video', episodes=100, format='video')
+```
+
+!!! info ""
+    `video` requires the optional `decord` dependency for reading and
+    `imageio` (with an FFmpeg backend) for writing.
+///
+
+/// tab | LeRobot
+The **`lerobot`** format is a read-only adapter over
+[`lerobot.datasets.LeRobotDataset`](https://github.com/huggingface/lerobot).
+It's identified by the `lerobot://` scheme and exposes the same episode-based
+API as the native SWM datasets: by default the primary camera is mapped to
+`pixels`, `action` to `action`, and `observation.state` to `proprio`.
+
+```python
+ds = swm.data.load_dataset(
+    'lerobot://lerobot/pusht',
+    primary_camera_key='observation.images.top',  # → 'pixels'
     num_steps=8,
-    frameskip=1,
-    keys_to_load=["pixels", "action", "proprio", "ep_idx", "step_idx"],
-    keys_to_cache=["action", "proprio", "ep_idx", "step_idx"],
+    keys_to_load=['pixels', 'action', 'proprio', 'ep_idx', 'step_idx'],
+    keys_to_cache=['action', 'proprio', 'ep_idx', 'step_idx'],
 )
 ```
+
+!!! info ""
+    LeRobot support is feature-gated to **Python 3.12+** because the upstream
+    `lerobot` package requires it. Install with
+    `pip install 'stable-worldmodel[lerobot]'`. There is no `lerobot` writer —
+    mapping arbitrary `World` info dicts onto LeRobot's schema is not supported.
 ///
 
 /// tab | Goal-Conditioned
-The **`GoalDataset`** wraps any dataset to add goal observations for goal-conditioned learning. Goals are sampled from random states, future states in the same episode, or the current state.
+**`GoalDataset`** wraps any of the formats above to add a sampled goal
+observation per item, for goal-conditioned learning. Goals are drawn from
+one of four buckets (random, geometric future, uniform future, current)
+according to a probability vector.
 
-**Usage:**
 ```python
-from stable_worldmodel.data import HDF5Dataset, GoalDataset
+from stable_worldmodel.data import GoalDataset
 
-# Wrap any base dataset
-base_dataset = HDF5Dataset(name="my_dataset", num_steps=50)
-goal_dataset = GoalDataset(
-    base_dataset,
-    goal_probabilities=(0.3, 0.5, 0.2),  # (random, future, current)
-    gamma=0.99,  # Discount for future sampling
-    seed=42
+base = swm.data.load_dataset('data/pusht.h5', num_steps=4)
+goal = GoalDataset(
+    base,
+    goal_probabilities=(0.3, 0.5, 0.0, 0.2),  # random, geom. future, uniform future, current
+    gamma=0.99,
+    seed=42,
 )
-
-# Items now include goal_pixels and goal_proprio keys
-item = goal_dataset[0]
+item = goal[0]                                  # adds 'goal_pixels', 'goal_proprio'
 ```
 ///
+
+## **[ Converting Between Formats ]**
+
+`convert()` walks each episode of a source dataset and writes it through the
+writer of `dest_format`. Source format is autodetected unless you pass
+`source_format=`.
+
+```python
+from stable_worldmodel.data import convert
+
+# HDF5 → MP4 directory (fps forwarded to VideoWriter)
+convert('data/pusht.h5', 'data/pusht_video',
+        dest_format='video', fps=30)
+
+# Folder → HDF5 (good for shrinking many JPEGs into one file)
+convert('data/pusht_folder', 'data/pusht.h5', dest_format='hdf5')
+```
+
+This composes with `load_dataset`'s resolution rules, so you can convert
+straight from a HuggingFace repo or a `lerobot://` URL:
+
+```python
+convert('lerobot://lerobot/pusht', 'data/pusht_local',
+        source_format='lerobot', dest_format='video',
+        primary_camera_key='observation.images.top')
+```
+
+## **[ Registering a Custom Format ]**
+
+A format is just a class with three classmethods. Decorate it with
+`@register_format` and the rest of the stack picks it up.
+
+```python
+from stable_worldmodel.data import Format, register_format
+from stable_worldmodel.data.dataset import Dataset
+
+@register_format
+class Parquet(Format):
+    name = 'parquet'
+
+    @classmethod
+    def detect(cls, path):
+        from pathlib import Path
+        return Path(path).suffix == '.parquet'
+
+    @classmethod
+    def open_reader(cls, path, **kw):
+        return ParquetDataset(path, **kw)        # subclass of Dataset
+
+    @classmethod
+    def open_writer(cls, path, **kw):
+        return ParquetWriter(path, **kw)          # __enter__/__exit__/write_episode
+```
+
+Once imported, your format is usable everywhere:
+
+```python
+swm.data.load_dataset('foo.parquet')                   # reader
+world.collect('foo.parquet', episodes=10, format='parquet')  # writer
+swm.data.list_formats()         # ['hdf5', 'folder', 'video', 'lerobot', 'parquet']
+```
+
+Read-only formats simply omit `open_writer`; write-only formats omit
+`open_reader`. Both calls raise a clear error by default.
 
 ## **[ Base Class ]**
 
@@ -204,8 +334,6 @@ item = goal_dataset[0]
         members: false
         show_source: false
 
-## **[ Utilities ]**
-
 ::: stable_worldmodel.data.MergeDataset
     options:
         heading_level: 3
@@ -217,3 +345,21 @@ item = goal_dataset[0]
         heading_level: 3
         members: false
         show_source: false
+
+## **[ Format Registry ]**
+
+::: stable_worldmodel.data.format.Format
+    options:
+        heading_level: 3
+        members: false
+        show_source: false
+
+::: stable_worldmodel.data.format.register_format
+::: stable_worldmodel.data.format.list_formats
+::: stable_worldmodel.data.format.get_format
+::: stable_worldmodel.data.format.detect_format
+
+## **[ Top-Level Helpers ]**
+
+::: stable_worldmodel.data.load_dataset
+::: stable_worldmodel.data.convert

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -187,19 +187,30 @@ The `WorldModelPolicy` internally calls the solver to optimize action sequences 
 
 ## Dataset
 
-Stable World-Model provides utilities for recording and loading episode datasets in HDF5 format.
+Stable World-Model provides a small, pluggable data layer for recording and
+loading episode datasets. Recording, loading, and conversion all go through
+the same **format registry**, so the same code records to a single HDF5
+file or to a folder of MP4 episodes — only the `format=` flag changes. See
+the [Dataset API](api/dataset.md) for the full reference; the rest of this
+section covers the everyday workflow.
 
 ### Recording a Dataset
 
-Use `world.collect()` to roll out episodes and save them in HDF5 format. This is useful for collecting expert demonstrations, random exploration data, or rollouts from a trained policy. Each info key becomes a column in the resulting file.
+Use `world.collect()` to roll out episodes and dump their trajectories. Each
+info key becomes a column in the resulting file. The default writer is
+`hdf5`; pass `format='video'` or `'folder'` to switch backends.
 
 ```python
 world = swm.World('swm/PushT-v1', num_envs=8, image_shape=(224, 224))
-policy = swm.policy.RandomPolicy(seed=42)  # can be your JEPA or RL Policy
+policy = swm.policy.RandomPolicy(seed=42)  # can be your JEPA or RL policy
 world.set_policy(policy)
 
-# Record 100 episodes to an HDF5 file (parent dirs are auto-created).
+# Single HDF5 file (recommended for training).
 world.collect('data/pusht_random.h5', episodes=100, seed=0)
+
+# Or a directory with one MP4 per episode (compact, easy to inspect).
+world.collect('data/pusht_random_video', episodes=100, seed=0,
+              format='video')
 ```
 
 !!! info "Expert Policies"
@@ -207,41 +218,62 @@ world.collect('data/pusht_random.h5', episodes=100, seed=0)
 
 ### Loading a Dataset
 
-Load recorded datasets using `HDF5Dataset`. The `frameskip` parameter controls the stride between frames, and `num_steps` sets the sequence length returned per sample. This makes it easy to train models on temporal sequences of observations and actions.
+`swm.data.load_dataset()` resolves a name to a local path and dispatches to
+the matching reader. It accepts a local path, a HuggingFace repo
+(`<user>/<repo>`, downloaded to `$STABLEWM_HOME/datasets/`), or a
+scheme-prefixed identifier such as `lerobot://lerobot/pusht`. `frameskip`
+controls the stride between frames; `num_steps` is the sequence length
+returned per sample.
 
 ```python
-from stable_worldmodel.data import HDF5Dataset
+import stable_worldmodel as swm
 
-dataset = HDF5Dataset(
-    name='pusht_random',
-    frameskip=1,  # stride between frames
-    num_steps=4,  # sequence length
-    keys_to_load=['pixels', 'action', 'state']
+dataset = swm.data.load_dataset(
+    'data/pusht_random.h5',                       # autodetected as hdf5
+    frameskip=1,
+    num_steps=4,
+    keys_to_load=['pixels', 'action', 'state'],
 )
 
-# Access samples
 sample = dataset[0]
 print(sample['pixels'].shape)   # (4, 3, H, W)
 print(sample['action'].shape)   # (4, action_dim)
 ```
 
-```python
-from stable_worldmodel.data import LeRobotAdapter
+The same call works for the other formats:
 
-dataset = LeRobotAdapter(
-    repo_id='lerobot/pusht',
-    primary_camera_key='observation.images.top',  # gets mapped to `pixels`
+```python
+# Folder / Video (autodetected from directory layout)
+swm.data.load_dataset('data/pusht_random_video', num_steps=4)
+
+# LeRobot Hub dataset
+swm.data.load_dataset(
+    'lerobot://lerobot/pusht',
+    primary_camera_key='observation.images.top',  # → `pixels`
     num_steps=4,
-    frameskip=1,
     keys_to_load=['pixels', 'action', 'proprio', 'ep_idx', 'step_idx'],
-    keys_to_cache=['action', 'proprio', 'ep_idx', 'step_idx'],
 )
 ```
 
 !!! info "LeRobot Support"
-    LeRobotAdapter support is read-only and requires Python 3.12+. You can install it passing in the optional dependency via `pip install 'stable-worldmodel[lerobot]'`.
+    LeRobot support is read-only and requires Python 3.12+. Install with `pip install 'stable-worldmodel[lerobot]'`.
 
-The dataset is compatible with PyTorch `DataLoader` for batched training.
+The returned dataset is compatible with PyTorch `DataLoader` for batched training.
+
+### Converting Between Formats
+
+`swm.data.convert()` migrates a dataset from one format to another, episode
+by episode. Source format is autodetected; pass `dest_format` and any
+writer kwargs:
+
+```python
+swm.data.convert(
+    'data/pusht_random.h5',           # source
+    'data/pusht_random_video',        # destination
+    dest_format='video',
+    fps=30,
+)
+```
 
 Use the CLI to list all available datasets, or inspect a specific one:
 

--- a/stable_worldmodel/data/__init__.py
+++ b/stable_worldmodel/data/__init__.py
@@ -1,3 +1,40 @@
 from .utils import *  # noqa: F403
 from .dataset import *  # noqa: F403
-from .lerobot import LeRobotAdapter as LeRobotAdapter
+from .format import (
+    FORMATS,
+    Format,
+    Writer,
+    detect_format,
+    get_format,
+    list_formats,
+    register_format,
+)
+
+# Importing the formats subpackage registers all built-in formats.
+from . import formats as _formats  # noqa: F401
+
+# Re-export concrete readers/writers from their format modules so existing
+# imports like `from stable_worldmodel.data import HDF5Dataset` keep working.
+from .formats.hdf5 import HDF5Dataset, HDF5Writer
+from .formats.folder import FolderDataset, FolderWriter, ImageDataset
+from .formats.video import VideoDataset, VideoWriter
+from .formats.lerobot import LeRobotAdapter
+
+
+__all__ = [
+    'FORMATS',
+    'Format',
+    'FolderDataset',
+    'FolderWriter',
+    'HDF5Dataset',
+    'HDF5Writer',
+    'ImageDataset',
+    'LeRobotAdapter',
+    'VideoDataset',
+    'VideoWriter',
+    'Writer',
+    'detect_format',
+    'get_format',
+    'list_formats',
+    'register_format',
+]

--- a/stable_worldmodel/data/dataset.py
+++ b/stable_worldmodel/data/dataset.py
@@ -1,30 +1,36 @@
-"""Dataset classes for episode-based reinforcement learning data."""
+"""Dataset abstractions: the base class plus composition wrappers.
 
-import logging
+Concrete readers (HDF5, folder, video, LeRobot) live under ``data.formats``.
+This module is the cross-cutting layer:
+
+  - :class:`Dataset` — the abstract base shared by every reader.
+  - :class:`MergeDataset` — horizontal join (columns from N datasets of equal length).
+  - :class:`ConcatDataset` — vertical concat (episodes from N datasets stacked).
+  - :class:`GoalDataset` — augments any dataset with a sampled goal observation.
+"""
+
+from __future__ import annotations
+
 from collections.abc import Callable
-from functools import lru_cache
-from pathlib import Path
-import re
 from typing import Any
 
-import h5py
-import hdf5plugin  # noqa: F401
 import numpy as np
 import torch
-from PIL import Image
-
-from stable_worldmodel.data.utils import get_cache_dir
 
 
 class Dataset:
     """Base class for episode-based datasets.
 
+    Subclasses fill in ``column_names`` and ``_load_slice``; everything else
+    (clip indexing, ``__getitem__``, ``load_chunk``, ``load_episode``) is
+    derived here.
+
     Args:
-        lengths: Array of episode lengths.
-        offsets: Array of episode start offsets in the data.
-        frameskip: Number of frames to skip between samples.
-        num_steps: Number of steps per sample.
-        transform: Optional transform to apply to loaded data.
+        lengths: Episode lengths.
+        offsets: Episode start offsets in the underlying flat storage.
+        frameskip: Stride between observation samples.
+        num_steps: Number of observation steps per sample.
+        transform: Optional dict-in / dict-out transform applied per sample.
     """
 
     def __init__(
@@ -79,7 +85,6 @@ class Dataset:
         return chunk
 
     def load_episode(self, episode_idx: int) -> dict:
-        """Load full episode by index."""
         return self._load_slice(episode_idx, 0, self.lengths[episode_idx])
 
     def get_col_data(self, col: str) -> np.ndarray:
@@ -100,305 +105,13 @@ class Dataset:
         raise NotImplementedError
 
 
-class HDF5Dataset(Dataset):
-    """Dataset loading from HDF5 file.
-
-    Reads data from a single .h5 file containing all episode data.
-    Uses SWMR mode for robust reading while writing.
-
-    Args:
-        name: Name of the dataset (filename without extension).
-        frameskip: Number of frames to skip between samples.
-        num_steps: Number of steps per sample sequence.
-        transform: Optional data transform callable.
-        keys_to_load: Specific keys to load (defaults to all except metadata).
-        keys_to_cache: Keys to load entirely into memory for faster access.
-        cache_dir: Directory containing the dataset file.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        frameskip: int = 1,
-        num_steps: int = 1,
-        transform: Callable[[dict], dict] | None = None,
-        keys_to_load: list[str] | None = None,
-        keys_to_cache: list[str] | None = None,
-        keys_to_merge: dict[str, list[str] | str] | None = None,
-        cache_dir: str | Path | None = None,
-    ) -> None:
-        datasets_dir = get_cache_dir(cache_dir, sub_folder='datasets')
-        self.h5_path = Path(datasets_dir, f'{name}.h5')
-        self.h5_file: h5py.File | None = None
-        self._cache: dict[str, np.ndarray] = {}
-
-        with h5py.File(self.h5_path, 'r') as f:
-            lengths, offsets = f['ep_len'][:], f['ep_offset'][:]
-            self._keys = keys_to_load or [
-                k for k in f.keys() if k not in ('ep_len', 'ep_offset')
-            ]
-
-            for key in keys_to_cache or []:
-                self._cache[key] = f[key][:]
-                logging.info(f"Cached '{key}' from '{self.h5_path}'")
-
-        super().__init__(lengths, offsets, frameskip, num_steps, transform)
-
-        if keys_to_merge:
-            for target, source in keys_to_merge.items():
-                self.merge_col(source, target)
-
-    @property
-    def column_names(self) -> list[str]:
-        return self._keys
-
-    def _open(self) -> None:
-        if self.h5_file is None:
-            self.h5_file = h5py.File(
-                self.h5_path, 'r', swmr=True, rdcc_nbytes=256 * 1024 * 1024
-            )
-
-    def _load_slice(self, ep_idx: int, start: int, end: int) -> dict:
-        self._open()
-        g_start, g_end = (
-            self.offsets[ep_idx] + start,
-            self.offsets[ep_idx] + end,
-        )
-        steps = {}
-        for col in self._keys:
-            src = self._cache if col in self._cache else self.h5_file
-            data = src[col][g_start:g_end]
-            if col != 'action':
-                data = data[:: self.frameskip]
-
-            if data.dtype == np.object_ or data.dtype.kind in ('S', 'U'):
-                val = data[0] if len(data) > 0 else b''
-                steps[col] = val.decode() if isinstance(val, bytes) else val
-            else:
-                steps[col] = torch.from_numpy(data)
-                if data.ndim == 4 and data.shape[-1] in (1, 3):
-                    steps[col] = steps[col].permute(0, 3, 1, 2)
-
-        return self.transform(steps) if self.transform else steps
-
-    def _get_col(self, col: str) -> np.ndarray:
-        if col in self._cache:
-            return self._cache[col]
-        self._open()
-        return self.h5_file[col][:]
-
-    def get_col_data(self, col: str) -> np.ndarray:
-        return self._get_col(col)
-
-    def get_row_data(self, row_idx: int | list[int]) -> dict:
-        self._open()
-        return {col: self.h5_file[col][row_idx] for col in self._keys}
-
-    def merge_col(
-        self,
-        source: list[str] | str,
-        target: str,
-        dim: int = -1,
-    ) -> None:
-        self._open()
-
-        if isinstance(source, str):
-            source = [k for k in self.h5_file.keys() if re.match(source, k)]
-
-        merged = np.concatenate([self._get_col(s) for s in source], axis=dim)
-        self._cache[target] = merged
-        if target not in self._keys:
-            self._keys.append(target)
-        logging.info(f"Merged columns {source} into '{target}' and cached it")
-
-    def get_dim(self, col: str) -> int:
-        data = self.get_col_data(col)
-        return np.prod(data.shape[1:]).item() if data.ndim > 1 else 1
-
-
-class FolderDataset(Dataset):
-    """Dataset loading from folder structure.
-
-    Metadata is stored in .npz files, heavy media (images) can be stored as individual files.
-
-    Args:
-        name: Name of the dataset folder.
-        frameskip: Number of frames to skip.
-        num_steps: Sequence length.
-        transform: Optional transform.
-        keys_to_load: Specific keys to load.
-        folder_keys: Keys that correspond to folders of image files.
-        cache_dir: Base directory containing the dataset folder.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        frameskip: int = 1,
-        num_steps: int = 1,
-        transform: Callable[[dict], dict] | None = None,
-        keys_to_load: list[str] | None = None,
-        folder_keys: list[str] | None = None,
-        cache_dir: str | Path | None = None,
-    ) -> None:
-        self.path = (
-            Path(cache_dir or get_cache_dir(sub_folder='datasets')) / name
-        )
-        self.folder_keys = folder_keys or []
-        self._cache: dict[str, np.ndarray] = {}
-
-        lengths = np.load(self.path / 'ep_len.npz')['arr_0']
-        offsets = np.load(self.path / 'ep_offset.npz')['arr_0']
-
-        if keys_to_load is None:
-            keys_to_load = sorted(
-                p.stem if p.suffix == '.npz' else p.name
-                for p in self.path.iterdir()
-                if p.stem not in ('ep_len', 'ep_offset')
-            )
-        self._keys = keys_to_load
-
-        for key in self._keys:
-            if key not in self.folder_keys:
-                npz = self.path / f'{key}.npz'
-                if npz.exists():
-                    self._cache[key] = np.load(npz)['arr_0']
-                    logging.info(f"Cached '{key}' from '{npz}'")
-
-        super().__init__(lengths, offsets, frameskip, num_steps, transform)
-
-    @property
-    def column_names(self) -> list[str]:
-        return self._keys
-
-    def _load_file(self, ep_idx: int, step: int, key: str) -> np.ndarray:
-        path = self.path / key / f'ep_{ep_idx}_step_{step}'
-        img_path = path.with_suffix('.jpeg')
-        if not img_path.exists():
-            img_path = path.with_suffix('.jpg')
-        return np.array(Image.open(img_path))
-
-    def _load_slice(self, ep_idx: int, start: int, end: int) -> dict:
-        g_start, g_end = (
-            self.offsets[ep_idx] + start,
-            self.offsets[ep_idx] + end,
-        )
-        steps = {}
-        for col in self._keys:
-            if col in self.folder_keys:
-                data = np.stack(
-                    [
-                        self._load_file(ep_idx, s, col)
-                        for s in range(start, end, self.frameskip)
-                    ]
-                )
-            else:
-                data = self._cache[col][g_start:g_end]
-                if col != 'action':
-                    data = data[:: self.frameskip]
-
-            if data.dtype == np.object_ or data.dtype.kind in ('S', 'U'):
-                val = data[0] if len(data) > 0 else b''
-                steps[col] = val.decode() if isinstance(val, bytes) else val
-            else:
-                steps[col] = torch.from_numpy(data)
-                if data.ndim == 4 and data.shape[-1] in (1, 3):
-                    steps[col] = steps[col].permute(0, 3, 1, 2)
-        return self.transform(steps) if self.transform else steps
-
-    def get_col_data(self, col: str) -> np.ndarray:
-        if col not in self._cache:
-            raise KeyError(
-                f"'{col}' not in cache (folder keys cannot be retrieved as full array)"
-            )
-        return self._cache[col]
-
-    def get_row_data(self, row_idx: int | list[int]) -> dict:
-        return {
-            c: self._cache[c][row_idx] for c in self._keys if c in self._cache
-        }
-
-
-class ImageDataset(FolderDataset):
-    """Convenience alias for FolderDataset with image defaults.
-
-    Assumes 'pixels' is a folder of images.
-    """
-
-    def __init__(
-        self, name: str, image_keys: list[str] | None = None, **kw: Any
-    ) -> None:
-        super().__init__(name, folder_keys=image_keys or ['pixels'], **kw)
-
-
-class VideoDataset(FolderDataset):
-    """Dataset loading video frames from MP4 files using decord.
-
-    Assumes video files are stored in a folder structure.
-    """
-
-    _decord: Any = None  # Lazy-loaded module reference
-
-    def __init__(
-        self, name: str, video_keys: list[str] | None = None, **kw: Any
-    ) -> None:
-        if VideoDataset._decord is None:
-            try:
-                import decord
-
-                decord.bridge.set_bridge('torch')
-                VideoDataset._decord = decord
-            except ImportError:
-                raise ImportError('VideoDataset requires decord')
-        super().__init__(name, folder_keys=video_keys or ['video'], **kw)
-
-    @lru_cache(maxsize=8)
-    def _reader(self, ep_idx: int, key: str) -> Any:
-        return VideoDataset._decord.VideoReader(
-            str(self.path / key / f'ep_{ep_idx}.mp4'), num_threads=1
-        )
-
-    def _load_file(self, ep_idx: int, step: int, key: str) -> np.ndarray:
-        return self._reader(ep_idx, key)[step].numpy()
-
-    def _load_slice(self, ep_idx: int, start: int, end: int) -> dict:
-        g_start, g_end = (
-            self.offsets[ep_idx] + start,
-            self.offsets[ep_idx] + end,
-        )
-        steps = {}
-        for col in self._keys:
-            if col in self.folder_keys:
-                # Decord efficient batch loading
-                frames = self._reader(ep_idx, col).get_batch(
-                    list(range(start, end, self.frameskip))
-                )
-                steps[col] = frames.permute(0, 3, 1, 2)
-            else:
-                data = self._cache[col][g_start:g_end]
-                if col != 'action':
-                    data = data[:: self.frameskip]
-
-                if data.dtype == np.object_ or data.dtype.kind in ('S', 'U'):
-                    val = data[0] if len(data) > 0 else b''
-                    steps[col] = (
-                        val.decode() if isinstance(val, bytes) else val
-                    )
-                else:
-                    steps[col] = torch.from_numpy(data)
-
-        return self.transform(steps) if self.transform else steps
-
-
 class MergeDataset:
-    """Merges multiple datasets of same length (horizontal join).
-
-    Combines columns from different datasets (e.g. one dataset has 'pixels',
-    another has 'rewards') into a single view.
+    """Merge several datasets of equal length by columns (horizontal join).
 
     Args:
-        datasets: List of dataset instances to merge.
-        keys_from_dataset: Optional list of keys to take from each dataset.
+        datasets: Datasets to merge.
+        keys_from_dataset: Per-dataset key lists. If omitted, each dataset
+            contributes the columns not yet seen in earlier datasets.
     """
 
     def __init__(
@@ -414,7 +127,6 @@ class MergeDataset:
         if keys_from_dataset:
             self.keys_map = keys_from_dataset
         else:
-            # Auto-deduplicate: each dataset provides keys not seen in previous datasets
             seen: set[str] = set()
             self.keys_map = []
             for ds in datasets:
@@ -431,7 +143,6 @@ class MergeDataset:
 
     @property
     def lengths(self) -> np.ndarray:
-        """Episode lengths from first dataset (all merged datasets share same structure)."""
         return self.datasets[0].lengths
 
     def __len__(self) -> int:
@@ -452,7 +163,6 @@ class MergeDataset:
         all_chunks = [
             ds.load_chunk(episodes_idx, start, end) for ds in self.datasets
         ]
-
         merged = []
         for items in zip(*all_chunks):
             combined = {}
@@ -478,24 +188,16 @@ class MergeDataset:
 
 
 class ConcatDataset:
-    """Concatenates multiple datasets (vertical join).
-
-    Combines datasets sequentially to increase the total number of episodes/samples.
-
-    Args:
-        datasets: List of datasets to concatenate.
-    """
+    """Concatenate datasets sequentially (vertical join, more episodes)."""
 
     def __init__(self, datasets: list[Any]) -> None:
         if not datasets:
             raise ValueError('Need at least one dataset')
         self.datasets = datasets
 
-        # Cumulative lengths for index mapping: [0, len(ds0), len(ds0)+len(ds1), ...]
         lengths = [len(ds) for ds in datasets]
         self._cum = np.cumsum([0] + lengths)
 
-        # Cumulative episode counts for load_chunk mapping
         ep_counts = [len(ds.lengths) for ds in datasets]
         self._ep_cum = np.cumsum([0] + ep_counts)
 
@@ -514,7 +216,6 @@ class ConcatDataset:
         return self._cum[-1]
 
     def _loc(self, idx: int) -> tuple[int, int]:
-        """Map global index to (dataset_index, local_index)."""
         if idx < 0:
             idx += len(self)
         ds_idx = int(np.searchsorted(self._cum[1:], idx, side='right'))
@@ -532,24 +233,19 @@ class ConcatDataset:
         start = np.asarray(start)
         end = np.asarray(end)
 
-        # Map global episode indices to dataset indices
         ds_indices = np.searchsorted(
             self._ep_cum[1:], episodes_idx, side='right'
         )
         local_eps = episodes_idx - self._ep_cum[ds_indices]
 
-        # Group by dataset and collect results
         results: list[dict | None] = [None] * len(episodes_idx)
         for ds_idx in range(len(self.datasets)):
             mask = ds_indices == ds_idx
             if not np.any(mask):
                 continue
-
             chunks = self.datasets[ds_idx].load_chunk(
                 local_eps[mask], start[mask], end[mask]
             )
-
-            # Place results back in original order
             for i, chunk in zip(np.where(mask)[0], chunks):
                 results[i] = chunk
 
@@ -569,7 +265,6 @@ class ConcatDataset:
             ds_idx, local_idx = self._loc(row_idx)
             return self.datasets[ds_idx].get_row_data(local_idx)
 
-        # Multiple indices: collect and stack results
         results: dict[str, list[Any]] = {}
         for idx in row_idx:
             ds_idx, local_idx = self._loc(idx)
@@ -583,15 +278,12 @@ class ConcatDataset:
 
 
 class GoalDataset:
-    """
-    Dataset wrapper that samples an additional goal observation per item.
+    """Wrap any dataset to return a sampled goal observation per item.
 
-    Works with any dataset type (HDF5Dataset, FolderDataset, VideoDataset, etc.)
-
-    Goals are sampled from:
-      - random state (uniform over dataset steps)
+    Goals are sampled from one of:
+      - random state (uniform over all dataset steps)
       - geometric future state in same episode (Geom(1-gamma))
-      - uniform future state in same episode (uniform over future steps)
+      - uniform future state in same episode
       - current state
     with probabilities (0.3, 0.5, 0.0, 0.2) by default.
     """
@@ -610,17 +302,6 @@ class GoalDataset:
         goal_keys: dict[str, str] | None = None,
         seed: int | None = None,
     ):
-        """
-        Args:
-            dataset: Base dataset to wrap.
-            goal_probabilities: Tuple of (p_random, p_geometric_future, p_uniform_future, p_current) for goal sampling.
-            gamma: Discount factor for geometric future goal sampling.
-            current_goal_offset: Number of frames from clip start for "current" goal sampling.
-                If None, defaults to num_steps, i.e., last frame of clip.
-                When training with history, set this to history_size so "current" means last frame of history.
-            goal_keys: Mapping of source observation keys to goal observation keys. If None, defaults to {"pixels": "goal", "proprio": "goal_proprio"}.
-            seed: Random seed for goal sampling.
-        """
         self.dataset = dataset
         self.current_goal_offset = (
             current_goal_offset
@@ -639,7 +320,6 @@ class GoalDataset:
         self.gamma = gamma
         self.rng = np.random.default_rng(seed)
 
-        # All Dataset subclasses have lengths and offsets
         self.episode_lengths = dataset.lengths
         self.episode_offsets = dataset.offsets
 
@@ -648,7 +328,6 @@ class GoalDataset:
             int(self._episode_cumlen[-1]) if len(self._episode_cumlen) else 0
         )
 
-        # Auto-detect goal keys if not provided
         if goal_keys is None:
             goal_keys = {}
             column_names = dataset.column_names
@@ -658,8 +337,6 @@ class GoalDataset:
                 goal_keys['proprio'] = 'goal_proprio'
         self.goal_keys = goal_keys
 
-        # Build clip_indices with stricter constraint to ensure at least one future frame
-        # for geometric/uniform future goal sampling (only if these modes are used)
         _, p_geometric_future, p_uniform_future, _ = goal_probabilities
         needs_future_filtering = p_geometric_future > 0 or p_uniform_future > 0
 
@@ -668,22 +345,19 @@ class GoalDataset:
             current_end_offset = (self.current_goal_offset - 1) * frameskip
 
             self._clip_indices = []
-            self._index_mapping = []  # Maps our indices to wrapped dataset indices
+            self._index_mapping = []
 
             for wrapped_idx, (ep, start) in enumerate(dataset.clip_indices):
                 current_end = start + current_end_offset
-                # Need at least one frame after current_end (i.e., current_end + frameskip < length)
                 if current_end + frameskip < self.episode_lengths[ep]:
                     self._clip_indices.append((ep, start))
                     self._index_mapping.append(wrapped_idx)
         else:
-            # No future goal sampling, use wrapped dataset's indices directly
             self._clip_indices = list(dataset.clip_indices)
             self._index_mapping = list(range(len(dataset.clip_indices)))
 
     @property
     def clip_indices(self):
-        """Clip indices filtered to ensure at least one future frame is available."""
         return self._clip_indices
 
     def __len__(self):
@@ -707,7 +381,6 @@ class GoalDataset:
         return 'current'
 
     def _sample_random_step(self) -> tuple[int, int]:
-        """Sample random (ep_idx, local_idx) from entire dataset."""
         if self._total_steps == 0:
             return 0, 0
         flat_idx = int(self.rng.integers(0, self._total_steps))
@@ -721,14 +394,11 @@ class GoalDataset:
     def _sample_geometric_future_step(
         self, ep_idx: int, local_start: int
     ) -> tuple[int, int]:
-        """Sample future (ep_idx, local_idx) from same episode using geometric distribution."""
         frameskip = self.dataset.frameskip
-        # The minimum goal index should be the last frame of the history (current state)
         current_end = local_start + (self.current_goal_offset - 1) * frameskip
         max_steps = (
             self.episode_lengths[ep_idx] - 1 - current_end
         ) // frameskip
-        # clip_indices filtering guarantees max_steps >= 1
         assert max_steps >= 1, f'No future frames available: {max_steps=}'
 
         p = max(1.0 - self.gamma, 1e-6)
@@ -740,14 +410,11 @@ class GoalDataset:
     def _sample_uniform_future_step(
         self, ep_idx: int, local_start: int
     ) -> tuple[int, int]:
-        """Sample future (ep_idx, local_idx) from same episode using uniform distribution."""
         frameskip = self.dataset.frameskip
-        # The minimum goal index should be the last frame of the history (current state)
         current_end = local_start + (self.current_goal_offset - 1) * frameskip
         max_steps = (
             self.episode_lengths[ep_idx] - 1 - current_end
         ) // frameskip
-        # clip_indices filtering guarantees max_steps >= 1
         assert max_steps >= 1, f'No future frames available: {max_steps=}'
 
         k = int(self.rng.integers(1, max_steps + 1))
@@ -755,27 +422,22 @@ class GoalDataset:
         return ep_idx, local_idx
 
     def _get_clip_info(self, idx: int) -> tuple[int, int]:
-        """Returns (episode_idx, local_start) for a given GoalDataset index."""
         return self._clip_indices[idx]
 
     def _load_single_step(
         self, ep_idx: int, local_idx: int
     ) -> dict[str, torch.Tensor]:
-        """Load a single step from episode ep_idx at local index local_idx."""
         return self.dataset._load_slice(ep_idx, local_idx, local_idx + 1)
 
     def __getitem__(self, idx: int):
-        # Get base sample from wrapped dataset using index mapping
         wrapped_idx = self._index_mapping[idx]
         steps = self.dataset[wrapped_idx]
 
         if not self.goal_keys:
             return steps
 
-        # Get episode and local start for this index
         ep_idx, local_start = self._get_clip_info(idx)
 
-        # Sample goal (transform will be applied via underlying dataset's load_chunk/load_slice)
         goal_kind = self._sample_goal_kind()
         if goal_kind == 'random':
             goal_ep_idx, goal_local_idx = self._sample_random_step()
@@ -787,18 +449,15 @@ class GoalDataset:
             goal_ep_idx, goal_local_idx = self._sample_uniform_future_step(
                 ep_idx, local_start
             )
-        else:  # current
-            # Use current_goal_offset to determine the "current" frame
+        else:
             frameskip = self.dataset.frameskip
             goal_local_idx = (
                 local_start + (self.current_goal_offset - 1) * frameskip
             )
             goal_ep_idx = ep_idx
 
-        # Load goal step
         goal_step = self._load_single_step(goal_ep_idx, goal_local_idx)
 
-        # Add goal observations to steps
         for src_key, goal_key in self.goal_keys.items():
             if src_key not in goal_step or src_key not in steps:
                 continue
@@ -812,10 +471,6 @@ class GoalDataset:
 
 __all__ = [
     'Dataset',
-    'HDF5Dataset',
-    'FolderDataset',
-    'ImageDataset',
-    'VideoDataset',
     'MergeDataset',
     'ConcatDataset',
     'GoalDataset',

--- a/stable_worldmodel/data/format.py
+++ b/stable_worldmodel/data/format.py
@@ -1,0 +1,99 @@
+"""Format registry — declarative read/write abstraction over the dataset
+backends shipped with stable-worldmodel.
+
+A `Format` ties together three concerns for a given on-disk layout:
+  - `name`  — the registry key, also used as the explicit `format=` kwarg.
+  - `detect(path)` — does this path look like our format?
+  - `open_reader(path, **kw)` / `open_writer(path, **kw)` — entry points.
+
+To add a new format, drop a file under `data/formats/`, subclass `Format`,
+implement the methods you need, and decorate with `@register_format`.
+Read-only formats simply omit `open_writer`; write-only formats omit
+`open_reader`. Both calls raise a clear error by default.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+FORMATS: dict[str, type[Format]] = {}
+
+
+def register_format(cls: type[Format]) -> type[Format]:
+    name = getattr(cls, 'name', None)
+    if not name:
+        raise ValueError(
+            f'{cls.__name__} must set a non-empty `name` class attribute'
+        )
+    if name in FORMATS:
+        raise ValueError(f'format {name!r} is already registered')
+    FORMATS[name] = cls
+    return cls
+
+
+def list_formats() -> list[str]:
+    return list(FORMATS)
+
+
+def get_format(name: str) -> type[Format]:
+    try:
+        return FORMATS[name]
+    except KeyError:
+        raise ValueError(
+            f'unknown format {name!r}; available: {list_formats()}'
+        ) from None
+
+
+def detect_format(path) -> type[Format] | None:
+    """Return the first registered format whose `detect()` matches, else None."""
+    for fmt in FORMATS.values():
+        if fmt.detect(path):
+            return fmt
+    return None
+
+
+class Format:
+    """Declarative format spec.
+
+    Subclasses set `name` and implement `detect`. They typically also
+    implement `open_reader` and/or `open_writer`.
+    """
+
+    name: str = ''
+
+    @classmethod
+    def detect(cls, path) -> bool:
+        raise NotImplementedError(f'{cls.__name__}.detect must be implemented')
+
+    @classmethod
+    def open_reader(cls, path, **kwargs):
+        raise NotImplementedError(
+            f'format {cls.name or cls.__name__!r} does not support reading'
+        )
+
+    @classmethod
+    def open_writer(cls, path, **kwargs) -> Writer:
+        raise NotImplementedError(
+            f'format {cls.name or cls.__name__!r} does not support writing (read-only)'
+        )
+
+
+@runtime_checkable
+class Writer(Protocol):
+    """Streaming writer protocol — append episodes, close on exit."""
+
+    def __enter__(self) -> Writer: ...
+    def __exit__(self, *exc) -> None: ...
+    def write_episode(self, ep_data: dict) -> None: ...
+
+
+__all__ = [
+    'FORMATS',
+    'Format',
+    'Writer',
+    'detect_format',
+    'get_format',
+    'list_formats',
+    'register_format',
+]

--- a/stable_worldmodel/data/formats/__init__.py
+++ b/stable_worldmodel/data/formats/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in dataset formats. Importing this package registers each format."""
+
+from . import hdf5  # noqa: F401
+from . import folder  # noqa: F401
+from . import video  # noqa: F401
+from . import lerobot  # noqa: F401

--- a/stable_worldmodel/data/formats/folder.py
+++ b/stable_worldmodel/data/formats/folder.py
@@ -1,0 +1,223 @@
+"""Folder format: a directory with .npz tabular columns + per-step image files."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+from stable_worldmodel.data.dataset import Dataset
+from stable_worldmodel.data.format import Format, register_format
+from stable_worldmodel.data.formats.utils import is_image_column
+from stable_worldmodel.data.utils import get_cache_dir
+
+
+class FolderDataset(Dataset):
+    """Dataset loading from a folder structure.
+
+    Tabular columns are stored as .npz files; image columns are stored as
+    one image file per step under ``<key>/ep_<i>_step_<j>.jpeg``.
+    """
+
+    def __init__(
+        self,
+        name: str | None = None,
+        frameskip: int = 1,
+        num_steps: int = 1,
+        transform: Callable[[dict], dict] | None = None,
+        keys_to_load: list[str] | None = None,
+        folder_keys: list[str] | None = None,
+        cache_dir: str | Path | None = None,
+        path: str | Path | None = None,
+    ) -> None:
+        if path is not None:
+            self.path = Path(path)
+        else:
+            if name is None:
+                raise TypeError(
+                    'FolderDataset requires either `name` or `path`'
+                )
+            self.path = (
+                Path(cache_dir or get_cache_dir(sub_folder='datasets')) / name
+            )
+        # Auto-detect folder keys from on-disk layout: any subdirectory whose
+        # name isn't a metadata key is an image/video column.
+        if folder_keys is None:
+            folder_keys = [p.name for p in self.path.iterdir() if p.is_dir()]
+        self.folder_keys = folder_keys
+        self._cache: dict[str, np.ndarray] = {}
+
+        lengths = np.load(self.path / 'ep_len.npz')['arr_0']
+        offsets = np.load(self.path / 'ep_offset.npz')['arr_0']
+
+        if keys_to_load is None:
+            keys_to_load = sorted(
+                p.stem if p.suffix == '.npz' else p.name
+                for p in self.path.iterdir()
+                if p.stem not in ('ep_len', 'ep_offset')
+            )
+        self._keys = keys_to_load
+
+        for key in self._keys:
+            if key not in self.folder_keys:
+                npz = self.path / f'{key}.npz'
+                if npz.exists():
+                    self._cache[key] = np.load(npz)['arr_0']
+                    logging.info(f"Cached '{key}' from '{npz}'")
+
+        super().__init__(lengths, offsets, frameskip, num_steps, transform)
+
+    @property
+    def column_names(self) -> list[str]:
+        return self._keys
+
+    def _load_file(self, ep_idx: int, step: int, key: str) -> np.ndarray:
+        path = self.path / key / f'ep_{ep_idx}_step_{step}'
+        img_path = path.with_suffix('.jpeg')
+        if not img_path.exists():
+            img_path = path.with_suffix('.jpg')
+        return np.array(Image.open(img_path))
+
+    def _load_slice(self, ep_idx: int, start: int, end: int) -> dict:
+        g_start, g_end = (
+            self.offsets[ep_idx] + start,
+            self.offsets[ep_idx] + end,
+        )
+        steps = {}
+        for col in self._keys:
+            if col in self.folder_keys:
+                data = np.stack(
+                    [
+                        self._load_file(ep_idx, s, col)
+                        for s in range(start, end, self.frameskip)
+                    ]
+                )
+            else:
+                data = self._cache[col][g_start:g_end]
+                if col != 'action':
+                    data = data[:: self.frameskip]
+
+            if data.dtype == np.object_ or data.dtype.kind in ('S', 'U'):
+                val = data[0] if len(data) > 0 else b''
+                steps[col] = val.decode() if isinstance(val, bytes) else val
+            else:
+                steps[col] = torch.from_numpy(data)
+                if data.ndim == 4 and data.shape[-1] in (1, 3):
+                    steps[col] = steps[col].permute(0, 3, 1, 2)
+        return self.transform(steps) if self.transform else steps
+
+    def get_col_data(self, col: str) -> np.ndarray:
+        if col not in self._cache:
+            raise KeyError(
+                f"'{col}' not in cache (folder keys cannot be retrieved as full array)"
+            )
+        return self._cache[col]
+
+    def get_row_data(self, row_idx: int | list[int]) -> dict:
+        return {
+            c: self._cache[c][row_idx] for c in self._keys if c in self._cache
+        }
+
+
+class ImageDataset(FolderDataset):
+    """Convenience alias: ``FolderDataset`` with ``pixels`` as the image folder."""
+
+    def __init__(
+        self,
+        name: str | None = None,
+        image_keys: list[str] | None = None,
+        **kw: Any,
+    ) -> None:
+        super().__init__(name=name, folder_keys=image_keys or ['pixels'], **kw)
+
+
+class FolderWriter:
+    """Append episodes to a folder dataset.
+
+    Layout::
+
+        <root>/
+          ep_len.npz, ep_offset.npz
+          <col>.npz                            # tabular columns
+          <img_col>/ep_<i>_step_<j>.jpeg       # per-step image files
+
+    Image columns are auto-detected: any value that is a ``uint8`` array
+    shaped ``(H, W, 3)`` or ``(H, W, 1)`` is written as JPEG.
+    """
+
+    def __init__(self, path):
+        self.path = Path(path)
+        self.path.mkdir(parents=True, exist_ok=True)
+        self._tabular: dict[str, list[np.ndarray]] = {}
+        self._lengths: list[int] = []
+        self._offsets: list[int] = []
+        self._global_ptr = 0
+        self._ep_idx = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self):
+        np.savez(self.path / 'ep_len.npz', np.asarray(self._lengths, np.int32))
+        np.savez(
+            self.path / 'ep_offset.npz', np.asarray(self._offsets, np.int64)
+        )
+        for col, parts in self._tabular.items():
+            np.savez(self.path / f'{col}.npz', np.concatenate(parts, axis=0))
+
+    def write_episode(self, ep_data: dict) -> None:
+        ep_len = len(next(iter(ep_data.values())))
+        for col, vals in ep_data.items():
+            if is_image_column(vals):
+                col_dir = self.path / col
+                col_dir.mkdir(exist_ok=True)
+                for step, frame in enumerate(vals):
+                    arr = np.asarray(frame)
+                    if arr.shape[-1] == 1:
+                        arr = arr.squeeze(-1)
+                    Image.fromarray(arr).save(
+                        col_dir / f'ep_{self._ep_idx}_step_{step}.jpeg'
+                    )
+            else:
+                self._tabular.setdefault(col, []).append(np.asarray(vals))
+
+        self._lengths.append(ep_len)
+        self._offsets.append(self._global_ptr)
+        self._global_ptr += ep_len
+        self._ep_idx += 1
+
+
+@register_format
+class Folder(Format):
+    name = 'folder'
+
+    @classmethod
+    def detect(cls, path) -> bool:
+        p = Path(path)
+        if not p.is_dir() or not (p / 'ep_len.npz').exists():
+            return False
+        # Folder is the fallback for directories with ep_len.npz; if any
+        # subfolder contains .mp4 files, the video format wins instead.
+        for sub in p.iterdir():
+            if sub.is_dir() and any(sub.glob('*.mp4')):
+                return False
+        return True
+
+    @classmethod
+    def open_reader(cls, path, **kwargs) -> FolderDataset:
+        return FolderDataset(path=path, **kwargs)
+
+    @classmethod
+    def open_writer(cls, path, **kwargs) -> FolderWriter:
+        return FolderWriter(path, **kwargs)
+
+
+__all__ = ['Folder', 'FolderDataset', 'FolderWriter', 'ImageDataset']

--- a/stable_worldmodel/data/formats/hdf5.py
+++ b/stable_worldmodel/data/formats/hdf5.py
@@ -1,0 +1,223 @@
+"""HDF5 format: single .h5 file with per-column datasets + ep_len/ep_offset."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import h5py
+import hdf5plugin  # noqa: F401
+import numpy as np
+import torch
+
+from stable_worldmodel.data.dataset import Dataset
+from stable_worldmodel.data.format import Format, register_format
+from stable_worldmodel.data.utils import get_cache_dir
+
+
+class HDF5Dataset(Dataset):
+    """Dataset loading from a single HDF5 file (SWMR mode for safe reads)."""
+
+    def __init__(
+        self,
+        name: str | None = None,
+        frameskip: int = 1,
+        num_steps: int = 1,
+        transform: Callable[[dict], dict] | None = None,
+        keys_to_load: list[str] | None = None,
+        keys_to_cache: list[str] | None = None,
+        keys_to_merge: dict[str, list[str] | str] | None = None,
+        cache_dir: str | Path | None = None,
+        path: str | Path | None = None,
+    ) -> None:
+        if path is not None:
+            self.h5_path = Path(path)
+        else:
+            if name is None:
+                raise TypeError('HDF5Dataset requires either `name` or `path`')
+            datasets_dir = get_cache_dir(cache_dir, sub_folder='datasets')
+            self.h5_path = Path(datasets_dir, f'{name}.h5')
+
+        self.h5_file: h5py.File | None = None
+        self._cache: dict[str, np.ndarray] = {}
+
+        with h5py.File(self.h5_path, 'r') as f:
+            lengths, offsets = f['ep_len'][:], f['ep_offset'][:]
+            self._keys = keys_to_load or [
+                k for k in f.keys() if k not in ('ep_len', 'ep_offset')
+            ]
+
+            for key in keys_to_cache or []:
+                self._cache[key] = f[key][:]
+                logging.info(f"Cached '{key}' from '{self.h5_path}'")
+
+        super().__init__(lengths, offsets, frameskip, num_steps, transform)
+
+        if keys_to_merge:
+            for target, source in keys_to_merge.items():
+                self.merge_col(source, target)
+
+    @property
+    def column_names(self) -> list[str]:
+        return self._keys
+
+    def _open(self) -> None:
+        if self.h5_file is None:
+            self.h5_file = h5py.File(
+                self.h5_path, 'r', swmr=True, rdcc_nbytes=256 * 1024 * 1024
+            )
+
+    def _load_slice(self, ep_idx: int, start: int, end: int) -> dict:
+        self._open()
+        g_start, g_end = (
+            self.offsets[ep_idx] + start,
+            self.offsets[ep_idx] + end,
+        )
+        steps = {}
+        for col in self._keys:
+            src = self._cache if col in self._cache else self.h5_file
+            data = src[col][g_start:g_end]
+            if col != 'action':
+                data = data[:: self.frameskip]
+
+            if data.dtype == np.object_ or data.dtype.kind in ('S', 'U'):
+                val = data[0] if len(data) > 0 else b''
+                steps[col] = val.decode() if isinstance(val, bytes) else val
+            else:
+                steps[col] = torch.from_numpy(data)
+                if data.ndim == 4 and data.shape[-1] in (1, 3):
+                    steps[col] = steps[col].permute(0, 3, 1, 2)
+
+        return self.transform(steps) if self.transform else steps
+
+    def _get_col(self, col: str) -> np.ndarray:
+        if col in self._cache:
+            return self._cache[col]
+        self._open()
+        return self.h5_file[col][:]
+
+    def get_col_data(self, col: str) -> np.ndarray:
+        return self._get_col(col)
+
+    def get_row_data(self, row_idx: int | list[int]) -> dict:
+        self._open()
+        return {col: self.h5_file[col][row_idx] for col in self._keys}
+
+    def merge_col(
+        self,
+        source: list[str] | str,
+        target: str,
+        dim: int = -1,
+    ) -> None:
+        self._open()
+
+        if isinstance(source, str):
+            source = [k for k in self.h5_file.keys() if re.match(source, k)]
+
+        merged = np.concatenate([self._get_col(s) for s in source], axis=dim)
+        self._cache[target] = merged
+        if target not in self._keys:
+            self._keys.append(target)
+        logging.info(f"Merged columns {source} into '{target}' and cached it")
+
+    def get_dim(self, col: str) -> int:
+        data = self.get_col_data(col)
+        return np.prod(data.shape[1:]).item() if data.ndim > 1 else 1
+
+
+class HDF5Writer:
+    """Append episodes to a single HDF5 file. Schema is inferred from the
+    first episode and locked thereafter."""
+
+    def __init__(self, path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._f: h5py.File | None = None
+        self._initialized = False
+        self._ep_written = 0
+        self._global_ptr = 0
+
+    def __enter__(self):
+        self._f = h5py.File(str(self.path), 'w', libver='latest')
+        return self
+
+    def __exit__(self, *exc):
+        if self._f is not None:
+            self._f.close()
+            self._f = None
+
+    def write_episode(self, ep_data: dict) -> None:
+        if self._f is None:
+            raise RuntimeError('HDF5Writer used outside of a `with` block')
+        if not self._initialized:
+            self._init_schema(ep_data)
+            self._initialized = True
+
+        ep_len = len(next(iter(ep_data.values())))
+        for col, vals in ep_data.items():
+            ds = self._f[col]
+            ds.resize(self._global_ptr + ep_len, axis=0)
+            ds[self._global_ptr : self._global_ptr + ep_len] = np.array(vals)
+
+        self._f['ep_len'].resize(self._ep_written + 1, axis=0)
+        self._f['ep_len'][self._ep_written] = ep_len
+        self._f['ep_offset'].resize(self._ep_written + 1, axis=0)
+        self._f['ep_offset'][self._ep_written] = self._global_ptr
+
+        self._ep_written += 1
+        self._global_ptr += ep_len
+
+    def _init_schema(self, sample_ep: dict) -> None:
+        for col, vals in sample_ep.items():
+            sample = np.asarray(vals[0])
+            self._f.create_dataset(
+                col,
+                shape=(0, *sample.shape),
+                maxshape=(None, *sample.shape),
+                dtype=sample.dtype,
+                chunks=(1, *sample.shape),
+            )
+        self._f.create_dataset(
+            'ep_len', shape=(0,), maxshape=(None,), dtype=np.int32
+        )
+        self._f.create_dataset(
+            'ep_offset', shape=(0,), maxshape=(None,), dtype=np.int64
+        )
+
+
+@register_format
+class HDF5(Format):
+    name = 'hdf5'
+
+    @classmethod
+    def detect(cls, path) -> bool:
+        p = Path(path)
+        if p.suffix in ('.h5', '.hdf5'):
+            return True
+        if p.is_dir():
+            return any(p.glob('*.h5')) or any(p.glob('*.hdf5'))
+        return False
+
+    @classmethod
+    def open_reader(cls, path, **kwargs) -> HDF5Dataset:
+        p = Path(path)
+        if p.is_dir():
+            files = sorted(p.glob('*.h5')) + sorted(p.glob('*.hdf5'))
+            if not files:
+                raise FileNotFoundError(f'No .h5/.hdf5 file in {p}')
+            if len(files) > 1:
+                raise ValueError(
+                    f'Ambiguous dataset: multiple HDF5 files in {p}. '
+                    'Pass the file directly.'
+                )
+            p = files[0]
+        return HDF5Dataset(path=p, **kwargs)
+
+    @classmethod
+    def open_writer(cls, path, **kwargs) -> HDF5Writer:
+        return HDF5Writer(path, **kwargs)
+
+
+__all__ = ['HDF5', 'HDF5Dataset', 'HDF5Writer']

--- a/stable_worldmodel/data/formats/lerobot.py
+++ b/stable_worldmodel/data/formats/lerobot.py
@@ -1,4 +1,9 @@
-"""LeRobot Hub datasets exposed through the stable-worldmodel Dataset API."""
+"""LeRobot Hub format (read-only).
+
+Identified by the ``lerobot://`` scheme. Mapping ``World.collect``'s
+arbitrary info-dict to LeRobot's prescribed schema is non-trivial and
+therefore not supported as a writer here.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +16,9 @@ import numpy as np
 import torch
 
 from stable_worldmodel.data.dataset import Dataset
+from stable_worldmodel.data.format import Format, register_format
+
+_SCHEME = 'lerobot://'
 
 
 def _import_lerobot_hub_dataset() -> type:
@@ -36,7 +44,6 @@ def _import_lerobot_hub_dataset() -> type:
 
 
 def _scalarize(value: Any) -> Any:
-    """Convert tensors/arrays to plain Python scalars when possible."""
     if isinstance(value, torch.Tensor):
         if value.ndim == 0:
             return value.item()
@@ -49,7 +56,6 @@ def _scalarize(value: Any) -> Any:
 
 
 def _column_to_numpy(column: Any) -> np.ndarray:
-    """Convert a LeRobot/HF dataset column to a NumPy array."""
     if isinstance(column, torch.Tensor):
         return column.detach().cpu().numpy()
     if isinstance(column, np.ndarray):
@@ -354,3 +360,20 @@ class LeRobotAdapter(Dataset):
     def get_dim(self, col: str) -> int:
         data = self.get_col_data(col)
         return np.prod(data.shape[1:]).item() if data.ndim > 1 else 1
+
+
+@register_format
+class LeRobot(Format):
+    name = 'lerobot'
+
+    @classmethod
+    def detect(cls, path) -> bool:
+        return isinstance(path, str) and path.startswith(_SCHEME)
+
+    @classmethod
+    def open_reader(cls, path, **kwargs):
+        repo_id = path[len(_SCHEME) :] if path.startswith(_SCHEME) else path
+        return LeRobotAdapter(repo_id, **kwargs)
+
+
+__all__ = ['LeRobot', 'LeRobotAdapter']

--- a/stable_worldmodel/data/formats/utils.py
+++ b/stable_worldmodel/data/formats/utils.py
@@ -1,0 +1,17 @@
+"""Tiny helpers shared by built-in formats."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def is_image_column(vals) -> bool:
+    """Return True if `vals` looks like a sequence of HxW image frames."""
+    if not vals:
+        return False
+    sample = np.asarray(vals[0])
+    return (
+        sample.dtype == np.uint8
+        and sample.ndim == 3
+        and sample.shape[-1] in (1, 3)
+    )

--- a/stable_worldmodel/data/formats/video.py
+++ b/stable_worldmodel/data/formats/video.py
@@ -1,0 +1,162 @@
+"""Video format: tabular .npz columns + one .mp4 per episode for image keys."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from stable_worldmodel.data.format import Format, register_format
+from stable_worldmodel.data.formats.utils import is_image_column
+from stable_worldmodel.data.formats.folder import FolderDataset
+
+
+class VideoDataset(FolderDataset):
+    """Loads frames from MP4 files (one per episode) using decord."""
+
+    _decord: Any = None  # Lazy module reference
+
+    def __init__(
+        self,
+        name: str | None = None,
+        video_keys: list[str] | None = None,
+        **kw: Any,
+    ) -> None:
+        if VideoDataset._decord is None:
+            try:
+                import decord
+
+                decord.bridge.set_bridge('torch')
+                VideoDataset._decord = decord
+            except ImportError:
+                raise ImportError('VideoDataset requires decord')
+        super().__init__(name=name, folder_keys=video_keys or ['video'], **kw)
+
+    @lru_cache(maxsize=8)
+    def _reader(self, ep_idx: int, key: str) -> Any:
+        return VideoDataset._decord.VideoReader(
+            str(self.path / key / f'ep_{ep_idx}.mp4'), num_threads=1
+        )
+
+    def _load_file(self, ep_idx: int, step: int, key: str) -> np.ndarray:
+        return self._reader(ep_idx, key)[step].numpy()
+
+    def _load_slice(self, ep_idx: int, start: int, end: int) -> dict:
+        g_start, g_end = (
+            self.offsets[ep_idx] + start,
+            self.offsets[ep_idx] + end,
+        )
+        steps = {}
+        for col in self._keys:
+            if col in self.folder_keys:
+                frames = self._reader(ep_idx, col).get_batch(
+                    list(range(start, end, self.frameskip))
+                )
+                steps[col] = frames.permute(0, 3, 1, 2)
+            else:
+                data = self._cache[col][g_start:g_end]
+                if col != 'action':
+                    data = data[:: self.frameskip]
+
+                if data.dtype == np.object_ or data.dtype.kind in ('S', 'U'):
+                    val = data[0] if len(data) > 0 else b''
+                    steps[col] = (
+                        val.decode() if isinstance(val, bytes) else val
+                    )
+                else:
+                    steps[col] = torch.from_numpy(data)
+
+        return self.transform(steps) if self.transform else steps
+
+
+class VideoWriter:
+    """Append episodes; image columns are encoded as one MP4 per episode.
+
+    Layout::
+
+        <root>/
+          ep_len.npz, ep_offset.npz
+          <col>.npz                 # tabular columns
+          <img_col>/ep_<i>.mp4      # one video per episode per image col
+    """
+
+    def __init__(self, path, fps: int = 25, codec: str = 'libx264'):
+        self.path = Path(path)
+        self.path.mkdir(parents=True, exist_ok=True)
+        self.fps = fps
+        self.codec = codec
+        self._tabular: dict[str, list[np.ndarray]] = {}
+        self._lengths: list[int] = []
+        self._offsets: list[int] = []
+        self._global_ptr = 0
+        self._ep_idx = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self):
+        np.savez(self.path / 'ep_len.npz', np.asarray(self._lengths, np.int32))
+        np.savez(
+            self.path / 'ep_offset.npz', np.asarray(self._offsets, np.int64)
+        )
+        for col, parts in self._tabular.items():
+            np.savez(self.path / f'{col}.npz', np.concatenate(parts, axis=0))
+
+    def write_episode(self, ep_data: dict) -> None:
+        import imageio
+
+        ep_len = len(next(iter(ep_data.values())))
+        for col, vals in ep_data.items():
+            if is_image_column(vals):
+                col_dir = self.path / col
+                col_dir.mkdir(exist_ok=True)
+                writer = imageio.get_writer(
+                    str(col_dir / f'ep_{self._ep_idx}.mp4'),
+                    fps=self.fps,
+                    codec=self.codec,
+                )
+                for frame in vals:
+                    arr = np.asarray(frame)
+                    if arr.shape[-1] == 1:
+                        arr = np.repeat(arr, 3, axis=-1)
+                    writer.append_data(arr)
+                writer.close()
+            else:
+                self._tabular.setdefault(col, []).append(np.asarray(vals))
+
+        self._lengths.append(ep_len)
+        self._offsets.append(self._global_ptr)
+        self._global_ptr += ep_len
+        self._ep_idx += 1
+
+
+@register_format
+class Video(Format):
+    name = 'video'
+
+    @classmethod
+    def detect(cls, path) -> bool:
+        p = Path(path)
+        if not p.is_dir() or not (p / 'ep_len.npz').exists():
+            return False
+        for sub in p.iterdir():
+            if sub.is_dir() and any(sub.glob('*.mp4')):
+                return True
+        return False
+
+    @classmethod
+    def open_reader(cls, path, **kwargs) -> VideoDataset:
+        return VideoDataset(path=path, **kwargs)
+
+    @classmethod
+    def open_writer(cls, path, **kwargs) -> VideoWriter:
+        return VideoWriter(path, **kwargs)
+
+
+__all__ = ['Video', 'VideoDataset', 'VideoWriter']

--- a/stable_worldmodel/data/utils.py
+++ b/stable_worldmodel/data/utils.py
@@ -4,6 +4,8 @@ import subprocess
 import urllib.request
 from pathlib import Path
 
+import numpy as np
+import torch
 from loguru import logger as logging
 from tqdm import tqdm
 
@@ -31,61 +33,90 @@ def ensure_dir_exists(path: Path):
         path.mkdir(parents=True, exist_ok=True)
 
 
-def load_dataset(name: str, cache_dir: str = None, **kwargs):
-    """Resolve a dataset and return an instantiated :class:`HDF5Dataset`.
+def load_dataset(
+    name: str,
+    cache_dir: str = None,
+    format: str | None = None,
+    **kwargs,
+):
+    """Resolve a dataset name to a local path and dispatch to the matching
+    format reader from the registry.
 
-    Supported formats for `name`:
+    Supported names:
 
-    1. **Local path** — absolute or relative path to a ``.h5`` / ``.hdf5`` file
-       or a directory containing exactly one such file.
+    1. **Local path** — file or directory.
+    2. **HuggingFace repo** (``<user>/<repo>``) — downloaded and cached under
+       ``<cache_dir>/datasets/<user>--<repo>/``.
+    3. **Format scheme** (e.g. ``lerobot://lerobot/pusht``) — passed through
+       to the matching format unchanged.
 
-    2. **HuggingFace repo** (``<user>/<repo>``) — downloaded from HF and cached
-       under ``<cache_dir>/datasets/<user>--<repo>/``.  The repo must expose a
-       single ``dataset.tar.zst`` archive containing one HDF5 file.
+    The format is auto-detected via :func:`detect_format` unless ``format`` is
+    provided explicitly. To register a new format, decorate a
+    :class:`~stable_worldmodel.data.format.Format` subclass with
+    :func:`~stable_worldmodel.data.format.register_format`.
 
     Args:
-        name: Local path or HF repo id (``user/repo``).
-        cache_dir: Root cache directory.  Defaults to ``STABLEWM_HOME`` or
+        name: Local path, HF repo id, or scheme-prefixed identifier.
+        cache_dir: Root cache directory. Defaults to ``STABLEWM_HOME`` or
             ``~/.stable_worldmodel``.
-        **kwargs: Extra arguments passed to ``HDF5Dataset``.
+        format: Explicit format name (skips detection).
+        **kwargs: Forwarded to the format's reader.
 
     Returns:
-        An :class:`~stable_worldmodel.data.dataset.HDF5Dataset` instance.
-
-    Example::
-
-        ds = load_dataset('my-org/my-robot-data', num_steps=4, frameskip=2)
+        A reader instance (typically a
+        :class:`~stable_worldmodel.data.dataset.Dataset` subclass).
     """
-    from stable_worldmodel.data.dataset import HDF5Dataset
+    from stable_worldmodel.data.format import (
+        FORMATS,
+        detect_format,
+        get_format,
+    )
+
+    name = str(name)
+
+    # Scheme-prefixed identifiers (e.g. lerobot://...) bypass path resolution.
+    if '://' in name:
+        if format is None:
+            for fmt in FORMATS.values():
+                if fmt.detect(name):
+                    return fmt.open_reader(name, **kwargs)
+            raise ValueError(f'No format detected for {name!r}')
+        return get_format(format).open_reader(name, **kwargs)
 
     datasets_dir = get_cache_dir(cache_dir, sub_folder='datasets')
     ensure_dir_exists(datasets_dir)
-    h5_path = _resolve_dataset(name, datasets_dir)
-    rel_name = str(h5_path.relative_to(datasets_dir).with_suffix(''))
-    return HDF5Dataset(name=rel_name, cache_dir=cache_dir, **kwargs)
+    path = _resolve_dataset(name, datasets_dir)
+
+    if format is not None:
+        return get_format(format).open_reader(path, **kwargs)
+
+    fmt = detect_format(path)
+    if fmt is None:
+        raise ValueError(
+            f'No format detected for {path!r}; pass format= explicitly.'
+        )
+    return fmt.open_reader(path, **kwargs)
 
 
 def _resolve_dataset(name: str, datasets_dir: Path) -> Path:
+    """Resolve *name* (local path or HF repo id) to a local path.
+
+    Returns whatever exists on disk — file or directory. Format detection
+    happens after this in :func:`load_dataset`.
+    """
     local = Path(name)
     if not local.is_absolute():
         local = datasets_dir / local
 
-    # format 1a: explicit HDF5 file path
-    if local.suffix in ('.h5', '.hdf5'):
-        if local.exists():
-            return local
-        raise FileNotFoundError(f'Dataset file not found: {local}')
+    if local.exists():
+        return local
 
-    # format 1b: directory containing a single HDF5 file
-    if local.is_dir():
-        return _resolve_dataset_folder(local)
-
-    # format 2: HuggingFace repo (<user>/<repo>)
-    if '/' in name:
+    # HuggingFace repo: <user>/<repo>
+    if '/' in name and not name.startswith(('.', '/')):
         return _resolve_dataset_hf(name, datasets_dir)
 
-    raise ValueError(
-        f"Cannot resolve '{name}': not a .h5 file, a folder, or a HF repo id."
+    raise FileNotFoundError(
+        f'Cannot resolve {name!r}: not a local path or HF repo id.'
     )
 
 
@@ -203,4 +234,77 @@ def _extract_zst(archive: Path) -> None:
         )
 
 
-__all__ = ['load_dataset', 'get_cache_dir', 'ensure_dir_exists']
+def convert(
+    source,
+    dest,
+    *,
+    source_format: str | None = None,
+    dest_format: str = 'hdf5',
+    cache_dir: str | None = None,
+    progress: bool = True,
+    **dest_kwargs,
+) -> None:
+    """Convert a dataset from one registered format to another.
+
+    Reads each episode from *source* and writes it through the writer of
+    *dest_format*. Format detection follows the same rules as
+    :func:`load_dataset` — autodetect by default, or pass ``source_format``
+    explicitly.
+
+    Args:
+        source: Path or identifier accepted by :func:`load_dataset`.
+        dest: Output path for the destination writer.
+        source_format: Force a source format (skips detection).
+        dest_format: Registered writer name (default ``'hdf5'``).
+        cache_dir: Forwarded to the source loader for HF/local resolution.
+        progress: Show a progress bar over episodes.
+        **dest_kwargs: Forwarded to the destination writer.
+
+    Example::
+
+        from stable_worldmodel.data import convert
+        convert('data.h5', 'data_video/', dest_format='video', fps=30)
+    """
+    from stable_worldmodel.data.format import get_format
+
+    src = load_dataset(source, cache_dir=cache_dir, format=source_format)
+    writer_cls = get_format(dest_format)
+
+    iterator = range(len(src.lengths))
+    if progress:
+        iterator = tqdm(iterator, desc=f'Converting → {dest_format}')
+
+    with writer_cls.open_writer(dest, **dest_kwargs) as writer:
+        for ep_idx in iterator:
+            ep = src.load_episode(ep_idx)
+            writer.write_episode(
+                _episode_to_step_lists(ep, int(src.lengths[ep_idx]))
+            )
+
+
+def _episode_to_step_lists(ep: dict, ep_len: int) -> dict[str, list]:
+    """Adapt an episode dict from a reader to the ``{col: [step_arr, ...]}``
+    shape that writers consume.
+
+    Specifically:
+      - Tensors → NumPy arrays.
+      - Image arrays in ``(N, C, H, W)`` are transposed back to ``(N, H, W, C)``.
+      - Scalars (e.g. flattened string columns) are repeated ``ep_len`` times.
+    """
+    out: dict[str, list] = {}
+    for col, val in ep.items():
+        if isinstance(val, torch.Tensor):
+            arr = val.detach().cpu().numpy()
+        elif isinstance(val, np.ndarray):
+            arr = val
+        else:
+            out[col] = [val] * ep_len
+            continue
+
+        if arr.ndim == 4 and arr.shape[1] in (1, 3):
+            arr = arr.transpose(0, 2, 3, 1)
+        out[col] = list(arr)
+    return out
+
+
+__all__ = ['load_dataset', 'convert', 'get_cache_dir', 'ensure_dir_exists']

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -229,34 +229,34 @@ class World:
         episodes: int,
         seed: int | None = None,
         options: dict | None = None,
+        format: str = 'hdf5',
     ) -> None:
-        """Roll out ``episodes`` and dump their trajectories to HDF5.
+        """Roll out ``episodes`` and dump their trajectories using the writer
+        registered for ``format``.
 
         Each info key becomes a column. Leading length-1 time dims are
         squeezed. Columns starting with ``_`` (e.g. ``_needs_flush``)
-        are skipped. The file layout is::
-
-            <col>:       (total_steps, *value_shape)
-            ep_len:      (n_episodes,)      int32
-            ep_offset:   (n_episodes,)      int64  — index into <col>
+        are skipped.
 
         Args:
-            path: HDF5 file to create (parent dirs are auto-created).
+            path: Output path (file or directory, depending on the format).
+                Parent dirs are auto-created.
             episodes: Number of episodes to record.
             seed: Base seed for env resets.
             options: Reset options forwarded to ``envs.reset``.
+            format: Registered format name (default ``'hdf5'``). See
+                :func:`stable_worldmodel.data.list_formats` for available
+                writers; new formats can be added via
+                :func:`stable_worldmodel.data.register_format`.
         """
-        import h5py
         from tqdm import tqdm
 
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        buffers = [defaultdict(list) for _ in range(self.num_envs)]
-        ep_written = 0
-        global_ptr = 0
-        initialized = False
+        from stable_worldmodel.data.format import get_format
 
-        with h5py.File(str(path), 'w', libver='latest') as f:
+        writer_cls = get_format(format)
+        buffers = [defaultdict(list) for _ in range(self.num_envs)]
+
+        with writer_cls.open_writer(path) as writer:
 
             def on_step(world):
                 for col, data in world.infos.items():
@@ -278,16 +278,11 @@ class World:
                         buffers[i][col].append(val)
 
             def on_done(env_idx, ep_idx, world):
-                nonlocal ep_written, global_ptr, initialized
                 ep = {k: list(v) for k, v in buffers[env_idx].items()}
                 buffers[env_idx].clear()
                 if 'action' in ep:
                     ep['action'].append(ep['action'].pop(0))
-                if not initialized:
-                    _init_h5(f, ep)
-                    initialized = True
-                global_ptr += _write_h5_episode(f, ep, ep_written, global_ptr)
-                ep_written += 1
+                writer.write_episode(ep)
                 pbar.update(1)
 
             with tqdm(total=episodes, desc='Recording') as pbar:
@@ -536,30 +531,3 @@ def _apply_callables(env, callables, init_state):
             else:
                 prepared[name] = data.get('value')
         getattr(env, method)(**prepared)
-
-
-def _init_h5(f, sample_ep):
-    for col, vals in sample_ep.items():
-        sample = np.asarray(vals[0])
-        f.create_dataset(
-            col,
-            shape=(0, *sample.shape),
-            maxshape=(None, *sample.shape),
-            dtype=sample.dtype,
-            chunks=(1, *sample.shape),
-        )
-    f.create_dataset('ep_len', shape=(0,), maxshape=(None,), dtype=np.int32)
-    f.create_dataset('ep_offset', shape=(0,), maxshape=(None,), dtype=np.int64)
-
-
-def _write_h5_episode(f, ep_data, ep_idx, global_ptr):
-    ep_len = len(next(iter(ep_data.values())))
-    for col, vals in ep_data.items():
-        ds = f[col]
-        ds.resize(global_ptr + ep_len, axis=0)
-        ds[global_ptr : global_ptr + ep_len] = np.array(vals)
-    f['ep_len'].resize(ep_idx + 1, axis=0)
-    f['ep_len'][ep_idx] = ep_len
-    f['ep_offset'].resize(ep_idx + 1, axis=0)
-    f['ep_offset'][ep_idx] = global_ptr
-    return ep_len

--- a/tests/data/test_data_utils.py
+++ b/tests/data/test_data_utils.py
@@ -129,10 +129,10 @@ def test_resolve_dataset_explicit_hdf5_file(tmp_path):
 def test_resolve_dataset_directory(tmp_path):
     sub = tmp_path / 'subdir'
     sub.mkdir()
-    h5 = sub / 'data.h5'
-    h5.touch()
+    (sub / 'data.h5').touch()
+    # _resolve_dataset returns the path as-is; format detection happens later.
     result = _resolve_dataset(str(sub), tmp_path)
-    assert result == h5
+    assert result == sub
 
 
 def test_resolve_dataset_hf_repo(tmp_path):
@@ -144,7 +144,7 @@ def test_resolve_dataset_hf_repo(tmp_path):
 
 
 def test_resolve_dataset_invalid_name_raises(tmp_path):
-    with pytest.raises(ValueError, match='Cannot resolve'):
+    with pytest.raises(FileNotFoundError, match='Cannot resolve'):
         _resolve_dataset('not_a_valid_name', tmp_path)
 
 
@@ -533,20 +533,23 @@ def _make_h5(path: Path):
 
 
 def test_load_dataset_from_local_h5(tmp_path):
-    # load_dataset resolves the h5, computes a relative name, and delegates to HDF5Dataset
+    """load_dataset autodetects HDF5 from a .h5 path and returns a working reader."""
+    from stable_worldmodel.data import HDF5Dataset
+
     datasets_dir = tmp_path / 'datasets'
     datasets_dir.mkdir()
     h5 = datasets_dir / 'mydata.h5'
     _make_h5(h5)
 
-    with patch('stable_worldmodel.data.dataset.HDF5Dataset') as mock_cls:
-        load_dataset(str(h5), cache_dir=str(tmp_path))
-        mock_cls.assert_called_once()
-        call_kwargs = mock_cls.call_args[1]
-        assert call_kwargs['name'] == 'mydata'
+    ds = load_dataset(str(h5), cache_dir=str(tmp_path))
+    assert isinstance(ds, HDF5Dataset)
+    assert ds.h5_path == h5
 
 
 def test_load_dataset_from_directory(tmp_path):
+    """load_dataset autodetects HDF5 from a directory containing one .h5 file."""
+    from stable_worldmodel.data import HDF5Dataset
+
     datasets_dir = tmp_path / 'datasets'
     datasets_dir.mkdir()
     sub = datasets_dir / 'mydata'
@@ -554,11 +557,9 @@ def test_load_dataset_from_directory(tmp_path):
     h5 = sub / 'dataset.h5'
     _make_h5(h5)
 
-    with patch('stable_worldmodel.data.dataset.HDF5Dataset') as mock_cls:
-        load_dataset(str(sub), cache_dir=str(tmp_path))
-        mock_cls.assert_called_once()
-        call_kwargs = mock_cls.call_args[1]
-        assert call_kwargs['name'] == 'mydata/dataset'
+    ds = load_dataset(str(sub), cache_dir=str(tmp_path))
+    assert isinstance(ds, HDF5Dataset)
+    assert ds.h5_path == h5
 
 
 def test_load_dataset_missing_file_raises(tmp_path):

--- a/tests/data/test_format.py
+++ b/tests/data/test_format.py
@@ -1,0 +1,581 @@
+"""Tests for the format registry, writers, and conversion utility."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+import stable_worldmodel as swm
+from stable_worldmodel.data import (
+    FORMATS,
+    Format,
+    FolderDataset,
+    HDF5Dataset,
+    VideoDataset,
+    convert,
+    detect_format,
+    get_format,
+    list_formats,
+    register_format,
+)
+from stable_worldmodel.data.formats.folder import Folder, FolderWriter
+from stable_worldmodel.data.formats.hdf5 import HDF5, HDF5Writer
+from stable_worldmodel.data.formats.lerobot import LeRobot
+from stable_worldmodel.data.formats.video import Video, VideoWriter
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+def _episode(n_steps: int, with_pixels: bool = True) -> dict:
+    """Build an in-memory episode in writer input shape."""
+    rng = np.random.default_rng(0)
+    ep = {
+        'action': [
+            rng.standard_normal(2).astype(np.float32) for _ in range(n_steps)
+        ],
+        'proprio': [
+            rng.standard_normal(4).astype(np.float32) for _ in range(n_steps)
+        ],
+    }
+    if with_pixels:
+        ep['pixels'] = [
+            rng.integers(0, 255, size=(8, 8, 3), dtype=np.uint8)
+            for _ in range(n_steps)
+        ]
+    return ep
+
+
+@pytest.fixture
+def two_episodes():
+    return [_episode(5), _episode(7)]
+
+
+# ─── Registry ─────────────────────────────────────────────────────────────────
+
+
+class TestRegistry:
+    def test_builtins_registered(self):
+        assert {'hdf5', 'folder', 'video', 'lerobot'}.issubset(
+            set(list_formats())
+        )
+
+    def test_get_format_returns_class(self):
+        assert get_format('hdf5') is HDF5
+        assert get_format('folder') is Folder
+        assert get_format('video') is Video
+        assert get_format('lerobot') is LeRobot
+
+    def test_get_format_unknown_raises(self):
+        with pytest.raises(ValueError, match='unknown format'):
+            get_format('does_not_exist')
+
+    def test_register_format_adds_to_registry(self):
+        class _Tmp(Format):
+            name = '_tmp_test_register'
+
+            @classmethod
+            def detect(cls, path):
+                return False
+
+        try:
+            register_format(_Tmp)
+            assert FORMATS['_tmp_test_register'] is _Tmp
+            assert '_tmp_test_register' in list_formats()
+        finally:
+            FORMATS.pop('_tmp_test_register', None)
+
+    def test_register_format_rejects_missing_name(self):
+        class _NoName(Format):
+            pass
+
+        with pytest.raises(ValueError, match='non-empty'):
+            register_format(_NoName)
+
+    def test_register_format_rejects_duplicate(self):
+        class _Dup(Format):
+            name = 'hdf5'  # already taken
+
+            @classmethod
+            def detect(cls, path):
+                return False
+
+        with pytest.raises(ValueError, match='already registered'):
+            register_format(_Dup)
+
+    def test_register_format_returns_class_for_decorator_use(self):
+        # @register_format must return the class so it can be used as a decorator.
+        class _Echo(Format):
+            name = '_echo_test'
+
+            @classmethod
+            def detect(cls, path):
+                return False
+
+        try:
+            assert register_format(_Echo) is _Echo
+        finally:
+            FORMATS.pop('_echo_test', None)
+
+    def test_format_base_methods_raise(self, tmp_path):
+        # Subclasses that don't override these should still get a clean
+        # NotImplementedError (not AttributeError).
+        class _Bare(Format):
+            name = '_bare_test'
+
+        with pytest.raises(NotImplementedError):
+            _Bare.detect(tmp_path)
+        with pytest.raises(NotImplementedError):
+            _Bare.open_reader(tmp_path)
+        with pytest.raises(NotImplementedError):
+            _Bare.open_writer(tmp_path)
+
+
+# ─── Detection ────────────────────────────────────────────────────────────────
+
+
+class TestDetect:
+    def test_hdf5_matches_h5_file(self, tmp_path):
+        # detect() is a path shape check, not a file existence check.
+        f = tmp_path / 'data.h5'
+        f.touch()
+        assert HDF5.detect(f) is True
+        assert HDF5.detect(tmp_path / 'whatever.hdf5') is True
+        assert HDF5.detect(tmp_path / 'whatever.txt') is False
+
+    def test_hdf5_matches_dir_with_h5(self, tmp_path):
+        (tmp_path / 'a.h5').touch()
+        assert HDF5.detect(tmp_path) is True
+
+    def test_hdf5_rejects_unrelated(self, tmp_path):
+        (tmp_path / 'data.txt').touch()
+        assert HDF5.detect(tmp_path / 'data.txt') is False
+
+    def test_folder_requires_ep_len(self, tmp_path):
+        assert Folder.detect(tmp_path) is False
+        (tmp_path / 'ep_len.npz').touch()
+        assert Folder.detect(tmp_path) is True
+
+    def test_folder_loses_to_video_when_mp4_present(self, tmp_path):
+        (tmp_path / 'ep_len.npz').touch()
+        sub = tmp_path / 'video'
+        sub.mkdir()
+        (sub / 'ep_0.mp4').touch()
+        assert Folder.detect(tmp_path) is False
+        assert Video.detect(tmp_path) is True
+
+    def test_video_rejects_dir_without_mp4(self, tmp_path):
+        (tmp_path / 'ep_len.npz').touch()
+        assert Video.detect(tmp_path) is False
+
+    def test_lerobot_matches_scheme(self):
+        assert LeRobot.detect('lerobot://lerobot/pusht') is True
+        assert LeRobot.detect('lerobot/pusht') is False
+        assert LeRobot.detect('/some/path') is False
+        assert LeRobot.detect(Path('/some/path')) is False
+
+    def test_detect_format_dispatches(self, tmp_path):
+        h5 = tmp_path / 'a.h5'
+        h5.touch()
+        assert detect_format(h5) is HDF5
+
+        folder = tmp_path / 'folder_ds'
+        folder.mkdir()
+        (folder / 'ep_len.npz').touch()
+        assert detect_format(folder) is Folder
+
+    def test_detect_format_returns_none_for_unknown(self, tmp_path):
+        unknown = tmp_path / 'nothing.bin'
+        unknown.touch()
+        assert detect_format(unknown) is None
+
+
+# ─── HDF5 writer ──────────────────────────────────────────────────────────────
+
+
+class TestHDF5Writer:
+    def test_roundtrip(self, tmp_path, two_episodes):
+        out = tmp_path / 'data.h5'
+        with HDF5Writer(out) as w:
+            for ep in two_episodes:
+                w.write_episode(ep)
+
+        ds = HDF5Dataset(path=out)
+        assert list(ds.lengths) == [5, 7]
+        assert list(ds.offsets) == [0, 5]
+        assert set(ds.column_names) == {'action', 'proprio', 'pixels'}
+
+        ep0 = ds.load_episode(0)
+        assert ep0['pixels'].shape == (5, 3, 8, 8)  # NCHW
+        assert ep0['proprio'].shape == (5, 4)
+
+    def test_open_writer_via_format(self, tmp_path, two_episodes):
+        out = tmp_path / 'data.h5'
+        with HDF5.open_writer(out) as w:
+            w.write_episode(two_episodes[0])
+        assert out.exists()
+        assert isinstance(HDF5.open_reader(out), HDF5Dataset)
+
+    def test_outside_with_block_raises(self, tmp_path, two_episodes):
+        w = HDF5Writer(tmp_path / 'data.h5')
+        with pytest.raises(RuntimeError, match='outside of a `with` block'):
+            w.write_episode(two_episodes[0])
+
+    def test_ep_offsets_are_cumulative(self, tmp_path, two_episodes):
+        out = tmp_path / 'data.h5'
+        with HDF5Writer(out) as w:
+            for ep in two_episodes:
+                w.write_episode(ep)
+        with h5py.File(out, 'r') as f:
+            assert list(f['ep_len'][:]) == [5, 7]
+            assert list(f['ep_offset'][:]) == [0, 5]
+            assert f['action'].shape[0] == 12
+
+    def test_per_step_shape_mismatch_raises(self, tmp_path):
+        # Schema is locked after the first episode — a column whose per-step
+        # shape changes in a later episode must fail loudly.
+        out = tmp_path / 'data.h5'
+        rng = np.random.default_rng(0)
+        ep_a = {
+            'action': [
+                rng.standard_normal(2).astype(np.float32) for _ in range(3)
+            ]
+        }
+        ep_b = {
+            'action': [
+                rng.standard_normal(7).astype(np.float32) for _ in range(3)
+            ]
+        }
+        with pytest.raises((ValueError, TypeError, OSError)):
+            with HDF5Writer(out) as w:
+                w.write_episode(ep_a)
+                w.write_episode(ep_b)
+
+
+class TestHDF5OpenReader:
+    def test_directory_with_single_h5(self, tmp_path, two_episodes):
+        sub = tmp_path / 'data_dir'
+        sub.mkdir()
+        with HDF5Writer(sub / 'data.h5') as w:
+            w.write_episode(two_episodes[0])
+        ds = HDF5.open_reader(sub)
+        assert isinstance(ds, HDF5Dataset)
+
+    def test_directory_with_no_h5_raises(self, tmp_path):
+        sub = tmp_path / 'empty_dir'
+        sub.mkdir()
+        with pytest.raises(FileNotFoundError, match='No .h5/.hdf5'):
+            HDF5.open_reader(sub)
+
+    def test_directory_with_multiple_h5_raises(self, tmp_path):
+        sub = tmp_path / 'ambiguous'
+        sub.mkdir()
+        (sub / 'a.h5').touch()
+        (sub / 'b.h5').touch()
+        with pytest.raises(ValueError, match='Ambiguous'):
+            HDF5.open_reader(sub)
+
+
+# ─── Folder writer ────────────────────────────────────────────────────────────
+
+
+class TestFolderWriter:
+    def test_roundtrip(self, tmp_path, two_episodes):
+        out = tmp_path / 'folder_ds'
+        with FolderWriter(out) as w:
+            for ep in two_episodes:
+                w.write_episode(ep)
+
+        # Layout assertions.
+        assert (out / 'ep_len.npz').exists()
+        assert (out / 'ep_offset.npz').exists()
+        assert (out / 'action.npz').exists()
+        assert (out / 'pixels').is_dir()
+        assert (out / 'pixels' / 'ep_0_step_0.jpeg').exists()
+        assert (out / 'pixels' / 'ep_1_step_6.jpeg').exists()
+
+        # Reader sees the same shape.
+        ds = FolderDataset(path=out, folder_keys=['pixels'])
+        assert list(ds.lengths) == [5, 7]
+        assert set(ds.column_names) == {'action', 'proprio', 'pixels'}
+
+        ep0 = ds.load_episode(0)
+        assert ep0['pixels'].shape == (5, 3, 8, 8)  # NCHW after reader permute
+        assert ep0['proprio'].shape == (5, 4)
+
+    def test_format_open_writer_and_reader(self, tmp_path, two_episodes):
+        out = tmp_path / 'fmt_folder'
+        with Folder.open_writer(out) as w:
+            for ep in two_episodes:
+                w.write_episode(ep)
+        ds = Folder.open_reader(out, folder_keys=['pixels'])
+        assert isinstance(ds, FolderDataset)
+        assert len(ds.lengths) == 2
+
+    def test_autodetects_folder_keys_from_subdirs(
+        self, tmp_path, two_episodes
+    ):
+        # Without folder_keys, FolderDataset should pick up subdirectories
+        # (image/video columns) automatically from the on-disk layout.
+        out = tmp_path / 'autodetect'
+        with FolderWriter(out) as w:
+            for ep in two_episodes:
+                w.write_episode(ep)
+        ds = FolderDataset(path=out)  # no folder_keys passed
+        assert ds.folder_keys == ['pixels']
+        ep0 = ds.load_episode(0)
+        assert ep0['pixels'].shape == (5, 3, 8, 8)
+
+    def test_explicit_empty_folder_keys_disables_subdir_loading(
+        self, tmp_path, two_episodes
+    ):
+        # Passing folder_keys=[] explicitly should NOT auto-detect — let the
+        # caller treat all subdirs as nonexistent.
+        out = tmp_path / 'no_folder_keys'
+        with FolderWriter(out) as w:
+            w.write_episode(two_episodes[0])
+        ds = FolderDataset(
+            path=out,
+            folder_keys=[],
+            keys_to_load=['action', 'proprio'],
+        )
+        assert ds.folder_keys == []
+        ep0 = ds.load_episode(0)
+        assert 'pixels' not in ep0
+
+
+# ─── Video writer ─────────────────────────────────────────────────────────────
+
+
+class TestVideoWriter:
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_imageio(self):
+        if importlib.util.find_spec('imageio') is None:
+            pytest.skip('imageio not available')
+
+    @staticmethod
+    def _video_episode(n_steps: int, hw: int = 32) -> dict:
+        rng = np.random.default_rng(0)
+        return {
+            'action': [
+                rng.standard_normal(2).astype(np.float32)
+                for _ in range(n_steps)
+            ],
+            'pixels': [
+                rng.integers(0, 255, size=(hw, hw, 3), dtype=np.uint8)
+                for _ in range(n_steps)
+            ],
+        }
+
+    def test_writes_expected_layout(self, tmp_path):
+        out = tmp_path / 'video_ds'
+        eps = [self._video_episode(8), self._video_episode(10)]
+        with VideoWriter(out, fps=25) as w:
+            for ep in eps:
+                w.write_episode(ep)
+
+        assert (out / 'ep_len.npz').exists()
+        assert (out / 'pixels' / 'ep_0.mp4').exists()
+        assert (out / 'pixels' / 'ep_1.mp4').exists()
+        assert (out / 'action.npz').exists()
+        np.testing.assert_array_equal(
+            np.load(out / 'ep_len.npz')['arr_0'], np.array([8, 10], np.int32)
+        )
+
+    def test_decord_roundtrip(self, tmp_path):
+        if importlib.util.find_spec('decord') is None:
+            pytest.skip('decord not available')
+
+        out = tmp_path / 'video_ds'
+        eps = [self._video_episode(8), self._video_episode(10)]
+        with VideoWriter(out, fps=25) as w:
+            for ep in eps:
+                w.write_episode(ep)
+
+        ds = VideoDataset(path=out, video_keys=['pixels'])
+        assert list(ds.lengths) == [8, 10]
+        ep0 = ds.load_episode(0)
+        assert ep0['pixels'].shape[0] == 8
+        assert ep0['pixels'].shape[1] == 3  # CHW after reader permute
+
+
+# ─── Convert ──────────────────────────────────────────────────────────────────
+
+
+class TestConvert:
+    def test_hdf5_to_folder(self, tmp_path, two_episodes):
+        # Seed source HDF5.
+        src = tmp_path / 'src.h5'
+        with HDF5Writer(src) as w:
+            for ep in two_episodes:
+                w.write_episode(ep)
+
+        dst = tmp_path / 'folder_ds'
+        convert(src, dst, dest_format='folder', progress=False)
+
+        assert (dst / 'ep_len.npz').exists()
+        assert (dst / 'pixels' / 'ep_0_step_0.jpeg').exists()
+
+        ds = FolderDataset(path=dst, folder_keys=['pixels'])
+        assert list(ds.lengths) == [5, 7]
+        assert set(ds.column_names) == {'action', 'proprio', 'pixels'}
+
+    def test_folder_to_hdf5(self, tmp_path, two_episodes):
+        src = tmp_path / 'folder_ds'
+        with FolderWriter(src) as w:
+            for ep in two_episodes:
+                w.write_episode(ep)
+
+        dst = tmp_path / 'out.h5'
+        convert(src, dst, dest_format='hdf5', progress=False)
+        ds = HDF5Dataset(path=dst)
+        assert list(ds.lengths) == [5, 7]
+
+    def test_tabular_only_dataset(self, tmp_path):
+        # No image columns — exercises the non-image branch of the
+        # episode-shape adapter inside `convert`.
+        rng = np.random.default_rng(0)
+        eps = [
+            {
+                'action': [
+                    rng.standard_normal(3).astype(np.float32) for _ in range(4)
+                ],
+                'reward': [
+                    rng.standard_normal(1).astype(np.float32) for _ in range(4)
+                ],
+            }
+            for _ in range(2)
+        ]
+        src = tmp_path / 'src.h5'
+        with HDF5Writer(src) as w:
+            for ep in eps:
+                w.write_episode(ep)
+
+        dst = tmp_path / 'dst.h5'
+        convert(src, dst, dest_format='hdf5', progress=False)
+
+        a = HDF5Dataset(path=src)
+        b = HDF5Dataset(path=dst)
+        assert list(a.lengths) == list(b.lengths)
+        np.testing.assert_array_equal(
+            a.get_col_data('action'), b.get_col_data('action')
+        )
+        np.testing.assert_array_equal(
+            a.get_col_data('reward'), b.get_col_data('reward')
+        )
+
+    def test_hdf5_to_hdf5_identity(self, tmp_path, two_episodes):
+        src = tmp_path / 'src.h5'
+        with HDF5Writer(src) as w:
+            for ep in two_episodes:
+                w.write_episode(ep)
+
+        dst = tmp_path / 'dst.h5'
+        convert(src, dst, dest_format='hdf5', progress=False)
+
+        a = HDF5Dataset(path=src)
+        b = HDF5Dataset(path=dst)
+        assert list(a.lengths) == list(b.lengths)
+        assert set(a.column_names) == set(b.column_names)
+
+        np.testing.assert_array_equal(
+            a.get_col_data('action'), b.get_col_data('action')
+        )
+        np.testing.assert_array_equal(
+            a.get_col_data('pixels'), b.get_col_data('pixels')
+        )
+
+
+# ─── load_dataset autodetect ──────────────────────────────────────────────────
+
+
+class TestLoadDatasetAutodetect:
+    def test_autodetects_hdf5(self, tmp_path, two_episodes):
+        out = tmp_path / 'datasets' / 'data.h5'
+        out.parent.mkdir()
+        with HDF5Writer(out) as w:
+            w.write_episode(two_episodes[0])
+        ds = swm.data.load_dataset(str(out), cache_dir=str(tmp_path))
+        assert isinstance(ds, HDF5Dataset)
+
+    def test_autodetects_folder(self, tmp_path, two_episodes):
+        out = tmp_path / 'datasets' / 'folder_ds'
+        out.parent.mkdir()
+        with FolderWriter(out) as w:
+            w.write_episode(two_episodes[0])
+        ds = swm.data.load_dataset(
+            str(out), cache_dir=str(tmp_path), folder_keys=['pixels']
+        )
+        assert isinstance(ds, FolderDataset)
+
+    def test_explicit_format_overrides_detection(self, tmp_path, two_episodes):
+        # Write a folder, but force-load it as folder explicitly.
+        out = tmp_path / 'datasets' / 'folder_ds'
+        out.parent.mkdir()
+        with FolderWriter(out) as w:
+            w.write_episode(two_episodes[0])
+        ds = swm.data.load_dataset(
+            str(out),
+            cache_dir=str(tmp_path),
+            format='folder',
+            folder_keys=['pixels'],
+        )
+        assert isinstance(ds, FolderDataset)
+
+    def test_unknown_format_raises(self, tmp_path):
+        unknown = tmp_path / 'datasets' / 'mystery.weird'
+        unknown.parent.mkdir()
+        unknown.touch()
+        with pytest.raises(ValueError, match='No format detected'):
+            swm.data.load_dataset(str(unknown), cache_dir=str(tmp_path))
+
+
+# ─── World.collect with non-default format ────────────────────────────────────
+
+
+class TestCollectFormat:
+    def test_collect_to_folder(self, tmp_path):
+        from stable_worldmodel import World
+        from stable_worldmodel.policy import RandomPolicy
+
+        world = World(
+            env_name='swm/PushT-v1',
+            num_envs=2,
+            image_shape=(32, 32),
+            max_episode_steps=10,
+        )
+        world.set_policy(RandomPolicy())
+
+        out = tmp_path / 'folder_collected'
+        world.collect(out, episodes=2, seed=0, format='folder')
+        world.envs.close()
+
+        assert (out / 'ep_len.npz').exists()
+        assert (out / 'pixels').is_dir()
+        # Reload via auto-detection.
+        ds = swm.data.load_dataset(
+            str(out), cache_dir=str(tmp_path), folder_keys=['pixels']
+        )
+        assert isinstance(ds, FolderDataset)
+        assert len(ds.lengths) == 2
+
+    def test_collect_unknown_format_raises(self, tmp_path):
+        from stable_worldmodel import World
+        from stable_worldmodel.policy import RandomPolicy
+
+        world = World(
+            env_name='swm/PushT-v1',
+            num_envs=1,
+            image_shape=(32, 32),
+            max_episode_steps=5,
+        )
+        world.set_policy(RandomPolicy())
+        try:
+            with pytest.raises(ValueError, match='unknown format'):
+                world.collect(tmp_path / 'x', episodes=1, format='nonexistent')
+        finally:
+            world.envs.close()


### PR DESCRIPTION
Data handling used to be HDF5-only with the writer hardcoded inside World.collect. This PR adds a small format registry (data/format.py) so recording, loading, and converting all go through the same interface — built-ins are hdf5, folder, video, and lerobot (read-only), and adding a new format means dropping one file under data/formats/ with a name, detect(), open_reader, and open_writer. 

Users now pick a format when recording (world.collect(path, format='folder')), autodetect on load (swm.data.load_dataset(path) sniffs the path; format= overrides), and convert across any registered pair via the new convert('data.h5', 'data_video/', dest_format='video'). 

Docs are rewritten to walk through each format and show how to register your own. All existing imports still work — data/__init__.py re-exports every reader/writer from its new home, so no call sites change.