### PR TITLE
Add string-column support to Lance writer

### DIFF
--- a/stable_worldmodel/data/formats/lance.py
+++ b/stable_worldmodel/data/formats/lance.py
@@ -579,9 +579,10 @@ class LanceWriter:
     the stem is the table name; otherwise ``table_name`` must be supplied.
 
     Image columns (``pixels`` / ``pixels_<view>``, or any uint8 HxWxC array)
-    are JPEG-encoded into ``pa.binary``. Tabular columns become fixed-size
-    lists of float32. Column names with ``.`` are renamed to ``_`` (Lance
-    rejects dots in top-level field names).
+    are JPEG-encoded into ``pa.binary``. String columns become ``pa.string``.
+    Other tabular columns become fixed-size lists of float32. Column names
+    with ``.`` are renamed to ``_`` (Lance rejects dots in top-level field
+    names).
 
     Two write paths:
       * :meth:`write_episode` — push one episode; one ``table.add`` per call,
@@ -629,6 +630,7 @@ class LanceWriter:
         self._appending_existing = False
         self._rename_map: dict[str, str] = {}
         self._image_cols: set[str] = set()
+        self._string_cols: set[str] = set()
         self._dims: dict[str, int] = {}
         self._schema: pa.Schema | None = None
         self._ep_idx = 0
@@ -707,12 +709,17 @@ class LanceWriter:
         self._table = self._db.open_table(self.table_name)
         schema = self._table.schema
         image_cols: set[str] = set()
+        string_cols: set[str] = set()
         dims: dict[str, int] = {}
         for f in schema:
             if f.name in ('episode_idx', 'step_idx'):
                 continue
             if pa.types.is_binary(f.type) or pa.types.is_large_binary(f.type):
                 image_cols.add(f.name)
+            elif pa.types.is_string(f.type) or pa.types.is_large_string(
+                f.type
+            ):
+                string_cols.add(f.name)
             elif pa.types.is_fixed_size_list(f.type):
                 dims[f.name] = f.type.list_size
             else:
@@ -725,6 +732,7 @@ class LanceWriter:
         existing = self._table.to_lance().to_table(columns=['episode_idx'])
         ep_col = existing.column('episode_idx').to_numpy()
         self._image_cols = image_cols
+        self._string_cols = string_cols
         self._dims = dims
         self._schema = schema
         self._global_ptr = int(len(ep_col))
@@ -735,9 +743,12 @@ class LanceWriter:
     def _validate_episode_against_existing(self, ep_data: dict) -> None:
         reserved = {'episode_idx', 'step_idx'}
         incoming_to_lance: dict[str, str] = {}
-        for col in ep_data:
+        for col, vals in ep_data.items():
             lance_name = _to_lance_name(col)
             if lance_name in reserved:
+                continue
+            is_image = _is_image_name(lance_name) or is_image_column(vals)
+            if not is_image and np.asarray(vals[0]).dtype.kind not in 'biufUS':
                 continue
             if lance_name in incoming_to_lance.values():
                 raise ValueError(
@@ -747,7 +758,9 @@ class LanceWriter:
             incoming_to_lance[col] = lance_name
         lance_to_incoming = {v: k for k, v in incoming_to_lance.items()}
 
-        expected = set(self._image_cols) | set(self._dims)
+        expected = (
+            set(self._image_cols) | set(self._string_cols) | set(self._dims)
+        )
         incoming = set(lance_to_incoming)
         missing = expected - incoming
         extra = incoming - expected
@@ -789,6 +802,7 @@ class LanceWriter:
     def _init_schema(self, sample_ep: dict) -> None:
         rename_map: dict[str, str] = {}
         image_cols: set[str] = set()
+        string_cols: set[str] = set()
         dims: dict[str, int] = {}
         ordered_cols: list[str] = []
 
@@ -801,19 +815,37 @@ class LanceWriter:
                 dropped,
             )
 
+        dropped_non_numeric: list[str] = []
         for col, vals in sample_ep.items():
             lance_name = _to_lance_name(col)
             if lance_name in reserved:
                 continue
+
+            is_image = _is_image_name(lance_name) or is_image_column(vals)
+            is_string = False
+            if not is_image:
+                sample = np.asarray(vals[0])
+                if sample.dtype.kind in 'US':
+                    is_string = True
+                elif sample.dtype.kind not in 'biuf':
+                    dropped_non_numeric.append(col)
+                    continue
+
             rename_map[col] = lance_name
             ordered_cols.append(lance_name)
-
-            if _is_image_name(lance_name) or is_image_column(vals):
+            if is_image:
                 image_cols.add(lance_name)
-                continue
+            elif is_string:
+                string_cols.add(lance_name)
+            else:
+                dims[lance_name] = int(sample.reshape(-1).shape[0])
 
