### PR TITLE
Fix hardcoded history_size in LeWM/PLDM rollout

### DIFF
--- a/stable_worldmodel/wm/lewm/lewm.py
+++ b/stable_worldmodel/wm/lewm/lewm.py
@@ -55,15 +55,21 @@ class LeWM(nn.Module):
     ## Inference only ##
     ####################
 
-    def rollout(self, info, action_sequence, history_size: int = 3):
+    def rollout(self, info, action_sequence, history_size: int | None = None):
         """Rollout the model given an initial info dict and action sequence.
         pixels: (B, S, T, C, H, W)
         action_sequence: (B, S, T, action_dim)
          - S is the number of action plan samples
          - T is the time horizon
+
+        history_size: context window the autoregressive predictor consumes.
+            Defaults to ``self.predictor.num_frames`` so inference matches the
+            value the checkpoint was trained with.
         """
 
         assert 'pixels' in info, 'pixels not in info_dict'
+        if history_size is None:
+            history_size = self.predictor.num_frames
         H = info['pixels'].size(2)
         B, S, T = action_sequence.shape[:3]
         act_0, act_future = torch.split(action_sequence, [H, T - H], dim=2)

--- a/stable_worldmodel/wm/pldm/pldm.py
+++ b/stable_worldmodel/wm/pldm/pldm.py
@@ -58,15 +58,21 @@ class PLDM(nn.Module):
     ## Inference only ##
     ####################
 
-    def rollout(self, info, action_sequence, history_size: int = 3):
+    def rollout(self, info, action_sequence, history_size: int | None = None):
         """Rollout the model given an initial info dict and action sequence.
         pixels: (B, S, T, C, H, W)
         action_sequence: (B, S, T, action_dim)
          - S is the number of action plan samples
          - T is the time horizon
+
+        history_size: context window the autoregressive predictor consumes.
+            Defaults to ``self.predictor.num_frames`` so inference matches the
+            value the checkpoint was trained with.
         """
 
         assert 'pixels' in info, 'pixels not in info_dict'
+        if history_size is None:
+            history_size = self.predictor.num_frames
         H = info['pixels'].size(2)
         B, S, T = action_sequence.shape[:3]
         act_0, act_future = torch.split(action_sequence, [H, T - H], dim=2)

