### PR TITLE
Update cheetah agent default color init value

### DIFF
--- a/stable_worldmodel/envs/dmcontrol/cheetah.py
+++ b/stable_worldmodel/envs/dmcontrol/cheetah.py
@@ -76,7 +76,7 @@ class CheetahDMControlWrapper(DMControlWrapper):
                             shape=(3,),
                             dtype=np.float64,
                             init_value=np.array(
-                                [0.6, 0.3, 0.3], dtype=np.float64
+                                [0.7, 0.5, 0.3], dtype=np.float64
                             ),
                         ),
                         'torso_density': swm_space.Box(


### PR DESCRIPTION
Changes the default `init_value` of the cheetah agent `color` variation from `[0.6, 0.3, 0.3]` to `[0.7, 0.5, 0.3]` in `CheetahDMControlWrapper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)