### PR TITLE
Add stream writer support when collecting dataset

### DIFF
--- a/stable_worldmodel/data/format.py
+++ b/stable_worldmodel/data/format.py
@@ -14,6 +14,7 @@ Read-only formats simply omit `open_writer`; write-only formats omit
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Protocol, runtime_checkable
 
 
@@ -104,11 +105,22 @@ class Format:
 
 @runtime_checkable
 class Writer(Protocol):
-    """Streaming writer protocol — append episodes, close on exit."""
+    """Streaming writer protocol — append episodes, close on exit.
+
+    Two write paths are supported:
+
+    * :meth:`write_episode` — push one episode at a time.
+    * :meth:`write_episodes` — pull from a caller-provided iterable. Formats
+      that benefit from a single bulk write (e.g. Lance, where each
+      ``table.add`` produces a new dataset version) override this with a
+      streaming implementation; everyone else can fall back to looping over
+      :meth:`write_episode`.
+    """
 
     def __enter__(self) -> Writer: ...
     def __exit__(self, *exc) -> None: ...
     def write_episode(self, ep_data: dict) -> None: ...
+    def write_episodes(self, episodes: Iterable[dict]) -> None: ...
 
 
 __all__ = [

--- a/stable_worldmodel/data/formats/folder.py
+++ b/stable_worldmodel/data/formats/folder.py
@@ -227,6 +227,10 @@ class FolderWriter:
         self._global_ptr += ep_len
         self._ep_idx += 1
 
+    def write_episodes(self, episodes) -> None:
+        for ep in episodes:
+            self.write_episode(ep)
+
     def _clear_existing(self) -> None:
         import shutil
 

--- a/stable_worldmodel/data/formats/hdf5.py
+++ b/stable_worldmodel/data/formats/hdf5.py
@@ -197,6 +197,10 @@ class HDF5Writer:
         self._ep_written += 1
         self._global_ptr += ep_len
 
+    def write_episodes(self, episodes) -> None:
+        for ep in episodes:
+            self.write_episode(ep)
+
     def _load_existing_state(self) -> None:
         if 'ep_len' not in self._f or 'ep_offset' not in self._f:
             raise ValueError(

--- a/stable_worldmodel/data/formats/lance.py
+++ b/stable_worldmodel/data/formats/lance.py
@@ -508,7 +508,7 @@ class LanceDataset(Dataset):
 
 
 class LanceWriter:
-    """Append episodes to a Lance table, schema inferred from the first ep.
+    """Append episodes to a Lance table.
 
     Layout: ``<path>/<table>.lance/`` (LanceDB stores each table as a
     directory). When ``path`` ends in ``.lance``, the parent is the URI and
@@ -518,6 +518,15 @@ class LanceWriter:
     are JPEG-encoded into ``pa.binary``. Tabular columns become fixed-size
     lists of float32. Column names with ``.`` are renamed to ``_`` (Lance
     rejects dots in top-level field names).
+
+    Two write paths:
+      * :meth:`write_episode` — push one episode; one ``table.add`` per call,
+        one Lance version per call. Convenient for tests and one-off writes.
+      * :meth:`write_episodes` — pull from a caller-provided iterable and
+        stream it through a single ``pa.RecordBatchReader``. The whole
+        iterable lands as one Lance version (the iterator pattern from the
+        LanceDB docs). Memory stays bounded to one in-flight batch — the
+        right shape for large collection sessions like ``World.collect``.
     """
 
     def __init__(
@@ -583,26 +592,52 @@ class LanceWriter:
     def write_episode(self, ep_data: dict) -> None:
         if self._db is None:
             raise RuntimeError('LanceWriter used outside of a `with` block')
+        self._consume_episodes([ep_data])
+
+    def write_episodes(self, episodes) -> None:
+        if self._db is None:
+            raise RuntimeError('LanceWriter used outside of a `with` block')
+        self._consume_episodes(episodes)
+
+    def _consume_episodes(self, episodes) -> None:
+        """Drive a single ``create_table``/``table.add`` from an iterable.
+
+        The schema must be settled before we hand the reader to Lance, so we
+        peek the first episode here, run the standard schema-init / append-
+        validation hooks against it, then yield it as the first batch and
+        stream the remaining episodes through the same generator.
+        """
+        iterator = iter(episodes)
+        try:
+            first_ep = next(iterator)
+        except StopIteration:
+            return
 
         if not self._initialized:
-            self._init_schema(ep_data)
+            self._init_schema(first_ep)
             self._initialized = True
         elif self._appending_existing and not self._rename_map:
-            self._validate_episode_against_existing(ep_data)
+            self._validate_episode_against_existing(first_ep)
 
-        ep_len = len(next(iter(ep_data.values())))
-        batch = self._build_batch(ep_data, ep_len)
+        def batch_gen():
+            yield self._batch_from_episode(first_ep)
+            for ep in iterator:
+                yield self._batch_from_episode(ep)
 
-        table = pa.Table.from_batches([batch], schema=self._schema)
+        reader = pa.RecordBatchReader.from_batches(self._schema, batch_gen())
         if self._table is None:
             self._table = self._db.create_table(
-                self.table_name, data=table, schema=self._schema
+                self.table_name, data=reader, schema=self._schema
             )
         else:
-            self._table.add(table)
+            self._table.add(reader)
 
+    def _batch_from_episode(self, ep_data: dict) -> pa.RecordBatch:
+        ep_len = len(next(iter(ep_data.values())))
+        batch = self._build_batch(ep_data, ep_len)
         self._ep_idx += 1
         self._global_ptr += ep_len
+        return batch
 
     def _open_existing_for_append(self) -> None:
         self._table = self._db.open_table(self.table_name)

--- a/stable_worldmodel/data/formats/video.py
+++ b/stable_worldmodel/data/formats/video.py
@@ -178,6 +178,10 @@ class VideoWriter:
         self._global_ptr += ep_len
         self._ep_idx += 1
 
+    def write_episodes(self, episodes) -> None:
+        for ep in episodes:
+            self.write_episode(ep)
+
     def _clear_existing(self) -> None:
         import shutil
 

--- a/stable_worldmodel/data/utils.py
+++ b/stable_worldmodel/data/utils.py
@@ -272,12 +272,13 @@ def convert(
     if progress:
         iterator = tqdm(iterator, desc=f'Converting → {dest_format}')
 
-    with writer_cls.open_writer(dest, **dest_kwargs) as writer:
+    def episodes():
         for ep_idx in iterator:
             ep = src.load_episode(ep_idx)
-            writer.write_episode(
-                _episode_to_step_lists(ep, int(src.lengths[ep_idx]))
-            )
+            yield _episode_to_step_lists(ep, int(src.lengths[ep_idx]))
+
+    with writer_cls.open_writer(dest, **dest_kwargs) as writer:
+        writer.write_episodes(episodes())
 
 
 def _episode_to_step_lists(ep: dict, ep_len: int) -> dict[str, list]:

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -262,44 +262,45 @@ class World:
         writer_cls = get_format(format)
         buffers = [defaultdict(list) for _ in range(self.num_envs)]
 
-        with writer_cls.open_writer(path) as writer:
+        def on_step(world):
+            for col, data in world.infos.items():
+                if col.startswith('_'):
+                    continue
+                if not isinstance(data, (np.ndarray, torch.Tensor)):
+                    continue
+                if data.ndim > 1 and data.shape[1] == 1:
+                    if isinstance(data, torch.Tensor):
+                        data = data.squeeze(1)
+                    else:
+                        data = np.squeeze(data, axis=1)
+                for i in range(world.num_envs):
+                    val = data[i]
+                    if isinstance(val, torch.Tensor):
+                        val = val.detach().cpu().numpy()
+                    elif isinstance(val, np.ndarray):
+                        val = val.copy()
+                    buffers[i][col].append(val)
 
-            def on_step(world):
-                for col, data in world.infos.items():
-                    if col.startswith('_'):
-                        continue
-                    if not isinstance(data, (np.ndarray, torch.Tensor)):
-                        continue
-                    if data.ndim > 1 and data.shape[1] == 1:
-                        if isinstance(data, torch.Tensor):
-                            data = data.squeeze(1)
-                        else:
-                            data = np.squeeze(data, axis=1)
-                    for i in range(world.num_envs):
-                        val = data[i]
-                        if isinstance(val, torch.Tensor):
-                            val = val.detach().cpu().numpy()
-                        elif isinstance(val, np.ndarray):
-                            val = val.copy()
-                        buffers[i][col].append(val)
+        with writer_cls.open_writer(path) as writer, tqdm(
+            total=episodes, desc='Recording'
+        ) as pbar:
 
-            def on_done(env_idx, ep_idx, world):
-                ep = {k: list(v) for k, v in buffers[env_idx].items()}
-                buffers[env_idx].clear()
-                if 'action' in ep:
-                    ep['action'].append(ep['action'].pop(0))
-                writer.write_episode(ep)
-                pbar.update(1)
-
-            with tqdm(total=episodes, desc='Recording') as pbar:
-                self._run(
+            def episode_iter():
+                for env_idx, _ in self._run_iter(
                     episodes=episodes,
                     seed=seed,
                     options=options,
                     mode='auto',
                     on_step=on_step,
-                    on_done=on_done,
-                )
+                ):
+                    ep = {k: list(v) for k, v in buffers[env_idx].items()}
+                    buffers[env_idx].clear()
+                    if 'action' in ep:
+                        ep['action'].append(ep['action'].pop(0))
+                    pbar.update(1)
+                    yield ep
+
+            writer.write_episodes(episode_iter())
 
     def _run(
         self,
@@ -311,6 +312,32 @@ class World:
         on_step=None,
         on_done=None,
     ) -> None:
+        """Drive the policy. Thin wrapper around :meth:`_run_iter` that
+        invokes ``on_done(env_idx, ep_idx, world)`` for each completion."""
+        for env_idx, ep_count in self._run_iter(
+            episodes=episodes,
+            max_steps=max_steps,
+            seed=seed,
+            options=options,
+            mode=mode,
+            on_step=on_step,
+        ):
+            if on_done:
+                on_done(env_idx, ep_count, self)
+
+    def _run_iter(
+        self,
+        episodes: int | None = None,
+        max_steps: int | None = None,
+        seed: int | None = None,
+        options: dict | None = None,
+        mode: str = 'auto',
+        on_step=None,
+    ):
+        """Drive the policy and yield ``(env_idx, ep_count)`` on each
+        episode completion. Letting callers consume completions as a
+        generator is what makes streaming writes possible without threading.
+        """
         assert mode in RESET_MODES, f'reset_mode must be one of {RESET_MODES}'
 
         if self.policy is None:
@@ -341,8 +368,7 @@ class World:
                 continue
 
             for i in np.where(done)[0]:
-                if on_done:
-                    on_done(i, ep_count, self)
+                yield int(i), ep_count
                 ep_count += 1
                 if episodes is not None and ep_count >= episodes:
                     return

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -281,9 +281,10 @@ class World:
                         val = val.copy()
                     buffers[i][col].append(val)
 
-        with writer_cls.open_writer(path) as writer, tqdm(
-            total=episodes, desc='Recording'
-        ) as pbar:
+        with (
+            writer_cls.open_writer(path) as writer,
+            tqdm(total=episodes, desc='Recording') as pbar,
+        ):
 
             def episode_iter():
                 for env_idx, _ in self._run_iter(


### PR DESCRIPTION
creating one Lance version per episode could slow down large World.collect runs significantly. Reshape the writer around a pull API: write_episodes(iterable) drives a single db.create_table / table.add call against a pa.RecordBatchReader that yields each episode lazily as a pyarrow RecordBatch. one Lance version per writer session, with memory bounded to one in-flight batch.

Other writers (HDF5/folder/video) get a trivial loop fallback