### PR TITLE
fix: broadcast LeWM goal across candidates

### DIFF
--- a/stable_worldmodel/wm/lewm/lewm.py
+++ b/stable_worldmodel/wm/lewm/lewm.py
@@ -110,9 +110,9 @@ class LeWM(nn.Module):
     def criterion(self, info_dict: dict):
         """Compute the cost between predicted embeddings and goal embeddings."""
         pred_emb = info_dict['predicted_emb']  # (B,S, T-1, dim)
-        goal_emb = info_dict['goal_emb']  # (B, S, T, dim)
+        goal_emb = info_dict['goal_emb']  # (B, T, dim)
 
-        goal_emb = goal_emb[..., -1:, :].expand_as(pred_emb)
+        goal_emb = goal_emb[:, None, -1:, :].expand_as(pred_emb)
 
         # return last-step cost per action candidate
         cost = F.mse_loss(


### PR DESCRIPTION
Evaluating LeWM with batch_size > 1 gives me a dimension mismatch error.

Before: goal_emb[..., -1:, :] has shape (B, 1, dim), then expand_as left pads into (1, B, 1, dim). For B > 1, this can't be broadcasted into (B, S, T, dim). 

After: goal_emb[:, None, -1:, :] has shape (B, 1, 1, dim), then expand_as directly broadcasts into (B, S, T, dim)

```
python scripts/plan/eval_wm.py policy=quentinll/lewm-pusht eval.dataset_name=pusht_expert_train.h5 eval.num_eval=5 solver.batch_size=5 bf16=true compile=true
[2026-06-06 15:10:56,334][datasets][INFO] - JAX version 0.6.2 available.
15:10:58 | INFO  | atomic_chec~| [atomic_save] installed crash-safe checkpoint plugin (write to sibling .tmp + fsync + atomic rename)
[2026-06-06 15:10:58,785][root][INFO] - Cached 'action' from '/home/mark123/.stable_worldmodel/datasets/pusht_expert_train.h5'
[2026-06-06 15:10:58,840][root][INFO] - Cached 'proprio' from '/home/mark123/.stable_worldmodel/datasets/pusht_expert_train.h5'
[2026-06-06 15:10:58,921][root][INFO] - Cached 'state' from '/home/mark123/.stable_worldmodel/datasets/pusht_expert_train.h5'
15:10:59 | INFO  | utils.py    | Loading quentinll/lewm-pusht from local cache...
15:10:59 | INFO  | utils.py    | Loading checkpoint from folder /home/mark123/.stable_worldmodel/checkpoints/models--quentinll--lewm-pusht...
15:10:59 | INFO  | utils.py    | Created ViT-tiny from scratch with config: {'hidden_size': 192, 'num_hidden_layers': 12, 'num_attention_heads': 3, 'intermediate_size': 768, 'image_size': 224, 'patch_size': 14}
1869611 valid starting points found for evaluation.
[ 209214 1015444 1028381 1529317 1805168]
[eval] saving videos to /home/mark123/.stable_worldmodel/checkpoints/quentinll (one env_{i}.mp4 per env)
Warming up compiled model...
/home/mark123/projects/stable-worldmodel/.venv/lib/python3.10/site-packages/gymnasium/spaces/box.py:424: UserWarning: WARN: Casting input x to numpy array.
  gym.logger.warn("Casting input x to numpy array.")
Error executing job with overrides: ['policy=quentinll/lewm-pusht', 'eval.dataset_name=pusht_expert_train.h5', 'eval.num_eval=5', 'solver.batch_size=5', 'bf16=true', 'compile=true']
Traceback (most recent call last):
  File "/home/mark123/projects/stable-worldmodel/scripts/plan/eval_wm.py", line 193, in run
    world.evaluate(
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/world/world.py", line 244, in evaluate
    return self._evaluate_from_dataset(
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/world/world.py", line 550, in _evaluate_from_dataset
    self._run(max_steps=eval_budget, mode=mode, on_step=on_step)
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/world/world.py", line 365, in _run
    for env_idx, ep_count in self._run_iter(
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/world/world.py", line 404, in _run_iter
    actions = self._get_actions()
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/world/world.py", line 449, in _get_actions
    return self.policy.get_action(self.infos)
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/policy.py", line 404, in get_action
    outputs = self.solver(sliced, init_action=sliced_init)
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/solver/cem.py", line 93, in __call__
    return self.solve(*args, **kwargs)
  File "/home/mark123/projects/stable-worldmodel/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/solver/cem.py", line 210, in solve
    costs = self.model.get_cost(expanded_infos, candidates)
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/wm/lewm/lewm.py", line 149, in get_cost
    cost = self.criterion(info_dict)
  File "/home/mark123/projects/stable-worldmodel/stable_worldmodel/wm/lewm/lewm.py", line 115, in criterion
    goal_emb = goal_emb[..., -1:, :].expand_as(pred_emb)
RuntimeError: The expanded size of the tensor (300) must match the existing size (5) at non-singleton dimension 1.  Target sizes: [5, 300, 6, 192].  Tensor sizes: [5, 1, 192]
```