-            sample = np.asarray(vals[0])
-            dims[lance_name] = int(sample.reshape(-1).shape[0])
+        if dropped_non_numeric:
+            logging.warning(
+                'LanceWriter: dropping non-numeric columns %s — values are '
+                'not convertible to float32.',
+                dropped_non_numeric,
+            )
 
         renamed = {k: v for k, v in rename_map.items() if k != v}
         if renamed:
@@ -829,11 +861,14 @@ class LanceWriter:
         for col in ordered_cols:
             if col in image_cols:
                 fields.append(pa.field(col, pa.binary()))
+            elif col in string_cols:
+                fields.append(pa.field(col, pa.string()))
             else:
                 fields.append(pa.field(col, pa.list_(pa.float32(), dims[col])))
 
         self._rename_map = rename_map
         self._image_cols = image_cols
+        self._string_cols = string_cols
         self._dims = dims
         self._schema = pa.schema(fields)
 
@@ -853,6 +888,12 @@ class LanceWriter:
                     for v in vals
                 ]
                 arrays.append(pa.array(blobs, type=pa.binary()))
+            elif lance_name in self._string_cols:
+                strs = [
+                    v.decode() if isinstance(v, (bytes, bytearray)) else str(v)
+                    for v in vals
+                ]
+                arrays.append(pa.array(strs, type=pa.string()))
             else:
                 dim = self._dims[lance_name]
                 flat = np.asarray(vals, dtype=np.float32).reshape(ep_len, dim)

--- a/tests/data/test_lance.py
+++ b/tests/data/test_lance.py
@@ -91,6 +91,56 @@ def test_image_column_autodetected(tmp_path):
     assert ds.image_columns == {'pixels'}
 
 
+def test_string_column_roundtrip(tmp_path):
+    """A per-episode-constant string column survives a write/read round-trip."""
+    rng = np.random.default_rng(0)
+    out = tmp_path / 'lang.lance'
+    tasks = ['pick up the cube', 'open the drawer']
+    with LanceWriter(out) as w:
+        for ep_idx, ep_len in enumerate((4, 3)):
+            w.write_episode(
+                {
+                    'action': [
+                        rng.standard_normal(2).astype(np.float32)
+                        for _ in range(ep_len)
+                    ],
+                    'task': [tasks[ep_idx]] * ep_len,
+                }
+            )
+
+    ds = LanceDataset(path=out)
+    assert 'task' in ds.column_names
+    assert ds.image_columns == set()
+    assert ds[0]['task'] == tasks[0]
+    # offsets[1] == 4 -> first row of the second episode
+    assert ds[4]['task'] == tasks[1]
+
+
+def test_string_column_append(tmp_path):
+    """A string column can be appended to an existing table with the same schema."""
+    rng = np.random.default_rng(0)
+    out = tmp_path / 'lang.lance'
+
+    def _ep(ep_len, task):
+        return {
+            'action': [
+                rng.standard_normal(2).astype(np.float32)
+                for _ in range(ep_len)
+            ],
+            'task': [task] * ep_len,
+        }
+
+    with LanceWriter(out) as w:
+        w.write_episode(_ep(4, 'first'))
+    with LanceWriter(out) as w:  # mode='append' default
+        w.write_episode(_ep(3, 'second'))
+
+    ds = LanceDataset(path=out)
+    assert ds.lengths.tolist() == [4, 3]
+    assert ds[0]['task'] == 'first'
+    assert ds[4]['task'] == 'second'
+
+
 def test_dot_rename(tmp_path):
     """HDF5-style dotted column names are renamed to underscores transparently."""
     rng = np.random.default_rng(0)


### PR DESCRIPTION
## What

`LanceDataset` (reader) already decodes `pa.string` columns, but `LanceWriter` silently dropped every non-numeric column — so a string field (e.g. a task name / language instruction) could never round-trip. This teaches the writer to store string columns as `pa.string`.

## Semantics

Per-episode **constant** strings. The reader collapses a slice to its first value (existing behavior at `lance.py:_process_batch`), which is exactly right for a field that's constant across an episode. Per-step strings are out of scope.

## Changes (`stable_worldmodel/data/formats/lance.py`)

- `_init_schema`: detect string samples (`dtype.kind in 'US'`) and emit a `pa.string` field instead of routing them to `dropped_non_numeric`.
- `_build_batch`: encode string columns into a `pa.string` array.
- `_open_existing_for_append` / `_validate_episode_against_existing`: accept string-typed columns on the append path.

No reader changes needed — string decoding already exists in `main`.

## Tests (`tests/data/test_lance.py`)

- `test_string_column_roundtrip` — write two episodes with a `task` string column, read it back per episode.
- `test_string_column_append` — append a second episode with a string column to an existing table.

Full `tests/data/test_lance.py` suite: **19 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)