### PR TITLE
Make SIGReg device-agnostic and multi-GPU correct

### DIFF
--- a/stable_worldmodel/wm/loss.py
+++ b/stable_worldmodel/wm/loss.py
@@ -4,38 +4,70 @@ from einops import einsum
 
 
 class SIGReg(torch.nn.Module):
-    """Sketch Isotropic Gaussian Regularizer.
+    """Sketch Isotropic Gaussian Regularizer (SIGReg).
 
-    Warning: This version only support single-gpu.
+    Device-agnostic, multi-GPU-capable adapter over the canonical LeJEPA
+    implementation shipped in ``stable_pretraining`` (already a dependency of
+    this package's ``train`` extra):
+    :class:`stable_pretraining.methods.lejepa.SlicedEppsPulley`.
+
+    Compared to the previous in-house implementation this version:
+
+    * runs on any device (CPU / CUDA / MPS) -- the random projection matrix is
+      drawn on the input's device rather than a hard-coded ``"cuda"``;
+    * supports distributed (DDP) training -- ``SlicedEppsPulley`` all-reduces the
+      per-direction Epps-Pulley statistic across ranks (``ReduceOp.AVG``), scales
+      by the global batch size, and seeds the random projections identically on
+      every rank, so the multi-GPU loss matches the single global-batch
+      statistic. It transparently falls back to single-process behaviour when
+      ``torch.distributed`` is not initialised.
+
+    Note:
+        Embeddings are pooled across all leading axes into ``(N, D)`` before the
+        sliced Epps-Pulley test, matching the reference LeJEPA application
+        (``all_projected.reshape(-1, D)``). The previous version instead computed
+        a separate statistic per time-step; pooling uses a larger effective
+        sample count, so the loss magnitude -- and therefore a good SIGReg
+        weight -- differs from the old single-GPU version.
+
+    Args:
+        knots: number of Epps-Pulley quadrature nodes (maps to ``n_points``);
+            must be odd.
+        num_proj: number of random 1-D projections (maps to ``num_slices``).
+
     Reference: https://arxiv.org/abs/2511.08544
     """
 
     def __init__(self, knots=17, num_proj=1024):
         super().__init__()
+        try:
+            from stable_pretraining.methods.lejepa import SlicedEppsPulley
+        except ImportError as exc:  # pragma: no cover - requires train extra
+            raise ImportError(
+                'SIGReg delegates to '
+                'stable_pretraining.methods.lejepa.SlicedEppsPulley, which '
+                'requires the optional training dependency. Install it with '
+                '`pip install "stable-worldmodel[train]"` '
+                '(or `pip install stable-pretraining`).'
+            ) from exc
+
         self.num_proj = num_proj
-        t = torch.linspace(0, 3, knots, dtype=torch.float32)
-        dt = 3 / (knots - 1)
-        weights = torch.full((knots,), 2 * dt, dtype=torch.float32)
-        weights[[0, -1]] = dt
-        window = torch.exp(-t.square() / 2.0)
-        self.register_buffer('t', t)
-        self.register_buffer('phi', window)
-        self.register_buffer('weights', weights * window)
+        # knots -> Epps-Pulley quadrature nodes; num_proj -> random slices.
+        self.sliced_ep = SlicedEppsPulley(num_slices=num_proj, n_points=knots)
 
     def forward(self, proj):
+        """Compute the SIGReg loss.
+
+        Args:
+            proj: embeddings of shape ``(..., D)`` (e.g. ``(T, B, D)``). All
+                leading axes are flattened into the sample axis; the statistic
+                is invariant to their order.
+
+        Returns:
+            Scalar tensor: the mean sliced Epps-Pulley statistic.
         """
-        proj: (T, B, D)
-        """
-        # sample random projections
-        A = torch.randn(proj.size(-1), self.num_proj, device='cuda')
-        A = A.div_(A.norm(p=2, dim=0))
-        # compute the epps-pulley statistic
-        x_t = (proj @ A).unsqueeze(-1) * self.t
-        err = (x_t.cos().mean(-3) - self.phi).square() + x_t.sin().mean(
-            -3
-        ).square()
-        statistic = (err @ self.weights) * proj.size(-2)
-        return statistic.mean()  # average over projections and time
+        proj = proj.reshape(-1, proj.size(-1))
+        return self.sliced_ep(proj)
 
 
 class VCReg(torch.nn.Module):

--- a/tests/wm/test_loss.py
+++ b/tests/wm/test_loss.py
@@ -1,0 +1,114 @@
+"""Tests for stable_worldmodel.wm.loss.SIGReg.
+
+SIGReg is a thin, device-agnostic, multi-GPU-capable adapter over
+``stable_pretraining.methods.lejepa.SlicedEppsPulley`` (the canonical LeJEPA
+SIGReg, arXiv:2511.08544). The distributed correctness of the underlying
+statistic is covered by stable_pretraining's own DDP tests; here we only test
+the adapter contract:
+
+* it constructs and runs on CPU (no hard-coded ``"cuda"`` device);
+* it faithfully delegates to ``SlicedEppsPulley`` with the documented kwarg
+  mapping (``knots -> n_points``, ``num_proj -> num_slices``);
+* it pools all leading axes into the sample axis and returns a finite scalar
+  through which gradients flow.
+
+Determinism note: ``SlicedEppsPulley`` seeds its random projection from an
+internal ``global_step`` buffer (initialised to 0), not the global torch RNG,
+so two freshly constructed modules draw the *same* first projection and can be
+compared directly.
+
+The adapter requires the optional ``train`` dependency (stable_pretraining);
+these tests skip when it is not installed (CI installs it via
+``uv sync --all-extras``).
+"""
+
+import pytest
+import torch
+
+
+# SIGReg's forward path delegates to stable_pretraining; skip cleanly when the
+# optional training dependency is absent.
+spt_lejepa = pytest.importorskip('stable_pretraining.methods.lejepa')
+
+from stable_worldmodel.wm.loss import SIGReg  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# device-agnostic: runs on CPU (the old version hard-coded device="cuda")
+# ---------------------------------------------------------------------------
+
+
+def test_sigreg_runs_on_cpu():
+    reg = SIGReg(knots=17, num_proj=64)
+    proj = torch.randn(4, 8, 16)  # (T, B, D) on CPU
+
+    out = reg(proj)
+
+    assert out.shape == ()  # scalar
+    assert torch.isfinite(out)
+    assert out.device.type == 'cpu'
+
+
+def test_sigreg_gradient_flows():
+    reg = SIGReg(knots=17, num_proj=64)
+    proj = torch.randn(4, 8, 16, requires_grad=True)
+
+    reg(proj).backward()
+
+    assert proj.grad is not None
+    assert torch.isfinite(proj.grad).all()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason='MPS device not available'
+)
+def test_sigreg_runs_on_mps():
+    reg = SIGReg(knots=17, num_proj=64).to('mps')
+    proj = torch.randn(4, 8, 16, device='mps')
+
+    out = reg(proj)
+
+    assert torch.isfinite(out)
+    assert out.device.type == 'mps'
+
+
+# ---------------------------------------------------------------------------
+# faithful delegation + kwarg mapping
+# ---------------------------------------------------------------------------
+
+
+def test_sigreg_kwarg_mapping():
+    reg = SIGReg(knots=9, num_proj=32)
+
+    assert isinstance(reg.sliced_ep, spt_lejepa.SlicedEppsPulley)
+    assert reg.sliced_ep.num_slices == 32  # num_proj -> num_slices
+    # knots -> n_points (Epps-Pulley quadrature nodes); the 'phi' buffer has
+    # length n_points.
+    assert reg.sliced_ep.ep.phi.numel() == 9
+
+
+def test_sigreg_matches_sliced_epps_pulley():
+    """SIGReg(proj) == SlicedEppsPulley(proj.reshape(-1, D)).
+
+    Both modules are freshly constructed, so both draw the same first
+    projection (global_step == 0).
+    """
+    proj = torch.randn(4, 8, 16)
+
+    out_adapter = SIGReg(knots=17, num_proj=64)(proj)
+    out_direct = spt_lejepa.SlicedEppsPulley(num_slices=64, n_points=17)(
+        proj.reshape(-1, proj.size(-1))
+    )
+
+    torch.testing.assert_close(out_adapter, out_direct)
+
+
+def test_sigreg_pools_leading_axes():
+    """Flattening (T, B, D) -> (T*B, D) feeds N=T*B samples to the EP test, so
+    a pre-reshaped input yields the same statistic."""
+    proj = torch.randn(4, 8, 16)
+
+    flat = SIGReg(knots=17, num_proj=64)(proj)
+    explicit = SIGReg(knots=17, num_proj=64)(proj.reshape(-1, 16))
+
+    torch.testing.assert_close(flat, explicit)