--- a/tests/wm/test_rollout_history_size.py
+++ b/tests/wm/test_rollout_history_size.py
@@ -1,0 +1,107 @@
+"""Regression tests for issue #225: rollout() must respect predictor.num_frames
+instead of a hardcoded history_size default.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from stable_worldmodel.wm.lewm.lewm import LeWM
+from stable_worldmodel.wm.pldm.pldm import PLDM
+
+
+class _FakeEncoderOutput:
+    def __init__(self, last_hidden_state):
+        self.last_hidden_state = last_hidden_state
+
+
+class FakeEncoder(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+        self.dummy = nn.Parameter(torch.zeros(1))
+
+    def forward(self, pixels, interpolate_pos_encoding=False):
+        bt = pixels.shape[0]
+        return _FakeEncoderOutput(
+            torch.zeros(bt, 1, self.dim, dtype=self.dummy.dtype)
+        )
+
+
+class SpyPredictor(nn.Module):
+    """Predictor stand-in that records the time-dim of every forward call."""
+
+    def __init__(self, num_frames, dim):
+        super().__init__()
+        self.num_frames = num_frames
+        self.dim = dim
+        self.window_sizes: list[int] = []
+
+    def forward(self, emb, act_emb):
+        self.window_sizes.append(emb.shape[1])
+        return emb.clone()
+
+
+class LinearActionEncoder(nn.Module):
+    def __init__(self, action_dim, emb_dim):
+        super().__init__()
+        self.lin = nn.Linear(action_dim, emb_dim)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+def _build(cls, num_frames, dim=8, action_dim=2):
+    model = cls(
+        encoder=FakeEncoder(dim),
+        predictor=SpyPredictor(num_frames=num_frames, dim=dim),
+        action_encoder=LinearActionEncoder(action_dim, dim),
+    )
+    model.eval()
+    return model
+
+
+def _make_inputs(num_frames, action_dim=2, future_steps=2):
+    B, S = 1, 1
+    T_hist = num_frames
+    T_total = T_hist + future_steps
+    info = {'pixels': torch.zeros(B, S, T_hist, 3, 4, 4)}
+    actions = torch.zeros(B, S, T_total, action_dim)
+    return info, actions
+
+
+@pytest.mark.parametrize('cls', [LeWM, PLDM])
+def test_rollout_respects_predictor_num_frames(cls):
+    """Without explicit history_size, rollout must use predictor.num_frames."""
+    num_frames = 5
+    model = _build(cls, num_frames=num_frames)
+    info, actions = _make_inputs(num_frames=num_frames)
+
+    with torch.no_grad():
+        model.rollout(info, actions)
+
+    windows = model.predictor.window_sizes
+    assert windows, 'predict() was never called'
+    assert all(w == num_frames for w in windows), (
+        f'rollout used the wrong context window. saw {windows}, '
+        f'expected all == predictor.num_frames ({num_frames}).'
+    )
+
+
+@pytest.mark.parametrize('cls', [LeWM, PLDM])
+def test_rollout_explicit_history_size_overrides(cls):
+    """Explicit history_size= still wins over predictor.num_frames (back-compat)."""
+    num_frames = 5
+    override = 2
+    model = _build(cls, num_frames=num_frames)
+    info, actions = _make_inputs(num_frames=num_frames)
+
+    with torch.no_grad():
+        model.rollout(info, actions, history_size=override)
+
+    windows = model.predictor.window_sizes
+    assert windows, 'predict() was never called'
+    assert all(w == override for w in windows), (
+        f'explicit history_size override was ignored. saw {windows}, '
+        f'expected all == {override}.'
+    )


### PR DESCRIPTION
Closes #225.

## Bug

`LeWM.rollout()` and `PLDM.rollout()` defaulted `history_size=3`; `get_cost()` never passes the kwarg, so inference always used a 3-frame context regardless of `predictor.num_frames`. Default training configs set `predictor.num_frames = wm.history_size`, so default-config users coincidentally hit no bug — but any user training with `wm.history_size != 3` silently runs eval on the wrong (OOD) window.

## Fix

Default `history_size` to `self.predictor.num_frames`:

- The predictor's `pos_embedding` is sized exactly to `num_frames`, so it is the hard upper bound the predictor can accept.
- It is the context length the checkpoint was trained against — any smaller default puts inference into an OOD regime that was never seen at train time.

Explicit `history_size=N` callers are unchanged (still useful for ablations or when initial pixels history is shorter than `num_frames`).

## Validation

### Unit test (`tests/wm/test_rollout_history_size.py`)

Parametrized over `LeWM` / `PLDM`. With a spy predictor where `num_frames=5`, `rollout()` is called without an explicit `history_size`.

- On `main`: windows seen by `predict()` are `[3, 3, 3]` — bug confirmed.
- After fix: `[5, 5, 5]`.
- Back-compat: explicit `history_size=2` override is still honored.

### End-to-end (PushT, single H100)

Trained one LeWM checkpoint with `wm.history_size=5` for 84 epochs on 3000 PushT expert episodes (final `validate/pred_loss = 0.0089`). Evaluated the **same checkpoint** on the same 50 starting indices with `seed=42`, `bf16=true`:

| Branch | Rollout `history_size` | Success rate |
|---|---|---|
| `main` (bug) | hardcoded 3 | 21/50 = **42.0%** |
| this PR | `predictor.num_frames` (5) | 29/50 = **58.0%** |

+16 percentage points absolute, +38% relative. Same checkpoint, same seed, same starting indices — only the rollout code path differs.