### PR TITLE
Use headless opencv and fix prejepa CausalPredictor target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ env = [
     "minigrid",
     "gymnasium[all]",
     "gymnasium-robotics",
-    "opencv-python",
+    "opencv-python-headless",
     "stable_baselines3>=2.0.0",
     "craftax>=1.5.0",
     "ale-py",

--- a/scripts/train/config/prejepa.yaml
+++ b/scripts/train/config/prejepa.yaml
@@ -57,7 +57,7 @@ model:
     _target_: stable_worldmodel.wm.prejepa.module.create_backbone
     name: ${backbone.name}
   predictor:
-    _target_: stable_worldmodel.wm.prejepa.CausalPredictor
+    _target_: stable_worldmodel.wm.prejepa.module.CausalPredictor
     num_patches: ???
     num_frames: ${wm.history_size}
     dim: ???


### PR DESCRIPTION
Two small fixes:

- **`pyproject.toml`**: switch the `env` extra dependency from `opencv-python` to `opencv-python-headless` (no GUI/system libs required for offscreen rendering).
- **`scripts/train/config/prejepa.yaml`**: fix the predictor `_target_` to the fully-qualified `stable_worldmodel.wm.prejepa.module.CausalPredictor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)