### PR TITLE
Add tutorials

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,9 @@ After you have installed stable-worldmodel, try the [Quick Start Guide](quick_st
 | | |
 |---|---|
 | **[Environments](envs/pusht.md)** | Explore the included environments: PushT, TwoRoom, OGBench, DMControl, and more. |
+| **[Tutorial: collect data](tutorial/collect_data.md)** | Build a small dataset, inspect it, load it for training, and convert it to another format. |
+| **[Tutorial: train a world model](tutorial/training_wm.md)** | Train or plug in a model that implements the planning cost interface, then evaluate it with MPC. |
+| **[Tutorial: add an environment](tutorial/new_env.md)** | Register a Gymnasium environment with pixels, state, goals, and factors of variation. |
 | **[CLI Reference](cli.md)** | Inspect datasets, environments, and checkpoints from the terminal with the `swm` command. |
 | **[API Reference](api/world.md)** | Detailed documentation for World, Policy, Solver, Dataset, and other modules. |
 

--- a/docs/tutorial/collect_data.md
+++ b/docs/tutorial/collect_data.md
@@ -25,6 +25,14 @@ format dependencies:
 pip install 'stable-worldmodel[all]'
 ```
 
+On macOS arm64, `decord` may not provide a compatible wheel for the `all`
+extra. The PushT collection path below can be run with the narrower runtime
+set instead:
+
+```bash
+pip install stable-worldmodel pygame pymunk shapely opencv-python-headless
+```
+
 Datasets are stored under `$STABLEWM_HOME/datasets`. If the variable is not
 set, the default root is `~/.stable_worldmodel`.
 
@@ -174,6 +182,11 @@ loader = DataLoader(
 batch = next(iter(loader))
 print(batch['pixels'].shape)  # (B, T, C, H, W)
 ```
+
+Lance datasets switch multiprocessing to the `spawn` start method for
+fork-safety. If you use `num_workers > 0`, run the `DataLoader` code from a
+normal Python file under an `if __name__ == '__main__':` guard. For notebooks,
+REPLs, or heredoc snippets, set `num_workers=0`.
 
 `num_steps` is the temporal window returned by `__getitem__`. `frameskip`
 controls the stride between observation frames while keeping action sequences

--- a/docs/tutorial/collect_data.md
+++ b/docs/tutorial/collect_data.md
@@ -1,4 +1,221 @@
 title: Collect Dataset
-summary: TBD
+summary: Create a small PushT dataset, inspect it, load it for training, and convert it to another format.
 sidebar_title: New Dataset
 ---
+
+This tutorial walks through the first stage of a world-model experiment:
+recording trajectories into a dataset that can be loaded by PyTorch training
+code.
+
+You will:
+
+- create a vectorized `World`,
+- collect PushT trajectories with a weak expert policy,
+- randomize selected factors of variation,
+- inspect the dataset from the CLI,
+- load fixed-length clips for training,
+- convert the dataset to another storage format.
+
+## Install
+
+Use the full extra for this tutorial because it needs environment and dataset
+format dependencies:
+
+```bash
+pip install 'stable-worldmodel[all]'
+```
+
+Datasets are stored under `$STABLEWM_HOME/datasets`. If the variable is not
+set, the default root is `~/.stable_worldmodel`.
+
+```bash
+export STABLEWM_HOME=$PWD/.stablewm
+mkdir -p "$STABLEWM_HOME/datasets"
+```
+
+## Inspect the environment
+
+List the environments registered by `stable_worldmodel`:
+
+```bash
+swm envs
+```
+
+Inspect PushT's factors of variation:
+
+```bash
+swm fovs swm/PushT-v1
+```
+
+Factors of variation are reset-time controls such as object colors, object
+positions, sizes, shapes, and physics parameters. Passing a factor name in
+`options={"variation": ...}` samples that factor for each episode.
+
+## Collect trajectories
+
+Create `collect_pusht_tutorial.py`:
+
+```python
+from pathlib import Path
+import os
+
+import stable_worldmodel as swm
+from stable_worldmodel.envs.pusht import WeakPolicy
+
+
+root = Path(os.environ.get('STABLEWM_HOME', Path.home() / '.stable_worldmodel'))
+dataset_path = root / 'datasets' / 'tutorial_pusht.lance'
+
+world = swm.World(
+    'swm/PushT-v1',
+    num_envs=8,
+    image_shape=(96, 96),
+    max_episode_steps=100,
+)
+
+world.set_policy(WeakPolicy(dist_constraint=100, seed=0))
+
+world.collect(
+    dataset_path,
+    episodes=64,
+    seed=0,
+    options={
+        'variation': [
+            'agent.start_position',
+            'block.start_position',
+            'block.angle',
+            'agent.color',
+            'block.color',
+        ],
+    },
+)
+
+world.close()
+print(f'wrote {dataset_path}')
+```
+
+Run it:
+
+```bash
+python collect_pusht_tutorial.py
+```
+
+The default dataset format is `lance`, which is the recommended format for
+training workloads with shuffled image trajectories. To write HDF5 instead,
+pass `format='hdf5'` and use a `.h5` path.
+
+```python
+world.collect(
+    root / 'datasets' / 'tutorial_pusht.h5',
+    episodes=64,
+    seed=0,
+    format='hdf5',
+)
+```
+
+## Inspect the dataset
+
+Datasets in `$STABLEWM_HOME/datasets` can be inspected by name:
+
+```bash
+swm inspect tutorial_pusht
+```
+
+The output includes the detected format, episode count, step count, and stored
+columns. All numeric entries from `world.infos` become columns. The standard
+columns include:
+
+| Column | Meaning |
+|---|---|
+| `pixels` | Rendered RGB frame resized by `World(image_shape=...)`. |
+| `action` | Action applied at the current step. |
+| `reward` | Environment reward. |
+| `terminated` / `truncated` | Episode-end flags. |
+| `state` / `proprio` | Low-dimensional state when the environment provides it. |
+| `step_idx` | Step index within the episode. |
+| `variation.*` | Variation values requested in reset options. |
+
+For Lance datasets, dots in field names are normalized to underscores on disk
+because Lance reserves `.` for struct paths.
+
+## Load training clips
+
+Load fixed-length clips with `swm.data.load_dataset()`:
+
+```python
+import stable_worldmodel as swm
+
+dataset = swm.data.load_dataset(
+    'tutorial_pusht.lance',
+    num_steps=8,
+    frameskip=1,
+    keys_to_load=['pixels', 'action', 'state'],
+)
+
+sample = dataset[0]
+print(sample.keys())
+print(sample['pixels'].shape)  # (T, C, H, W)
+print(sample['action'].shape)  # (T, action_dim)
+```
+
+Then use the dataset with a standard PyTorch `DataLoader`:
+
+```python
+from torch.utils.data import DataLoader
+
+loader = DataLoader(
+    dataset,
+    batch_size=32,
+    shuffle=True,
+    num_workers=4,
+    pin_memory=True,
+)
+
+batch = next(iter(loader))
+print(batch['pixels'].shape)  # (B, T, C, H, W)
+```
+
+`num_steps` is the temporal window returned by `__getitem__`. `frameskip`
+controls the stride between observation frames while keeping action sequences
+dense.
+
+## Convert formats
+
+Convert the Lance dataset to a video-backed dataset:
+
+```bash
+swm convert tutorial_pusht tutorial_pusht_video --dest-format video
+```
+
+Or convert in Python:
+
+```python
+from pathlib import Path
+import os
+
+import stable_worldmodel as swm
+
+root = Path(os.environ.get('STABLEWM_HOME', Path.home() / '.stable_worldmodel'))
+
+swm.data.convert(
+    root / 'datasets' / 'tutorial_pusht.lance',
+    root / 'datasets' / 'tutorial_pusht_video',
+    dest_format='video',
+    fps=30,
+)
+```
+
+Use `video` when you want compact, easy-to-watch rollouts. Use `lance` when
+you want fast random access during training.
+
+## Common checks
+
+- If `swm inspect tutorial_pusht` cannot find the dataset, confirm
+  `$STABLEWM_HOME` is the same in both shells.
+- If a policy returns the wrong shape, check `world.envs.action_space.shape`.
+  Vectorized worlds expect actions shaped like the batched action space.
+- If you need exact reproducibility for OOD experiments, include every factor
+  you randomize in `options['variation']`; only watched variation values are
+  written into the dataset.
+- If you collect outside `$STABLEWM_HOME/datasets`, pass an absolute path to
+  `swm.data.load_dataset()`.

--- a/docs/tutorial/new_env.md
+++ b/docs/tutorial/new_env.md
@@ -1,4 +1,306 @@
 title: Adding New Environment
-summary: TBD
+summary: Register a Gymnasium environment with pixels, state, goals, and factors of variation.
 sidebar_title: New Environment
 ---
+
+This tutorial shows how to add a custom environment to
+`stable_worldmodel`. The library builds on Gymnasium, so the environment
+itself is an ordinary `gymnasium.Env`. The extra requirements are:
+
+- `render()` must return an RGB array when `World(add_pixels=True)` is used.
+- Useful data should be returned in `info` (`state`, `goal`, `goal_state`,
+  task metrics, and so on).
+- Optional factors of variation should be exposed as `variation_space`.
+
+## Create a minimal environment
+
+Save this as `line_reach_env.py`:
+
+```python
+import gymnasium as gym
+import numpy as np
+from gymnasium import spaces
+
+from stable_worldmodel import spaces as swm_spaces
+
+
+class LineReachEnv(gym.Env):
+    metadata = {'render_modes': ['rgb_array'], 'render_fps': 20}
+
+    def __init__(self, render_mode='rgb_array'):
+        self.render_mode = render_mode
+        self.action_space = spaces.Box(
+            low=-1.0,
+            high=1.0,
+            shape=(1,),
+            dtype=np.float32,
+        )
+        self.observation_space = spaces.Box(
+            low=-1.0,
+            high=1.0,
+            shape=(2,),
+            dtype=np.float32,
+        )
+
+        self.variation_space = swm_spaces.Dict(
+            {
+                'agent': swm_spaces.Dict(
+                    {
+                        'start_position': swm_spaces.Box(
+                            low=np.array([-0.9], dtype=np.float32),
+                            high=np.array([0.9], dtype=np.float32),
+                            init_value=np.array([0.0], dtype=np.float32),
+                            shape=(1,),
+                            dtype=np.float32,
+                        ),
+                        'color': swm_spaces.RGBBox(
+                            init_value=np.array(
+                                [40, 120, 255],
+                                dtype=np.uint8,
+                            ),
+                        ),
+                    }
+                ),
+                'goal': swm_spaces.Dict(
+                    {
+                        'position': swm_spaces.Box(
+                            low=np.array([-0.9], dtype=np.float32),
+                            high=np.array([0.9], dtype=np.float32),
+                            init_value=np.array([0.75], dtype=np.float32),
+                            shape=(1,),
+                            dtype=np.float32,
+                        ),
+                        'color': swm_spaces.RGBBox(
+                            init_value=np.array(
+                                [255, 80, 80],
+                                dtype=np.uint8,
+                            ),
+                        ),
+                    }
+                ),
+            }
+        )
+
+        self.position = 0.0
+        self.goal = 0.75
+
+    def _obs(self):
+        return np.array([self.position, self.goal], dtype=np.float32)
+
+    def _info(self):
+        return {
+            'state': self._obs(),
+            'goal_state': np.array([self.goal], dtype=np.float32),
+            'goal': self._render(show_agent=False),
+        }
+
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed)
+        swm_spaces.reset_variation_space(
+            self.variation_space,
+            seed=seed,
+            options=options,
+            default_variations=(
+                'agent.start_position',
+                'goal.position',
+            ),
+        )
+        self.position = float(
+            self.variation_space['agent']['start_position'].value[0]
+        )
+        self.goal = float(self.variation_space['goal']['position'].value[0])
+        return self._obs(), self._info()
+
+    def step(self, action):
+        action = float(np.asarray(action, dtype=np.float32).reshape(-1)[0])
+        self.position = float(np.clip(self.position + 0.05 * action, -1.0, 1.0))
+
+        distance = abs(self.position - self.goal)
+        terminated = distance < 0.03
+        truncated = False
+        reward = 1.0 if terminated else -distance
+
+        return self._obs(), reward, terminated, truncated, self._info()
+
+    def render(self):
+        return self._render(show_agent=True)
+
+    def _render(self, show_agent=True):
+        canvas = np.full((64, 64, 3), 245, dtype=np.uint8)
+        canvas[31:33, 4:60] = 30
+
+        def xcoord(value):
+            return int(np.interp(value, [-1.0, 1.0], [4, 59]))
+
+        gx = xcoord(self.goal)
+        goal_color = self.variation_space['goal']['color'].value
+        canvas[20:44, max(0, gx - 1) : min(64, gx + 2)] = goal_color
+
+        if show_agent:
+            ax = xcoord(self.position)
+            agent_color = self.variation_space['agent']['color'].value
+            canvas[26:38, max(0, ax - 3) : min(64, ax + 4)] = agent_color
+
+        return canvas
+```
+
+The environment is still a normal Gymnasium environment. You can test it
+directly:
+
+```python
+env = LineReachEnv()
+obs, info = env.reset(seed=0)
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+frame = env.render()
+print(obs, reward, frame.shape)
+```
+
+## Register it
+
+For a one-file experiment, register the class in the same process before you
+construct `World`:
+
+```python
+import stable_worldmodel as swm
+from stable_worldmodel.envs import register
+
+from line_reach_env import LineReachEnv
+
+
+register(
+    id='swm/LineReach-v0',
+    entry_point=LineReachEnv,
+)
+
+world = swm.World(
+    'swm/LineReach-v0',
+    num_envs=4,
+    image_shape=(64, 64),
+    max_episode_steps=50,
+)
+```
+
+For a reusable package, put the registration in your package import path and
+use a string entry point:
+
+```python
+from stable_worldmodel.envs import register
+
+register(
+    id='swm/LineReach-v0',
+    entry_point='my_project.envs.line_reach:LineReachEnv',
+)
+```
+
+Make sure the module that calls `register(...)` is imported before creating
+the environment. The `swm envs` CLI can only list custom environments that
+are registered during CLI startup, so package-level registration is preferable
+for shared environments.
+
+## Use it through World
+
+```python
+import stable_worldmodel as swm
+from stable_worldmodel.policy import RandomPolicy
+
+world = swm.World(
+    'swm/LineReach-v0',
+    num_envs=8,
+    image_shape=(64, 64),
+    max_episode_steps=50,
+)
+
+world.set_policy(RandomPolicy(seed=0))
+world.reset(
+    seed=0,
+    options={
+        'variation': [
+            'agent.start_position',
+            'goal.position',
+            'agent.color',
+        ],
+    },
+)
+
+print(world.infos['pixels'].shape)  # (8, 1, 64, 64, 3)
+print(world.infos['state'].shape)   # (8, 1, 2)
+print(world.envs.single_variation_space.to_str())
+world.close()
+```
+
+`World` wraps the raw environment with `MegaWrapper`. That wrapper renders
+pixels, resizes them, moves observations and step metadata into `info`, and
+stacks values across the vectorized environments.
+
+## Collect a dataset
+
+```python
+from pathlib import Path
+import os
+
+import stable_worldmodel as swm
+
+
+root = Path(os.environ.get('STABLEWM_HOME', Path.home() / '.stable_worldmodel'))
+dataset_path = root / 'datasets' / 'line_reach_random.lance'
+
+world = swm.World(
+    'swm/LineReach-v0',
+    num_envs=8,
+    image_shape=(64, 64),
+    max_episode_steps=50,
+)
+world.set_policy(swm.policy.RandomPolicy(seed=0))
+
+world.collect(
+    dataset_path,
+    episodes=100,
+    seed=0,
+    options={'variation': ['all']},
+)
+world.close()
+```
+
+Now inspect and load it like any built-in dataset:
+
+```bash
+swm inspect line_reach_random
+```
+
+```python
+dataset = swm.data.load_dataset(
+    'line_reach_random.lance',
+    num_steps=8,
+    keys_to_load=['pixels', 'action', 'state', 'goal_state'],
+)
+```
+
+## State-only environments
+
+If your environment has no meaningful renderer, skip pixel rendering:
+
+```python
+world = swm.World(
+    'swm/LineReach-v0',
+    num_envs=8,
+    add_pixels=False,
+)
+```
+
+In that mode `pixels` is not added, video recording is unavailable, and the
+raw observation is lifted into `world.infos['observation']` unless your env
+already returns a dict observation.
+
+## Environment checklist
+
+- `reset()` calls `super().reset(seed=seed)` so Gymnasium seeds
+  `self.np_random`.
+- `action_space` and `observation_space` have stable shapes and dtypes.
+- `render()` returns `uint8` RGB with shape `(H, W, 3)`.
+- `info` contains every signal you want to record or train on.
+- Goal-conditioned tasks include both a visual goal (`goal`) and a compact
+  goal signal (`goal_state`) when possible.
+- Variation spaces use `stable_worldmodel.spaces` and are reset with
+  `reset_variation_space(...)`.
+- Exact variation values are written to datasets only for watched variation
+  keys passed in `options['variation']`.

--- a/docs/tutorial/training_wm.md
+++ b/docs/tutorial/training_wm.md
@@ -21,6 +21,13 @@ pip install 'stable-worldmodel[all]'
 export STABLEWM_HOME=$PWD/.stablewm
 ```
 
+On macOS arm64, `decord` may not provide a compatible wheel for the `all`
+extra. For the CPU smoke path below, install the narrower runtime set:
+
+```bash
+pip install 'stable-worldmodel[train]' pygame pymunk shapely opencv-python-headless
+```
+
 This tutorial assumes the dataset exists at:
 
 ```text
@@ -98,6 +105,11 @@ print(batch['pixels'].shape)  # (B, T, C, H, W)
 print(batch['action'].shape)  # (B, T, action_dim)
 ```
 
+Lance datasets switch multiprocessing to the `spawn` start method for
+fork-safety. If you use `num_workers > 0`, run the `DataLoader` code from a
+normal Python file under an `if __name__ == '__main__':` guard. For notebooks,
+REPLs, or heredoc snippets, set `num_workers=0`.
+
 The first action in an episode may be `NaN` because there is no previous
 environment action at reset. Training code should replace it before computing
 losses:
@@ -133,6 +145,8 @@ python scripts/train/lewm.py \
   trainer.devices=1 \
   trainer.precision=32 \
   loader.batch_size=8 \
+  loader.prefetch_factor=null \
+  loader.persistent_workers=false \
   num_workers=0 \
   output_model_name=tutorial_lewm_cpu
 ```

--- a/docs/tutorial/training_wm.md
+++ b/docs/tutorial/training_wm.md
@@ -1,4 +1,273 @@
 title: Training A World Model
-summary: TBD
+summary: Train or plug in a model that implements the planning cost interface, then evaluate it with model-predictive control.
 sidebar_title: Train World-Model
 ---
+
+This tutorial covers the second and third stages of a world-model experiment:
+training a model from collected trajectories and using it for planning.
+
+The important integration point is small: a model used by
+`WorldModelPolicy` must provide `get_cost(info_dict, action_candidates)`.
+Planning solvers such as CEM and MPPI search over action sequences and choose
+the sequence with the lowest predicted cost.
+
+## Prerequisites
+
+Install the full package and collect the dataset from
+[Collect Dataset](collect_data.md):
+
+```bash
+pip install 'stable-worldmodel[all]'
+export STABLEWM_HOME=$PWD/.stablewm
+```
+
+This tutorial assumes the dataset exists at:
+
+```text
+$STABLEWM_HOME/datasets/tutorial_pusht.lance
+```
+
+## The cost-model contract
+
+A cost model receives the current `World` info dict and a batch of candidate
+action sequences. It returns one scalar cost per environment and candidate.
+Lower is better.
+
+```python
+import torch
+
+
+class MyWorldModel(torch.nn.Module):
+    def get_cost(
+        self,
+        info_dict: dict,
+        action_candidates: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        info_dict:
+            Dict produced by World. Tensor values usually have shape
+            (num_envs, history, ...).
+
+        action_candidates:
+            Tensor with shape
+            (num_envs, num_samples, horizon, action_dim).
+
+        returns:
+            Cost tensor with shape (num_envs, num_samples).
+        """
+        costs = ...
+        return costs
+```
+
+For goal-conditioned planning, `info_dict` usually contains `pixels`,
+`goal`, `state`, and `goal_state` or related goal columns. Image models often
+compare predicted future embeddings against a goal embedding; state models
+often compare predicted state against `goal_state`.
+
+## Load trajectory clips
+
+Training starts from the same dataset API used everywhere else:
+
+```python
+import stable_worldmodel as swm
+
+dataset = swm.data.load_dataset(
+    'tutorial_pusht.lance',
+    num_steps=8,
+    frameskip=1,
+    keys_to_load=['pixels', 'action', 'state'],
+)
+```
+
+With PyTorch:
+
+```python
+from torch.utils.data import DataLoader
+
+loader = DataLoader(
+    dataset,
+    batch_size=64,
+    shuffle=True,
+    num_workers=4,
+    pin_memory=True,
+    drop_last=True,
+)
+
+batch = next(iter(loader))
+print(batch['pixels'].shape)  # (B, T, C, H, W)
+print(batch['action'].shape)  # (B, T, action_dim)
+```
+
+The first action in an episode may be `NaN` because there is no previous
+environment action at reset. Training code should replace it before computing
+losses:
+
+```python
+batch['action'] = torch.nan_to_num(batch['action'], 0.0)
+```
+
+## Use a reference training script
+
+The repository ships reference training scripts under `scripts/train/`. For
+example, `scripts/train/lewm.py` trains the LeWM baseline from image clips and
+actions.
+
+For a short GPU smoke run:
+
+```bash
+python scripts/train/lewm.py \
+  data.dataset.name=tutorial_pusht.lance \
+  trainer.max_epochs=2 \
+  loader.batch_size=32 \
+  num_workers=2 \
+  output_model_name=tutorial_lewm
+```
+
+For a CPU-only smoke run, override the trainer settings:
+
+```bash
+python scripts/train/lewm.py \
+  data.dataset.name=tutorial_pusht.lance \
+  trainer.max_epochs=1 \
+  trainer.accelerator=cpu \
+  trainer.devices=1 \
+  trainer.precision=32 \
+  loader.batch_size=8 \
+  num_workers=0 \
+  output_model_name=tutorial_lewm_cpu
+```
+
+These commands are useful for checking that the dataset and training
+dependencies are wired correctly. For real experiments, increase epochs,
+batch size, image resolution, and model size according to your hardware.
+
+## Save a custom model
+
+If you train your own model, save it with the checkpoint format used by the
+library:
+
+```python
+from stable_worldmodel.wm.utils import save_pretrained
+
+model_config = {
+    '_target_': 'my_project.models.MyWorldModel',
+    'hidden_dim': 256,
+    'action_dim': 2,
+}
+
+save_pretrained(
+    model=model,
+    run_name='tutorial_state_wm',
+    config=model_config,
+    filename='weights.pt',
+)
+```
+
+`config` must be the Hydra instantiation config for the model itself. If your
+training script has a larger config with keys such as `data`, `loader`, and
+`trainer`, pass only the model sub-config or use `config_key='model'`.
+
+## Evaluate with MPC
+
+Load the model and wrap it with a solver-backed policy:
+
+```python
+import stable_worldmodel as swm
+from stable_worldmodel.policy import PlanConfig, WorldModelPolicy
+from stable_worldmodel.solver import CEMSolver
+from stable_worldmodel.wm.utils import load_pretrained
+
+
+device = 'cuda'
+model = load_pretrained('tutorial_state_wm/weights.pt').to(device).eval()
+model.requires_grad_(False)
+
+world = swm.World(
+    'swm/PushT-v1',
+    num_envs=8,
+    image_shape=(96, 96),
+    max_episode_steps=100,
+)
+
+solver = CEMSolver(
+    model=model,
+    num_samples=300,
+    n_steps=5,
+    device=device,
+)
+
+policy = WorldModelPolicy(
+    solver=solver,
+    config=PlanConfig(
+        horizon=10,
+        receding_horizon=5,
+        action_block=1,
+        warm_start=True,
+    ),
+)
+
+world.set_policy(policy)
+results = world.evaluate(episodes=32, seed=0, video='videos/tutorial_eval')
+world.close()
+
+print(results)
+```
+
+Use the same preprocessing at evaluation time that you used during training.
+If you normalized actions or state columns, pass those reversible processors
+to `WorldModelPolicy(process=...)`. If you normalized images, pass the image
+transforms with `WorldModelPolicy(transform=...)`.
+
+## Evaluate from dataset starts and goals
+
+For goal-reaching experiments, it is common to initialize the simulator from
+states stored in a dataset and ask the policy to reach a future dataset goal.
+In this mode, `num_envs` must equal the number of requested episodes.
+
+```python
+dataset = swm.data.load_dataset(
+    'tutorial_pusht.lance',
+    num_steps=32,
+    keys_to_load=['pixels', 'action', 'state'],
+)
+
+world = swm.World(
+    'swm/PushT-v1',
+    num_envs=4,
+    image_shape=(96, 96),
+    max_episode_steps=100,
+)
+world.set_policy(policy)
+
+results = world.evaluate(
+    dataset=dataset,
+    episodes_idx=[0, 1, 2, 3],
+    start_steps=[0, 5, 10, 15],
+    goal_offset=25,
+    eval_budget=50,
+    callables=[
+        {'method': '_set_state', 'args': {'state': {'value': 'state'}}},
+        {
+            'method': '_set_goal_state',
+            'args': {'goal_state': {'value': 'goal_state'}},
+        },
+    ],
+    video='videos/tutorial_dataset_eval',
+)
+```
+
+Some environments need callables to restore internal simulator state from the
+dataset. PushT supports `_set_state` and `_set_goal_state`; the planned
+evaluation script in `scripts/plan/eval_wm.py` shows the full Hydra version
+of that workflow.
+
+## Debug checklist
+
+- `get_cost()` must return finite costs with shape `(num_envs, num_samples)`.
+- The solver's `device` must match the model device.
+- `PlanConfig.horizon * action_block` should fit inside the evaluation
+  budget.
+- Use `warm_start=True` for faster receding-horizon planning once the model
+  is stable.
+- Start with small `num_samples` and short horizons while debugging, then
+  increase them for final evaluation.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -32,10 +32,10 @@ nav:
       - guides/checkpoints.md
       - guides/online_learning.md
   - cli.md
-  # - Tutorial:
-  #     - tutorial/collect_data.md
-  #     - tutorial/new_env.md
-  #     - tutorial/training_wm.md
+  - Tutorial:
+      - tutorial/collect_data.md
+      - tutorial/training_wm.md
+      - tutorial/new_env.md
   - API:
       - api/world.md
       - api/policy.md

--- a/stable_worldmodel/wm/utils.py
+++ b/stable_worldmodel/wm/utils.py
@@ -35,7 +35,8 @@ def save_pretrained(
 
     config_path = ckpt_dir / 'config.json'
 
-    config = OmegaConf.to_container(config, resolve=True)
+    if OmegaConf.is_config(config):
+        config = OmegaConf.to_container(config, resolve=True)
     with open(config_path, 'w') as f:
         json.dump(config, f, indent=2)
 


### PR DESCRIPTION
 ## Summary

  - Add tutorial docs for:
    - collecting a PushT dataset
    - registering and using a custom Gymnasium environment
    - training/evaluating a world model with MPC
  - Wire the tutorials into the docs navigation.
  - Fix `save_pretrained()` so documented plain Python `dict` configs work, while preserving OmegaConf
  support.

  ## Validation

  - Ran the collection tutorial: env listing, PushT FOV inspection, dataset collection, dataset
  inspection, DataLoader loading, and video conversion.
  - Ran the custom environment tutorial: direct env use, SWM registration, world reset, dataset
  collection/loading, and state-only mode.
  - Ran LeWM tutorial smoke training on CPU.
  - Ran full tutorial workflow on an RTX 4090 GPU instance:
    - `stable-worldmodel[all]` installed successfully
    - CUDA detected and used
    - documented 2-epoch GPU LeWM smoke completed
    - checkpoints saved successfully
  - Ran CUDA MPC/checkpoint integration with `save_pretrained()`, `load_pretrained()`, `CEMSolver`, and
  `WorldModelPolicy`.