### PR DESCRIPTION
## Summary

`SIGReg` allocated its random projection matrix on a hard-coded `cuda` device and computed the Epps-Pulley statistic on each replica's local batch. This restricted it to a single CUDA device and made the regulariser inconsistent under multi-GPU training. This change delegates to the canonical LeJEPA implementation in `stable_pretraining`, which is already pinned by the `train` extra (`stable-pretraining>=0.1.7`), and adds tests.

## Problems

1. **Device.** `loss.py` allocated `A = torch.randn(..., device='cuda')`. This fails on CPU and MPS, and on a multi-process launch it binds to the default CUDA device rather than the rank's device. The rest of the codebase already allocates with `device=x.device`.

2. **Multi-GPU.** The Epps-Pulley statistic squares an empirical mean taken over the batch axis. Evaluating it on a local batch of size `b` and letting DDP average the gradients is not equivalent to evaluating it on the global batch of size `world_size * b`. The variance contribution to the squared mean is of order `1/b` instead of `1/(world_size * b)`, and the sample-count prefactor is local rather than global, so the effective regularisation strength depends on the number of GPUs. The previous docstring already noted that the implementation was single-GPU only.

## Change

`SIGReg` now wraps `stable_pretraining.methods.lejepa.SlicedEppsPulley`, which:

- draws the projection on the input's device (CPU, CUDA or MPS);
- all-reduces the per-direction cos/sin means across ranks with `ReduceOp.AVG` and scales by the global batch size, so the multi-GPU loss matches the single global-batch statistic (for equal per-rank batch sizes);
- seeds the projection identically on every rank through a synchronised step counter, so all ranks sketch the same directions;
- falls back to single-process behaviour when `torch.distributed` is not initialised.

The `SIGReg(knots, num_proj)` signature is preserved (`knots` maps to `n_points`, `num_proj` to `num_slices`), so `loss.sigreg.kwargs` and the training scripts are unchanged. The `stable_pretraining` import is local to the constructor, so `stable_worldmodel.wm.loss` still imports without the `train` extra and a missing dependency raises an actionable error.

## Behaviour change: retune `loss.sigreg.weight`

Embeddings are now pooled across all leading axes into `(N, D)` before the test, matching the reference LeJEPA application (`all_projected.reshape(-1, D)`). The previous code computed a separate statistic per time step. Pooling raises the effective sample count from the per-step batch to its product with the sequence length, which scales the magnitude of `sigreg_loss` by approximately that factor. With the defaults in `config/lewm.yaml` (`batch_size: 128`, `history_size: 3`, `num_preds: 1`, a length-4 sequence) the term grows by about 4x, so `loss.sigreg.weight` should be retuned. Dividing the current `0.09` by the sequence length is a reasonable starting point ahead of a sweep.

## Tests

`tests/wm/test_loss.py` covers device placement (CPU, and MPS when available), gradient flow, the `knots`/`num_proj` to `n_points`/`num_slices` mapping, and equivalence with calling `SlicedEppsPulley` directly on the reshaped input. The tests skip when the `train` extra is absent; CI installs it through `uv sync --all-extras`.
