### PR TITLE
Fix SIGReg hardcoded device='cuda'

### DIFF
--- a/stable_worldmodel/wm/loss.py
+++ b/stable_worldmodel/wm/loss.py
@@ -27,7 +27,7 @@ class SIGReg(torch.nn.Module):
         proj: (T, B, D)
         """
         # sample random projections
-        A = torch.randn(proj.size(-1), self.num_proj, device='cuda')
+        A = torch.randn(proj.size(-1), self.num_proj, device=proj.device)
         A = A.div_(A.norm(p=2, dim=0))
         # compute the epps-pulley statistic
         x_t = (proj @ A).unsqueeze(-1) * self.t


### PR DESCRIPTION
## Summary

`SIGReg.forward()` hardcodes `device='cuda'` when sampling random projections, causing a crash on CPU and any non-CUDA device.

## Change

```python
# before
A = torch.randn(proj.size(-1), self.num_proj, device='cuda')
# after
A = torch.randn(proj.size(-1), self.num_proj, device=proj.device)
```

Found this while setting up the LeWM training pipeline for OpenApps web screen data locally.