### PR TITLE
fix: use predictor.num_frames as default history_size in rollout()

### DIFF
--- a/stable_worldmodel/wm/lewm/lewm.py
+++ b/stable_worldmodel/wm/lewm/lewm.py
@@ -55,13 +55,15 @@ class LeWM(nn.Module):
     ## Inference only ##
     ####################
 
-    def rollout(self, info, action_sequence, history_size: int = 3):
+    def rollout(self, info, action_sequence, history_size: int = None):
         """Rollout the model given an initial info dict and action sequence.
         pixels: (B, S, T, C, H, W)
         action_sequence: (B, S, T, action_dim)
          - S is the number of action plan samples
          - T is the time horizon
         """
+        if history_size is None:
+            history_size = getattr(self.predictor, 'num_frames', 3)
 
         assert 'pixels' in info, 'pixels not in info_dict'
         H = info['pixels'].size(2)

--- a/stable_worldmodel/wm/pldm/pldm.py
+++ b/stable_worldmodel/wm/pldm/pldm.py
@@ -58,13 +58,15 @@ class PLDM(nn.Module):
     ## Inference only ##
     ####################
 
-    def rollout(self, info, action_sequence, history_size: int = 3):
+    def rollout(self, info, action_sequence, history_size: int = None):
         """Rollout the model given an initial info dict and action sequence.
         pixels: (B, S, T, C, H, W)
         action_sequence: (B, S, T, action_dim)
          - S is the number of action plan samples
          - T is the time horizon
         """
+        if history_size is None:
+            history_size = getattr(self.predictor, 'num_frames', 3)
 
         assert 'pixels' in info, 'pixels not in info_dict'
         H = info['pixels'].size(2)


### PR DESCRIPTION
## Summary

Fixes the bug where `rollout()` in both `LeWM` and `PLDM` used a hardcoded `history_size=3`, ignoring the `num_frames` value the model was actually trained with.

**Root cause:** `get_cost()` calls `self.rollout(info_dict, action_candidates)` without passing `history_size`, so it always falls back to the default of `3`. If the checkpoint was trained with a different `predictor.num_frames`, inference silently uses the wrong context window.

**Fix:** Change the default from `3` to `None`, then resolve it from `self.predictor.num_frames` at call time (with a fallback to `3` for predictors that don't expose `num_frames`).

Files changed:
- `stable_worldmodel/wm/lewm/lewm.py`
- `stable_worldmodel/wm/pldm/pldm.py`

Fixes #225

## Test plan

- [ ] Verify that a checkpoint trained with `num_frames=5` uses `history_size=5` during `get_cost()` rollout
- [ ] Verify backward compatibility: callers passing an explicit `history_size` value still work correctly
- [ ] Verify fallback to `3` when predictor has no `num_frames` attribute