### PR TITLE
Add ManiSkill3 environments (Franka Panda + SIMPLER Bridge)

### DIFF
--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -58,20 +58,6 @@ world = swm.World('swm/SimplerCarrotOnPlate-v0', num_envs=4, image_shape=(224, 2
     The Bridge tasks only support `obs_mode='rgb+segmentation'`, already set per-task
     in `TASK_SPECS`.
 
-!!! warning "Known limitation: ManiSkill motion-planning solvers vs. NumPy 2"
-    ManiSkill's *motion-planning* examples/solvers
-    (`mani_skill.examples.motionplanning.*`) **segfault under NumPy 2**. They depend on
-    `mplib==0.1.1` (pinned by `mani-skill` on Linux), whose compiled extension was built
-    against the NumPy 1.x ABI; passing NumPy-2 arrays into it crashes when the planner
-    builds its articulation model.
-
-    This does **not** affect this integration: the simulator, our `ManiSkillWrapper`,
-    rendering, and `World.evaluate` all run fine on NumPy 2 — only the optional
-    motion-planning trajectory generators are impacted. If you specifically need those
-    solvers, run them in a separate `numpy<2` environment, or replay ManiSkill's
-    pre-recorded demonstration datasets (`mani_skill.utils.download_demo`) instead, which
-    need no motion planning.
-
 ### Available Environments
 
 **Franka Panda table-top manipulation**

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -146,6 +146,27 @@ The script restores each demo's recorded initial `env_state` and replays its act
 wrapper, reporting `success_rate`. (Reproduction uses the initial state, not the seed — batched-GPU
 demos aren't seed-reproducible in a single env.)
 
+### World-model (MPC) evaluation — follow-up
+
+Running a trained world model via `scripts/plan/eval_wm.py` (goal-conditioned MPC, like PushT) is a
+**planned follow-up**, not part of this integration. We validated the full path once on an H100 (a
+LeWM model trained on a small PickCube dataset reached a **2% (1/50)** goal-reaching success rate),
+which surfaced what the follow-up needs:
+
+- **A sim-collected eval dataset in the benchmark format.** `eval_wm.py` reads `episode_idx`/`step_idx`
+  per row plus `ep_len`/`ep_offset`, with `pixels` (HWC), `action`, `proprio`, and `state` — the same
+  layout as the provided `pusht_expert_train.h5`. `World.collect` output isn't natively in this format
+  (Lance hides the index columns; HDF5 omits them), so the dataset is produced/hosted separately —
+  exactly as PushT's eval dataset is a provided/hosted artifact, not collect output.
+- **Goal-conditioning callables.** The env needs `_set_state`/`_set_goal_state` (to set the start state
+  and a sim-state goal); a validated implementation lives on the `maniskill-wm-eval` branch.
+- **A model-block checkpoint config.** `load_pretrained` instantiates `config.json` as the model block;
+  save with `save_pretrained(config_key='model')` (`lewm.py` otherwise saves the full cfg).
+- **Real-robot datasets don't apply here.** DROID (Franka) and BridgeData V2 / Open-X (WidowX) are for
+  *training policies*, not as MPC-eval datasets — they carry no ManiSkill sim state to restore. The
+  SIMPLER-style real2sim *policy* eval (run a trained policy in the sim, score native success via
+  `World.evaluate`) is a separate path that needs a trained policy, not a goal dataset.
+
 ## Adding a robot or task
 
 Environments are declared in `stable_worldmodel/envs/maniskill/tasks.py` as `TASK_SPECS` — a flat

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -158,10 +158,12 @@ python scripts/train/lewm.py data=maniskill \             # 2. train LeWM
 python scripts/plan/eval_wm.py --config-name maniskill    # 3. goal-conditioned MPC eval
 ```
 
-The MPC eval consumes a dataset in the benchmark layout (`episode_idx`/`step_idx`/`ep_len`/`ep_offset`
-+ `pixels` HWC + `action`/`proprio`/`state` = flat sim state) — the same format as PushT's provided
-`pusht_expert_train.h5`, supplied separately rather than read straight from `World.collect` output. The
-checkpoint's `config.json` must be the model block (`save_pretrained(config_key='model')`).
+Step 3 does not run on raw `collect_maniskill.py` output: `scripts/plan/config/maniskill.yaml` is a
+**template** you point at a prepared dataset in the benchmark layout (`episode_idx`/`step_idx`/`ep_len`/
+`ep_offset` + `pixels` HWC + `action`/`proprio`/`state` = flat sim state) — the same format as PushT's
+provided `pusht_expert_train.h5`, supplied separately rather than read straight from `World.collect`.
+The checkpoint's `config.json` must also be the model block (`save_pretrained(config_key='model')`;
+`lewm.py` otherwise saves the full cfg).
 
 ## Adding a robot or task
 

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -58,6 +58,20 @@ world = swm.World('swm/SimplerCarrotOnPlate-v0', num_envs=4, image_shape=(224, 2
     The Bridge tasks only support `obs_mode='rgb+segmentation'`, already set per-task
     in `TASK_SPECS`.
 
+!!! warning "Known limitation: ManiSkill motion-planning solvers vs. NumPy 2"
+    ManiSkill's *motion-planning* examples/solvers
+    (`mani_skill.examples.motionplanning.*`) **segfault under NumPy 2**. They depend on
+    `mplib==0.1.1` (pinned by `mani-skill` on Linux), whose compiled extension was built
+    against the NumPy 1.x ABI; passing NumPy-2 arrays into it crashes when the planner
+    builds its articulation model.
+
+    This does **not** affect this integration: the simulator, our `ManiSkillWrapper`,
+    rendering, and `World.evaluate` all run fine on NumPy 2 — only the optional
+    motion-planning trajectory generators are impacted. If you specifically need those
+    solvers, run them in a separate `numpy<2` environment, or replay ManiSkill's
+    pre-recorded demonstration datasets (`mani_skill.utils.download_demo`) instead, which
+    need no motion planning.
+
 ### Available Environments
 
 **Franka Panda table-top manipulation**

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -30,12 +30,14 @@ success detector (mapped onto `terminated`).
 ## Installation
 
 ```bash
-pip install "stable-worldmodel[maniskill]"   # or: uv sync --extra maniskill
+uv sync --group maniskill   # GPU box only; or: pip install mani-skill
 ```
 
-The dependency is GPU-only and is intentionally **not** part of `[all]`. The import is lazy, so
-`import stable_worldmodel` works (and the envs register) on machines without ManiSkill installed —
-they only fail when you actually instantiate one.
+ManiSkill is GPU-only (needs CUDA + Vulkan), so it's an opt-in **dependency group** rather than an
+extra — it is intentionally excluded from `uv sync --all-extras` / `[all]` (and has no clean wheel
+install on linux Python 3.11/3.12). The import is lazy, so `import stable_worldmodel` works (and the
+envs register) on machines without ManiSkill installed — they only fail when you actually instantiate
+one.
 
 ```python
 import stable_worldmodel as swm

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -111,8 +111,40 @@ The `info` dict returned by `reset()` and `step()` follows the standard SWM conv
 
 ### Variation Space
 
-The variation space is currently empty (`swm_spaces.Dict({})`). SIMPLER's distribution-shift knobs
-(lighting, camera, background, distractors, textures) are a planned follow-up.
+The env exposes a `variation_space` of visual Factors of Variation, aligned with SIMPLER's
+distribution-shift axes. These are sampled each reset (or set explicitly via
+`reset(options={'variation': [...]})` / `options={'variation_values': {...}}`) and recorded in
+`info['variation.<key>']`. The set is restricted to factors **verified to change the rendered
+frame** through the wrapper (applied by `_apply_variations` using ManiSkill's own SAPIEN APIs):
+
+| Factor | Type | Default | SIMPLER axis |
+|--------|------|---------|--------------|
+| `light.intensity` | `Box(0.3, 1.0, (1,))` | `0.7` | lighting (scene ambient) |
+| `camera.angle_delta` | `Box(-10, 10, (1, 2))` | `[[0, 0]]` (azimuth/elevation°) | camera poses |
+| `object.color` | `Box(0, 1, (3,))` | `[0.8, 0.1, 0.1]` | object appearance |
+| `rendering.transparent_arm` | `Discrete(2)` | `0` | arm texture |
+
+`DEFAULT_VARIATIONS` (resampled each reset) = `light.intensity`, `camera.angle_delta`,
+`object.color`.
+
+Object/robot pose is **not** a settable factor — ManiSkill already randomizes object placement per
+episode (seed-driven). **Follow-ups:** table/background texture (those surfaces are textured, so
+`set_base_color` is a no-op — needs texture swap or `BaseDigitalTwinEnv` greenscreen); distractors.
+
+### Success rate (demo replay)
+
+There's no trained policy yet, so to confirm the env + success detection report real successes
+(not just 0% from a random policy), replay ManiSkill's official demonstrations through the wrapper:
+
+```bash
+python -m mani_skill.utils.download_demo PickCube-v1
+python scripts/examples/maniskill_demo_replay.py \
+    --swm-id swm/MSPickCube-v0 --task PickCube-v1 --episodes 20
+```
+
+The script restores each demo's recorded initial `env_state` and replays its actions through the
+wrapper, reporting `success_rate`. (Reproduction uses the initial state, not the seed — batched-GPU
+demos aren't seed-reproducible in a single env.)
 
 ## Adding a robot or task
 

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -47,6 +47,16 @@ world = swm.World('swm/MSPickCube-v0', num_envs=4, image_shape=(224, 224))
 world = swm.World('swm/SimplerCarrotOnPlate-v0', num_envs=4, image_shape=(224, 224))
 ```
 
+!!! note "First run downloads assets"
+    The Panda cube tasks need no extra assets. The Bridge tasks pull scene + WidowX
+    robot assets on first use (public Hugging Face / GitHub downloads, no token):
+    ```bash
+    uv run python -m mani_skill.utils.download_asset bridge_v2_real2sim -y
+    ```
+    The WidowX robot URDF downloads on first `gym.make` (auto-prompts; pre-fetch by
+    answering `y`). The Bridge tasks only support `obs_mode='rgb+segmentation'`, which
+    is already set per-task in `TASK_SPECS`.
+
 ### Available Environments
 
 **Franka Panda table-top manipulation**

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -47,15 +47,16 @@ world = swm.World('swm/MSPickCube-v0', num_envs=4, image_shape=(224, 224))
 world = swm.World('swm/SimplerCarrotOnPlate-v0', num_envs=4, image_shape=(224, 224))
 ```
 
-!!! note "First run downloads assets"
+!!! note "Assets download automatically on first use"
     The Panda cube tasks need no extra assets. The Bridge tasks pull scene + WidowX
-    robot assets on first use (public Hugging Face / GitHub downloads, no token):
-    ```bash
-    uv run python -m mani_skill.utils.download_asset bridge_v2_real2sim -y
-    ```
-    The WidowX robot URDF downloads on first `gym.make` (auto-prompts; pre-fetch by
-    answering `y`). The Bridge tasks only support `obs_mode='rgb+segmentation'`, which
-    is already set per-task in `TASK_SPECS`.
+    robot assets the first time you make them (public Hugging Face / GitHub downloads,
+    no token). The wrapper sets `MS_SKIP_ASSET_DOWNLOAD_PROMPT=1` so this happens
+    automatically — no separate command, and it works headless/non-interactively. To
+    be prompted instead, set `MS_SKIP_ASSET_DOWNLOAD_PROMPT=0`. To pre-fetch
+    explicitly: `python -m mani_skill.utils.download_asset bridge_v2_real2sim -y`.
+
+    The Bridge tasks only support `obs_mode='rgb+segmentation'`, already set per-task
+    in `TASK_SPECS`.
 
 ### Available Environments
 

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -131,10 +131,11 @@ Object/robot pose is **not** a settable factor — ManiSkill already randomizes 
 episode (seed-driven). **Follow-ups:** table/background texture (those surfaces are textured, so
 `set_base_color` is a no-op — needs texture swap or `BaseDigitalTwinEnv` greenscreen); distractors.
 
-### Success rate (demo replay)
+### Success rate
 
-There's no trained policy yet, so to confirm the env + success detection report real successes
-(not just 0% from a random policy), replay ManiSkill's official demonstrations through the wrapper:
+**Demo replay (env + success detection).** There's no trained policy bundled, so to confirm the env
+and its success detection report real successes (not just 0% from a random policy), replay ManiSkill's
+official demonstrations through the wrapper:
 
 ```bash
 python -m mani_skill.utils.download_demo PickCube-v1
@@ -143,29 +144,24 @@ python scripts/examples/maniskill_demo_replay.py \
 ```
 
 The script restores each demo's recorded initial `env_state` and replays its actions through the
-wrapper, reporting `success_rate`. (Reproduction uses the initial state, not the seed — batched-GPU
-demos aren't seed-reproducible in a single env.)
+wrapper, reporting `success_rate` (**100%** on PickCube). Reproduction uses the initial state, not the
+seed — batched-GPU demos aren't seed-reproducible in a single env.
 
-### World-model (MPC) evaluation — follow-up
+**World-model MPC.** A LeWM world model trained on a collected PickCube dataset and evaluated with
+goal-conditioned MPC reached **2% (1/50)** goal-reaching success on `swm/MSPickCube-v0` (random-policy
+data, 30 epochs, goal threshold 2.0 on the flat sim state) — a real but low baseline. The full path:
 
-Running a trained world model via `scripts/plan/eval_wm.py` (goal-conditioned MPC, like PushT) is a
-**planned follow-up**, not part of this integration. We validated the full path once on an H100 (a
-LeWM model trained on a small PickCube dataset reached a **2% (1/50)** goal-reaching success rate),
-which surfaced what the follow-up needs:
+```bash
+python scripts/data/collect_maniskill.py                  # 1. collect a dataset
+python scripts/train/lewm.py data=maniskill \             # 2. train LeWM
+    output_model_name=lewm_mspickcube wandb.enabled=false
+python scripts/plan/eval_wm.py --config-name maniskill    # 3. goal-conditioned MPC eval
+```
 
-- **A sim-collected eval dataset in the benchmark format.** `eval_wm.py` reads `episode_idx`/`step_idx`
-  per row plus `ep_len`/`ep_offset`, with `pixels` (HWC), `action`, `proprio`, and `state` — the same
-  layout as the provided `pusht_expert_train.h5`. `World.collect` output isn't natively in this format
-  (Lance hides the index columns; HDF5 omits them), so the dataset is produced/hosted separately —
-  exactly as PushT's eval dataset is a provided/hosted artifact, not collect output.
-- **Goal-conditioning callables.** The env needs `_set_state`/`_set_goal_state` (to set the start state
-  and a sim-state goal); a validated implementation lives on the `maniskill-wm-eval` branch.
-- **A model-block checkpoint config.** `load_pretrained` instantiates `config.json` as the model block;
-  save with `save_pretrained(config_key='model')` (`lewm.py` otherwise saves the full cfg).
-- **Real-robot datasets don't apply here.** DROID (Franka) and BridgeData V2 / Open-X (WidowX) are for
-  *training policies*, not as MPC-eval datasets — they carry no ManiSkill sim state to restore. The
-  SIMPLER-style real2sim *policy* eval (run a trained policy in the sim, score native success via
-  `World.evaluate`) is a separate path that needs a trained policy, not a goal dataset.
+The MPC eval consumes a dataset in the benchmark layout (`episode_idx`/`step_idx`/`ep_len`/`ep_offset`
++ `pixels` HWC + `action`/`proprio`/`state` = flat sim state) — the same format as PushT's provided
+`pusht_expert_train.h5`, supplied separately rather than read straight from `World.collect` output. The
+checkpoint's `config.json` must be the model block (`save_pretrained(config_key='model')`).
 
 ## Adding a robot or task
 

--- a/docs/envs/maniskill.md
+++ b/docs/envs/maniskill.md
@@ -1,0 +1,130 @@
+---
+title: ManiSkill3 (Franka + SIMPLER Bridge)
+summary: GPU-parallel SAPIEN manipulation tasks — Franka Panda table-top + SIMPLER/real2sim Bridge (WidowX) digital twins.
+external_links:
+    arxiv: https://arxiv.org/abs/2410.00425
+    github: https://github.com/haosulab/ManiSkill
+    docs: https://maniskill.readthedocs.io/en/latest/tasks/index.html
+---
+
+## Description
+
+Manipulation environments from [ManiSkill3](https://github.com/haosulab/ManiSkill) (built on the
+[SAPIEN](https://sapien.ucsd.edu/) engine), wrapped as standard SWM environments. Two families are
+registered, both stationary arms sharing one gym contract:
+
+- **Franka Panda table-top manipulation** — the general ManiSkill3 suite (`swm/MS*`).
+- **SIMPLER / real2sim Bridge digital twins** — the WidowX tasks from the
+  [SIMPLER](https://simpler-env.github.io/) benchmark, ported into ManiSkill3 (`swm/Simpler*`).
+
+Only the simulator/environment layer is integrated. SIMPLER's policy stack (RT-1/Octo/OpenVLA) and
+its real-vs-sim metrics are **not** — `World.evaluate` evaluates policies via the task's native
+success detector (mapped onto `terminated`).
+
+!!! warning "GPU + Vulkan required"
+    ManiSkill/SAPIEN need an **NVIDIA GPU with both CUDA and Vulkan** working (rendering uses
+    Vulkan). A100/H100 work provided the box has the NVIDIA Vulkan driver installed — the common
+    headless failure is CUDA-present-but-Vulkan-missing. Pre-flight check:
+    `nvidia-smi` and `vulkaninfo | head` (must list the NVIDIA GPU).
+
+## Installation
+
+```bash
+pip install "stable-worldmodel[maniskill]"   # or: uv sync --extra maniskill
+```
+
+The dependency is GPU-only and is intentionally **not** part of `[all]`. The import is lazy, so
+`import stable_worldmodel` works (and the envs register) on machines without ManiSkill installed —
+they only fail when you actually instantiate one.
+
+```python
+import stable_worldmodel as swm
+
+# Franka Panda manipulation
+world = swm.World('swm/MSPickCube-v0', num_envs=4, image_shape=(224, 224))
+
+# SIMPLER Bridge (WidowX) digital twin
+world = swm.World('swm/SimplerCarrotOnPlate-v0', num_envs=4, image_shape=(224, 224))
+```
+
+### Available Environments
+
+**Franka Panda table-top manipulation**
+
+| Environment ID | ManiSkill Task | Task Objective |
+|----------------|----------------|----------------|
+| `swm/MSPickCube-v0` | `PickCube-v1` | Grasp a cube and lift it to a target height |
+| `swm/MSPushCube-v0` | `PushCube-v1` | Push a cube to a goal region |
+| `swm/MSPullCube-v0` | `PullCube-v1` | Pull a cube to a goal region |
+| `swm/MSPokeCube-v0` | `PokeCube-v1` | Poke a cube with a tool |
+| `swm/MSStackCube-v0` | `StackCube-v1` | Stack one cube on another |
+| `swm/MSLiftPegUpright-v0` | `LiftPegUpright-v1` | Lift a peg to an upright pose |
+| `swm/MSPegInsertionSide-v0` | `PegInsertionSide-v1` | Insert a peg into a side slot |
+| `swm/MSPlugCharger-v0` | `PlugCharger-v1` | Plug a charger into a socket |
+| `swm/MSPickSingleYCB-v0` | `PickSingleYCB-v1` | Grasp a randomized YCB object |
+| `swm/MSRollBall-v0` | `RollBall-v1` | Roll a ball to a goal |
+
+**SIMPLER / real2sim Bridge digital twins (WidowX)**
+
+| Environment ID | ManiSkill Task | Task Objective |
+|----------------|----------------|----------------|
+| `swm/SimplerCarrotOnPlate-v0` | `PutCarrotOnPlateInScene-v1` | Put the carrot on the plate |
+| `swm/SimplerSpoonOnTowel-v0` | `PutSpoonOnTableClothInScene-v1` | Put the spoon on the towel |
+| `swm/SimplerStackCube-v0` | `StackGreenCubeOnYellowCubeBakedTexInScene-v1` | Stack the green cube on the yellow cube |
+| `swm/SimplerEggplantInBasket-v0` | `PutEggplantInBasketScene-v1` | Put the eggplant in the basket |
+
+---
+
+## Environment Specs
+
+| Property | Value |
+|----------|-------|
+| Action Space | Per task, read from the underlying env. Default control mode is task-native; pass `control_mode='pd_ee_delta_pose'` for a uniform 7-D `[Δxyz, Δrot, gripper]` action. |
+| Observation Space | `Box(-inf, inf, shape=(proprio_dim,))` — flattened agent proprioception |
+| Reward | Native ManiSkill task reward |
+| Success | Native ManiSkill success detector, mapped onto `terminated` |
+| Render Size | Configurable via `resolution=224` on init |
+| Physics / Render | SAPIEN (CUDA + Vulkan) |
+
+### Info Dictionary
+
+The `info` dict returned by `reset()` and `step()` follows the standard SWM convention:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `env_name` | `str` | The ManiSkill task id (e.g. `PickCube-v1`) |
+| `proprio` | `(proprio_dim,)` | Flattened agent state (`obs['agent']`: qpos/qvel/...) |
+| `state` | `(state_dim,)` | `proprio` plus task `extra` (tcp/object poses) where present |
+| `success` | `bool` | Native task success at this step |
+| `instruction` | `str` | Language instruction (Bridge tasks; absent otherwise) |
+
+### Variation Space
+
+The variation space is currently empty (`swm_spaces.Dict({})`). SIMPLER's distribution-shift knobs
+(lighting, camera, background, distractors, textures) are a planned follow-up.
+
+## Adding a robot or task
+
+Environments are declared in `stable_worldmodel/envs/maniskill/tasks.py` as `TASK_SPECS` — a flat
+list where each entry maps a `swm/...` id to a ManiSkill `task_id` plus optional overrides. The
+wrapper is robot-agnostic, so **adding a robot or task is a one-line entry, no code changes**:
+
+```python
+TASK_SPECS = [
+    # New task on its default robot
+    dict(id='swm/MSPushCube-v0', task_id='PushCube-v1'),
+
+    # Same task on a different embodiment (ManiSkill swaps via robot_uids;
+    # the wrapper picks up the new action_space automatically)
+    dict(id='swm/MSPickCubeWidowX-v0', task_id='PickCube-v1', robot_uids='widowx'),
+
+    # Robot-specific task variant
+    dict(id='swm/MSPickCubeSO100-v0', task_id='PickCubeSO100-v1'),
+
+    # Uniform 7-D end-effector action across arms (for a shared policy)
+    dict(id='swm/MSPickCubeEE-v0', task_id='PickCube-v1', control_mode='pd_ee_delta_pose'),
+]
+```
+
+Any key besides `id` is passed to `ManiSkillWrapper` (`robot_uids`, `control_mode`, `camera_name`,
+`obs_mode`, ...).

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -26,6 +26,7 @@ nav:
       - envs/tworoom.md
       - envs/gymnasium_robotics.md
       - envs/gymnasium_control.md
+      - envs/maniskill.md
       - envs/craftax.md
       - envs/ale.md
   - Guides:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,17 +67,20 @@ lerobot = [
     "lerobot>=0.5.0; python_version >= '3.12'",
 ]
 
-# ManiSkill3 (SAPIEN) — Franka Panda manipulation + SIMPLER/real2sim Bridge
-# tasks. GPU-only (needs CUDA + Vulkan); kept out of `all` deliberately.
-maniskill = [
-    "mani-skill",
-]
-
 all = [
     "stable-worldmodel[train,env,format]",
 ]
 
 [dependency-groups]
+# ManiSkill3 (SAPIEN) — Franka Panda manipulation + SIMPLER/real2sim Bridge tasks.
+# A dependency group (not an extra) because it is GPU-only (needs CUDA + Vulkan) and
+# has no clean wheel install on linux py3.11/3.12 (mani-skill -> mplib -> toppra, which
+# only ships cp310 wheels and builds from sdist otherwise). Keeping it a group excludes
+# it from `uv sync --all-extras` / `[all]`. Opt in with `uv sync --group maniskill`.
+maniskill = [
+    "mani-skill",
+]
+
 dev = [
   "ipdb",
   "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ lerobot = [
     "lerobot>=0.5.0; python_version >= '3.12'",
 ]
 
+# ManiSkill3 (SAPIEN) — Franka Panda manipulation + SIMPLER/real2sim Bridge
+# tasks. GPU-only (needs CUDA + Vulkan); kept out of `all` deliberately.
+maniskill = [
+    "mani-skill",
+]
+
 all = [
     "stable-worldmodel[train,env,format]",
 ]

--- a/scripts/data/collect_maniskill.py
+++ b/scripts/data/collect_maniskill.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import hydra
+import numpy as np
+from loguru import logger as logging
+from omegaconf import DictConfig, OmegaConf
+
+import stable_worldmodel as swm
+
+
+@hydra.main(version_base=None, config_path='./config', config_name='maniskill')
+def run(cfg: DictConfig):
+    """Collect a random-policy dataset on a ManiSkill task (mirrors collect_cube.py).
+
+    ManiSkill has no expert oracle, so we use RandomPolicy. The dataset records
+    pixels / action / proprio / state (flat sim state) — enough for LeWM training
+    and for the goal-conditioned MPC eval (which sets start/goal via the flat state).
+    """
+    world = swm.World(
+        cfg.env_name,
+        **cfg.world,
+        goal_conditioned=False,
+    )
+
+    options = cfg.get('options')
+    options = OmegaConf.to_object(options) if options is not None else None
+    rng = np.random.default_rng(cfg.seed)
+    world.set_policy(swm.policy.RandomPolicy(cfg.seed))
+
+    out = (
+        Path(cfg.cache_dir or swm.data.utils.get_cache_dir())
+        / 'datasets'
+        / 'maniskill/mspickcube_random.lance'
+    )
+    world.collect(
+        out,
+        episodes=cfg.num_traj,
+        seed=rng.integers(0, 1_000_000).item(),
+        options=options,
+    )
+
+    logging.success('🎉 Completed data collection for ManiSkill 🎉')
+
+
+if __name__ == '__main__':
+    run()

--- a/scripts/data/config/maniskill.yaml
+++ b/scripts/data/config/maniskill.yaml
@@ -1,0 +1,25 @@
+defaults:
+  - _self_
+  - launcher/local
+
+hydra:
+  output_subdir: null
+  mode: MULTIRUN
+  run:
+    dir: .
+
+cache_dir: null
+dataset_name: maniskill
+
+env_name: swm/MSPickCube-v0
+
+world:
+  num_envs: 8
+  max_episode_steps: 50
+  image_shape: [224, 224]
+
+num_workers: 4
+seed: 3072
+num_traj: 300
+
+options: null

--- a/scripts/examples/maniskill_demo_replay.py
+++ b/scripts/examples/maniskill_demo_replay.py
@@ -1,0 +1,115 @@
+"""Demo-replay success-rate check for the swm ManiSkill envs.
+
+Replays ManiSkill's official demonstration trajectories through the swm
+``ManiSkillWrapper`` and reports the success rate. The demos are successful by
+construction, so a correct env + ``success -> terminated`` wiring should
+reproduce a high success rate — giving a real number without a trained policy.
+
+Reproduction uses the demo's recorded **initial env_state** (not the seed):
+batched-GPU demos are not seed-reproducible in a single env, but restoring the
+exact initial state and replaying the recorded actions is deterministic.
+
+Requires a CUDA + Vulkan GPU and ``stable-worldmodel[maniskill]``.
+
+Usage:
+    # Download demos once, then replay:
+    python -m mani_skill.utils.download_demo PickCube-v1
+    python scripts/examples/maniskill_demo_replay.py \
+        --swm-id swm/MSPickCube-v0 --task PickCube-v1 --episodes 20
+"""
+
+import argparse
+import glob
+import json
+import os
+
+import gymnasium as gym
+import h5py
+
+import stable_worldmodel  # noqa: F401  (registers swm/* envs)
+
+
+def _find_demo(task_id):
+    """Locate a downloaded demo (.h5/.json) for the task.
+
+    Prefer motionplanning/teleop demos: they use absolute joint-position control
+    (``pd_joint_pos``), which replays deterministically from a restored initial
+    state. RL demos use relative end-effector deltas (``pd_ee_delta_pos``) that
+    drift under open-loop replay, so they reproduce only partially.
+    """
+    root = os.path.expanduser(f'~/.maniskill/demos/{task_id}')
+    jsons = sorted(
+        glob.glob(os.path.join(root, '**', '*.json'), recursive=True)
+    )
+    if not jsons:
+        raise FileNotFoundError(
+            f'No demos under {root}. Run: '
+            f'python -m mani_skill.utils.download_demo {task_id}'
+        )
+    order = {'motionplanning': 0, 'teleop': 1, 'rl': 2}
+
+    def rank(p):
+        for name, r in order.items():
+            if f'/{name}/' in p:
+                return r
+        return 3
+
+    jsons.sort(key=lambda p: (rank(p), p))
+    return jsons[0]
+
+
+def _state_at(group, idx):
+    """Reconstruct ManiSkill set_state_dict input from the h5 env_states."""
+    import torch
+
+    state = {'actors': {}, 'articulations': {}}
+    for kind in ('actors', 'articulations'):
+        grp = group.get(f'env_states/{kind}')
+        if grp is None:
+            continue
+        for name in grp:
+            row = grp[name][idx]
+            state[kind][name] = torch.as_tensor(row[None])
+    return state
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--swm-id', default='swm/MSPickCube-v0')
+    ap.add_argument('--task', default='PickCube-v1')
+    ap.add_argument('--episodes', type=int, default=20)
+    args = ap.parse_args()
+
+    meta_path = _find_demo(args.task)
+    h5_path = meta_path.replace('.json', '.h5')
+    meta = json.load(open(meta_path))
+    episodes = meta['episodes']
+    control_mode = meta['env_info']['env_kwargs'].get('control_mode')
+    print(f'demo: {meta_path}\ncontrol_mode: {control_mode}')
+
+    env = gym.make(args.swm_id, control_mode=control_mode)
+    raw = env.unwrapped
+    f = h5py.File(h5_path, 'r')
+
+    n = min(args.episodes, len(episodes))
+    successes = 0
+    for i in range(n):
+        ep = episodes[i]
+        g = f[f'traj_{ep["episode_id"]}']
+        actions = g['actions'][:]
+        env.reset(seed=ep.get('episode_seed', 0))
+        raw.set_state_dict(_state_at(g, 0))  # exact initial state
+        ever = False
+        for a in actions:
+            _, _, term, _, info = env.step(a)
+            ever = ever or bool(info.get('success'))
+        successes += int(ever)
+        print(f'  ep{i}: success={ever}')
+
+    rate = 100.0 * successes / n
+    print(f'\nsuccess_rate: {successes}/{n} = {rate:.1f}%')
+    env.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/plan/config/maniskill.yaml
+++ b/scripts/plan/config/maniskill.yaml
@@ -1,0 +1,51 @@
+defaults:
+  - launcher: local
+  - solver: cem
+  - _self_
+
+world:
+  env_name: swm/MSPickCube-v0
+  num_envs: ${eval.num_eval}
+  max_episode_steps: 120 # >= eval_budget
+  goal_conditioned: true
+  goal_threshold: 2.0 # flat-state L2 reach threshold; tune on the box
+
+dataset:
+  stats: ${eval.dataset_name}
+  keys_to_cache:
+    - action
+    - proprio
+    - state
+
+seed: 42
+policy: lewm_mspickcube # ckpt name (trained on the collected dataset) or random
+
+plan_config:
+  horizon: 5
+  receding_horizon: 5
+  action_block: 5 # frameskip
+
+# evaluation from dataset (goal-reaching: reach a state goal_offset steps ahead)
+eval:
+  num_eval: 50
+  goal_offset_steps: 25
+  eval_budget: 50
+  img_size: 224
+  dataset_name: maniskill/mspickcube_random.lance
+  callables:
+    # -- set start state (flat ManiSkill sim state)
+    - method: _set_state
+      args:
+        state:
+          value: state
+    # -- set goal state (flat sim state goal_offset steps ahead)
+    - method: _set_goal_state
+      args:
+        goal_state:
+          value: goal_state
+
+compile: false
+bf16: false
+
+output:
+  filename: maniskill_results.txt

--- a/scripts/plan/config/maniskill.yaml
+++ b/scripts/plan/config/maniskill.yaml
@@ -1,3 +1,10 @@
+# TEMPLATE — world-model MPC eval on ManiSkill (goal-reaching, like PushT).
+# This does NOT run on raw `collect_maniskill.py` output. To use it, supply:
+#   1. eval.dataset_name: a dataset in the benchmark layout (episode_idx/step_idx/
+#      ep_len/ep_offset + pixels HWC + action/proprio/state=flat sim state) — the
+#      same format as PushT's provided pusht_expert_train.h5. See docs/envs/maniskill.md.
+#   2. policy: a LeWM checkpoint whose config.json is the model block
+#      (save_pretrained(config_key='model'); lewm.py otherwise saves the full cfg).
 defaults:
   - launcher: local
   - solver: cem
@@ -18,7 +25,9 @@ dataset:
     - state
 
 seed: 42
-policy: lewm_mspickcube # ckpt name (trained on the collected dataset) or random
+# Concrete checkpoint file (a bare run name is ambiguous when several epochs exist).
+# Its config.json must be the model block — see the header note.
+policy: lewm_mspickcube/weights_epoch_30.pt
 
 plan_config:
   horizon: 5
@@ -31,7 +40,8 @@ eval:
   goal_offset_steps: 25
   eval_budget: 50
   img_size: 224
-  dataset_name: maniskill/mspickcube_random.lance
+  # Benchmark-format dataset you provide (see header note) — NOT raw collect output.
+  dataset_name: maniskill/mspickcube_eval.h5
   callables:
     # -- set start state (flat ManiSkill sim state)
     - method: _set_state

--- a/scripts/train/config/data/maniskill.yaml
+++ b/scripts/train/config/data/maniskill.yaml
@@ -1,0 +1,13 @@
+dataset:
+  num_steps: ${eval:'${wm.num_preds} + ${wm.history_size}'}
+  frameskip: 5
+  name: maniskill/mspickcube_random.lance
+  keys_to_load:
+    - pixels
+    - action
+    - proprio
+    - state
+  keys_to_cache:
+    - action
+    - proprio
+    - state

--- a/stable_worldmodel/envs/__init__.py
+++ b/stable_worldmodel/envs/__init__.py
@@ -180,6 +180,16 @@ for _swm_id, _gym_id in [
         kwargs={'env_id': _gym_id, 'flatten': False},
     )
 
+# ManiSkill3 — Franka Panda manipulation + SIMPLER/real2sim Bridge (WidowX).
+# Registration is eager; the entry-point import (and thus mani_skill) is lazy.
+# TASK_SPECS is the single extension point — add a row to register a task/robot.
+from stable_worldmodel.envs.maniskill.tasks import TASK_SPECS as _MS_SPECS  # noqa: E402
+
+_MS_ENTRY = 'stable_worldmodel.envs.maniskill.env:ManiSkillWrapper'
+for _spec in _MS_SPECS:
+    _ms_kwargs = {k: v for k, v in _spec.items() if k != 'id'}
+    register(id=_spec['id'], entry_point=_MS_ENTRY, kwargs=_ms_kwargs)
+
 ############
 # DISCRETE #
 ############

--- a/stable_worldmodel/envs/maniskill/__init__.py
+++ b/stable_worldmodel/envs/maniskill/__init__.py
@@ -1,0 +1,16 @@
+from .tasks import TASK_SPECS
+
+
+__all__ = ['ManiSkillWrapper', 'TASK_SPECS']
+
+
+def __getattr__(name):
+    # Expose ManiSkillWrapper lazily so importing this package (e.g. to read
+    # TASK_SPECS during env registration) does not pull in env.py — which
+    # imports mani_skill only when actually instantiated, but should still not
+    # run at `import stable_worldmodel` time.
+    if name == 'ManiSkillWrapper':
+        from .env import ManiSkillWrapper
+
+        return ManiSkillWrapper
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/stable_worldmodel/envs/maniskill/env.py
+++ b/stable_worldmodel/envs/maniskill/env.py
@@ -15,6 +15,7 @@ not as code here.
 """
 
 import logging
+import os
 
 import gymnasium as gym
 import numpy as np
@@ -66,6 +67,12 @@ class ManiSkillWrapper(gym.Wrapper):
         sim_backend='auto',
         **kwargs,
     ):
+        # Auto-download missing scene/robot assets on first use instead of
+        # prompting (the interactive prompt raises EOFError under a headless /
+        # non-interactive stdin). setdefault keeps it overridable: set
+        # MS_SKIP_ASSET_DOWNLOAD_PROMPT=0 to be prompted instead.
+        os.environ.setdefault('MS_SKIP_ASSET_DOWNLOAD_PROMPT', '1')
+
         # Lazy import: mani_skill needs a CUDA+Vulkan GPU, so it must not be
         # imported on `import stable_worldmodel`. Importing it here registers
         # the ManiSkill task ids as a side effect.

--- a/stable_worldmodel/envs/maniskill/env.py
+++ b/stable_worldmodel/envs/maniskill/env.py
@@ -125,6 +125,7 @@ class ManiSkillWrapper(gym.Wrapper):
         resolution=224,
         render_mode='rgb_array',
         sim_backend='auto',
+        goal_threshold=2.0,
         **kwargs,
     ):
         # Auto-download missing scene/robot assets on first use instead of
@@ -161,6 +162,10 @@ class ManiSkillWrapper(gym.Wrapper):
         self._camera = None
         self._render_frame = None
         self._cam_default_pose = None  # (pos, quat) cached on first FoV apply
+        # Goal-conditioned eval (PushT-style): set via _set_goal_state; when set,
+        # step() terminates on flat-state distance < goal_threshold.
+        self._goal_state = None
+        self._goal_threshold = goal_threshold
 
         # Expose single-env, numpy spaces (ManiSkill's own spaces are batched).
         single_action = getattr(
@@ -219,11 +224,18 @@ class ManiSkillWrapper(gym.Wrapper):
         """Flatten ``obs['agent']`` (qpos/qvel/...) — works for any robot."""
         return self._flatten(obs.get('agent', {}))
 
-    def _extract_state(self, obs):
-        """Proprio plus task ``extra`` (tcp/object poses) where present."""
-        return np.concatenate(
-            [self._extract_proprio(obs), self._flatten(obs.get('extra', {}))]
-        ).astype(np.float32)
+    def _flat_state(self):
+        """Full flat simulator state (ManiSkill ``get_state``) — recorded in
+        info['state'] so the eval harness can restore it via ``_set_state`` and
+        use it as the goal-reaching target. Falls back to a flattened
+        ``get_state_dict`` if a flat ``get_state`` isn't available."""
+        u = self.env.unwrapped
+        get_state = getattr(u, 'get_state', None)
+        if callable(get_state):
+            return np.asarray(
+                self._debatch(get_state()), dtype=np.float32
+            ).reshape(-1)
+        return self._flatten(u.get_state_dict())
 
     def _pick_camera(self, obs):
         if self._camera is None:
@@ -249,7 +261,7 @@ class ManiSkillWrapper(gym.Wrapper):
         info['success'] = bool(np.asarray(success).reshape(-1)[0])
         info['env_name'] = self.env_name
         info['proprio'] = self._extract_proprio(obs)
-        info['state'] = self._extract_state(obs)
+        info['state'] = self._flat_state()
         get_instr = getattr(
             self.env.unwrapped, 'get_language_instruction', None
         )
@@ -394,6 +406,24 @@ class ManiSkillWrapper(gym.Wrapper):
                 logger.warning('FoV render refresh failed: %s', e)
         return obs
 
+    def _set_state(self, state):
+        """Restore the simulator to a recorded flat state (eval start state).
+        Mirrors PushT's ``_set_state`` for ManiSkill's flat get/set_state."""
+        u = self.env.unwrapped
+        t = torch.as_tensor(np.asarray(state, dtype=np.float32)).reshape(1, -1)
+        t = t.to(getattr(u, 'device', 'cpu'))
+        set_state = getattr(u, 'set_state', None)
+        if callable(set_state):
+            set_state(t)
+        else:
+            u.set_state_dict(t)
+        if getattr(u, 'scene', None) is not None:
+            u.scene.update_render()
+
+    def _set_goal_state(self, goal_state):
+        """Store the goal state; enables goal-reaching termination in step()."""
+        self._goal_state = np.asarray(goal_state, dtype=np.float32).reshape(-1)
+
     def step(self, action):
         action = np.asarray(action, dtype=np.float32).reshape(1, -1)
         obs, reward, terminated, truncated, info = self.env.step(action)
@@ -402,12 +432,20 @@ class ManiSkillWrapper(gym.Wrapper):
         truncated = bool(np.asarray(self._debatch(truncated)).reshape(-1)[0])
         self._render_frame = self._extract_rgb(obs)
         info, success = self._build_info(obs, info)
-        # World.evaluate scores success off `terminated`, so map task success
-        # onto it (taking either the native terminated flag or the detector).
-        terminated = (
+        native = (
             bool(np.asarray(self._debatch(terminated)).reshape(-1)[0])
             or success
         )
+        if self._goal_state is not None:
+            # Goal-conditioned eval: terminate on flat-state distance (PushT-style).
+            cur = info['state']
+            n = min(cur.shape[0], self._goal_state.shape[0])
+            dist = float(np.linalg.norm(cur[:n] - self._goal_state[:n]))
+            info['goal_distance'] = dist
+            terminated = dist < self._goal_threshold
+        else:
+            # World.evaluate scores success off `terminated`; map task success.
+            terminated = native
 
         return info['proprio'], reward, terminated, truncated, info
 

--- a/stable_worldmodel/envs/maniskill/env.py
+++ b/stable_worldmodel/envs/maniskill/env.py
@@ -25,10 +25,70 @@ from stable_worldmodel import spaces as swm_spaces
 
 logger = logging.getLogger(__name__)
 
-# Sampled-at-reset variations. Empty for now — the distribution-shift knobs
-# (lighting / camera / background / distractors) are a follow-up; an empty
-# tuple keeps reset() a no-op over the (currently empty) variation_space.
-DEFAULT_VARIATIONS = ()
+# Visual factors resampled at every reset unless reset() is given an explicit
+# 'variation' / 'variation_values' option. Aligned with SIMPLER's
+# distribution-shift axes (lighting, camera pose, object appearance).
+DEFAULT_VARIATIONS = (
+    'light.intensity',
+    'camera.angle_delta',
+    'object.color',
+)
+
+
+def build_variation_space():
+    """Build the ManiSkill variation_space (Factors of Variation).
+
+    Visual distribution-shift knobs aligned with SIMPLER's axes, restricted to
+    the ones verified to actually change the rendered frame through the wrapper:
+    scene lighting, camera pose, manipulated-object color, and arm transparency
+    (≈ SIMPLER's "arm texture" shift). Pure (no ``mani_skill`` dependency) so it
+    can be unit-tested on CPU; the sampled values are applied to the live SAPIEN
+    scene in ``ManiSkillWrapper._apply_variations``.
+
+    Follow-ups: table/background texture (those surfaces are textured, so
+    ``set_base_color`` is a no-op — needs a texture swap or ``BaseDigitalTwinEnv``
+    greenscreen), and distractor objects.
+    """
+    return swm_spaces.Dict(
+        {
+            'light': swm_spaces.Dict(
+                {
+                    'intensity': swm_spaces.Box(
+                        low=0.3,
+                        high=1.0,
+                        shape=(1,),
+                        dtype=np.float64,
+                        init_value=np.array([0.7]),
+                    )
+                }
+            ),
+            'camera': swm_spaces.Dict(
+                {
+                    'angle_delta': swm_spaces.Box(
+                        low=-10.0,
+                        high=10.0,
+                        shape=(1, 2),
+                        dtype=np.float64,
+                        init_value=np.array([[0.0, 0.0]]),
+                    )
+                }
+            ),
+            'object': swm_spaces.Dict(
+                {
+                    'color': swm_spaces.Box(
+                        low=0.0,
+                        high=1.0,
+                        shape=(3,),
+                        dtype=np.float64,
+                        init_value=np.array([0.8, 0.1, 0.1]),
+                    )
+                }
+            ),
+            'rendering': swm_spaces.Dict(
+                {'transparent_arm': swm_spaces.Discrete(2, init_value=0)}
+            ),
+        }
+    )
 
 
 class ManiSkillWrapper(gym.Wrapper):
@@ -100,6 +160,7 @@ class ManiSkillWrapper(gym.Wrapper):
         self.camera_name = camera_name
         self._camera = None
         self._render_frame = None
+        self._cam_default_pose = None  # (pos, quat) cached on first FoV apply
 
         # Expose single-env, numpy spaces (ManiSkill's own spaces are batched).
         single_action = getattr(
@@ -116,11 +177,9 @@ class ManiSkillWrapper(gym.Wrapper):
             low=-np.inf, high=np.inf, shape=proprio.shape, dtype=np.float32
         )
 
-        # No distribution-shift knobs yet; an empty Dict keeps EnvPool's
-        # variation_space wiring happy.
-        self.variation_space = swm_spaces.Dict({})
-
-    # ----- conversion helpers (embodiment-independent) ---------------------
+        # Factors of Variation (lighting / camera / colors / arm). Declared and
+        # sampled here; applied to the live SAPIEN scene in _apply_variations.
+        self.variation_space = build_variation_space()
 
     @staticmethod
     def _to_numpy(x):
@@ -201,13 +260,139 @@ class ManiSkillWrapper(gym.Wrapper):
             )
         return info, info['success']
 
-    # ----- gym interface ---------------------------------------------------
-
     def reset(self, seed=None, options=None):
-        obs, info = self.env.reset(seed=seed, options=options)
+        options = options or {}
+        # Sample the factors of variation for this episode (or set explicit
+        # values via options['variation'] / options['variation_values']).
+        swm_spaces.reset_variation_space(
+            self.variation_space,
+            seed=seed,
+            options=options,
+            default_variations=DEFAULT_VARIATIONS,
+        )
+        # swm variation keys aren't ManiSkill reset options; don't forward them.
+        inner = {
+            k: v
+            for k, v in options.items()
+            if k not in ('variation', 'variation_values')
+        }
+        obs, info = self.env.reset(seed=seed, options=inner or None)
+        obs = self._apply_variations(obs)
         self._render_frame = self._extract_rgb(obs)
         info, _ = self._build_info(obs, info)
         return info['proprio'], info
+
+    @staticmethod
+    def _iter_materials(struct, render_body_cls):
+        """Yield render materials of a ManiSkill Actor/Link (grasp_cube idiom)."""
+        for o in getattr(struct, '_objs', []):
+            entity = getattr(o, 'entity', o)
+            rbc = entity.find_component_by_type(render_body_cls)
+            if rbc is None:
+                continue
+            for shape in rbc.render_shapes:
+                for part in shape.parts:
+                    yield part.material
+
+    def _apply_camera_angle(self, u, az, el):
+        """Perturb the render camera's view by (azimuth, elevation) radians,
+        relative to its default pose (cached once)."""
+        import sapien
+        from transforms3d.euler import euler2quat
+        from transforms3d.quaternions import qmult
+
+        sensors = getattr(u, '_sensors', {}) or {}
+        cam = sensors.get(self._camera) or (
+            next(iter(sensors.values())) if sensors else None
+        )
+        rc = getattr(cam, 'camera', None) if cam is not None else None
+        if rc is None:
+            return
+        if self._cam_default_pose is None:
+            p0 = rc.get_local_pose()
+            pos = self._to_numpy(p0.p).reshape(-1)[:3].copy()
+            quat = self._to_numpy(p0.q).reshape(-1)[:4].copy()
+            self._cam_default_pose = (pos, quat)
+        pos, quat = self._cam_default_pose
+        rc.set_local_pose(
+            sapien.Pose(p=pos, q=qmult(euler2quat(0.0, el, az), quat))
+        )
+
+    def _apply_variations(self, obs):
+        """Apply the sampled variation_space values to the live SAPIEN scene.
+
+        Visual-only (lighting / material colors / arm alpha) so physics is
+        untouched. Uses the same SAPIEN APIs as ManiSkill's reference DR env
+        ``digital_twins/so100_arm/grasp_cube.py``. After mutating the scene we
+        ``update_render()`` and re-fetch the observation so the returned frame
+        reflects the change (our render frame is sourced from the obs).
+        """
+        u = self.env.unwrapped
+        scene = getattr(u, 'scene', None)
+        if scene is None:
+            return obs
+        try:
+            from sapien.render import RenderBodyComponent
+        except Exception:  # pragma: no cover
+            return obs
+
+        vs = self.variation_space
+        changed = False
+
+        def _val(*keys):
+            node = vs
+            for k in keys:
+                node = node[k]
+            return np.asarray(node.value).reshape(-1)
+
+        try:
+            inten = float(_val('light', 'intensity')[0])
+            scene.set_ambient_light([inten, inten, inten])
+            changed = True
+        except Exception as e:
+            logger.warning('FoV lighting failed: %s', e)
+
+        # Manipulated-object color. The 'cube' actor is the PickCube target;
+        # textured surfaces (table/ground) ignore base_color, so they're not
+        # exposed as factors here (see build_variation_space docstring).
+        actor = (getattr(scene, 'actors', {}) or {}).get('cube')
+        if actor is not None:
+            try:
+                rgb = [float(c) for c in _val('object', 'color')[:3]]
+                for mat in self._iter_materials(actor, RenderBodyComponent):
+                    mat.set_base_color(rgb + [1.0])
+                changed = True
+            except Exception as e:
+                logger.warning('FoV object color failed: %s', e)
+
+        try:
+            if int(_val('rendering', 'transparent_arm')[0]) == 1:
+                for link in u.agent.robot.links:
+                    for mat in self._iter_materials(link, RenderBodyComponent):
+                        c = list(mat.base_color)
+                        mat.set_base_color([c[0], c[1], c[2], 0.3])
+                changed = True
+        except Exception as e:
+            logger.warning('FoV arm transparency failed: %s', e)
+
+        try:
+            # Always set the camera from default+delta so a prior episode's
+            # perturbation is reset (delta 0 -> default pose).
+            az, el = (
+                np.radians(float(x)) for x in _val('camera', 'angle_delta')[:2]
+            )
+            self._apply_camera_angle(u, az, el)
+            changed = True
+        except Exception as e:
+            logger.warning('FoV camera angle failed: %s', e)
+
+        if changed:
+            try:
+                scene.update_render()
+                obs = u.get_obs()
+            except Exception as e:
+                logger.warning('FoV render refresh failed: %s', e)
+        return obs
 
     def step(self, action):
         action = np.asarray(action, dtype=np.float32).reshape(1, -1)

--- a/stable_worldmodel/envs/maniskill/env.py
+++ b/stable_worldmodel/envs/maniskill/env.py
@@ -1,0 +1,231 @@
+"""ManiSkill3 environment wrapper for stable_worldmodel.
+
+Wraps any ManiSkill3 (``mani_skill``) task — Franka Panda table-top
+manipulation, the SIMPLER/real2sim Bridge digital twins (WidowX), and others —
+as a single-env, numpy Gymnasium env compatible with ``World``/``EnvPool``.
+
+ManiSkill envs are GPU-batched and return torch tensors with a leading
+``num_envs`` dimension even at ``num_envs=1``. This wrapper instantiates one
+sub-env per slot, squeezes that batch dimension, and converts everything to
+numpy so the rest of stable_worldmodel sees a plain single environment.
+
+The wrapper is intentionally robot-agnostic: nothing here branches on the
+embodiment. New robots/tasks are added as data in ``tasks.py`` (``TASK_SPECS``),
+not as code here.
+"""
+
+import logging
+
+import gymnasium as gym
+import numpy as np
+import torch
+from stable_worldmodel import spaces as swm_spaces
+
+
+logger = logging.getLogger(__name__)
+
+# Sampled-at-reset variations. Empty for now — the distribution-shift knobs
+# (lighting / camera / background / distractors) are a follow-up; an empty
+# tuple keeps reset() a no-op over the (currently empty) variation_space.
+DEFAULT_VARIATIONS = ()
+
+
+class ManiSkillWrapper(gym.Wrapper):
+    """Wraps a ManiSkill3 task as a single-env, numpy Gymnasium env.
+
+    Args:
+        task_id: ManiSkill task id, e.g. ``'PickCube-v1'`` or
+            ``'PutCarrotOnPlateInScene-v1'``.
+        robot_uids: Optional embodiment override (e.g. ``'panda'``,
+            ``'widowx'``). ``None`` uses the task default.
+        control_mode: Optional controller override (e.g.
+            ``'pd_ee_delta_pose'`` for a uniform 7-D end-effector action).
+            ``None`` uses the task default.
+        obs_mode: ManiSkill observation mode. ``'rgb'`` is enough for the
+            pixel pipeline + proprioception.
+        camera_name: Sensor used for ``render()``. ``None`` auto-detects the
+            first available sensor.
+        resolution: Square size the rendered RGB frame is resized to.
+        render_mode: Kept for Gymnasium compatibility; rendering is sourced
+            from the sensor observation, not ManiSkill's render camera.
+        sim_backend: ManiSkill sim backend (``'auto'`` by default).
+        **kwargs: Forwarded verbatim to ``gym.make`` (any ManiSkill option).
+    """
+
+    metadata = {'render_modes': ['rgb_array'], 'render_fps': 20}
+
+    def __init__(
+        self,
+        task_id,
+        robot_uids=None,
+        control_mode=None,
+        obs_mode='rgb',
+        camera_name=None,
+        resolution=224,
+        render_mode='rgb_array',
+        sim_backend='auto',
+        **kwargs,
+    ):
+        # Lazy import: mani_skill needs a CUDA+Vulkan GPU, so it must not be
+        # imported on `import stable_worldmodel`. Importing it here registers
+        # the ManiSkill task ids as a side effect.
+        import mani_skill.envs  # noqa: F401
+
+        make_kwargs = {
+            'num_envs': 1,
+            'obs_mode': obs_mode,
+            'sim_backend': sim_backend,
+        }
+        if robot_uids is not None:
+            make_kwargs['robot_uids'] = robot_uids
+        if control_mode is not None:
+            make_kwargs['control_mode'] = control_mode
+        make_kwargs.update(kwargs)
+
+        env = gym.make(task_id, **make_kwargs)
+        super().__init__(env)
+
+        self.env_name = task_id
+        self.render_mode = render_mode
+        self.render_size = resolution
+        self.camera_name = camera_name
+        self._camera = None
+        self._render_frame = None
+
+        # Expose single-env, numpy spaces (ManiSkill's own spaces are batched).
+        single_action = getattr(
+            env.unwrapped, 'single_action_space', env.action_space
+        )
+        self.action_space = self._clean_box(single_action)
+
+        # Probe one reset to determine the proprio dimensionality and cache the
+        # render camera. This runs on the GPU the env already requires.
+        obs, _ = env.reset()
+        proprio = self._extract_proprio(obs)
+        self._render_frame = self._extract_rgb(obs)
+        self.observation_space = gym.spaces.Box(
+            low=-np.inf, high=np.inf, shape=proprio.shape, dtype=np.float32
+        )
+
+        # No distribution-shift knobs yet; an empty Dict keeps EnvPool's
+        # variation_space wiring happy.
+        self.variation_space = swm_spaces.Dict({})
+
+    # ----- conversion helpers (embodiment-independent) ---------------------
+
+    @staticmethod
+    def _to_numpy(x):
+        if isinstance(x, torch.Tensor):
+            return x.detach().cpu().numpy()
+        return x
+
+    def _debatch(self, x):
+        """Convert to numpy and drop a leading ``num_envs == 1`` dimension."""
+        x = self._to_numpy(x)
+        if isinstance(x, np.ndarray) and x.ndim >= 1 and x.shape[0] == 1:
+            x = x[0]
+        return x
+
+    def _clean_box(self, space):
+        low = np.asarray(space.low, dtype=np.float32).reshape(-1)
+        high = np.asarray(space.high, dtype=np.float32).reshape(-1)
+        return gym.spaces.Box(low=low, high=high, dtype=np.float32)
+
+    def _collect_leaves(self, node, out):
+        if isinstance(node, dict):
+            for v in node.values():
+                self._collect_leaves(v, out)
+        else:
+            arr = self._debatch(node)
+            if isinstance(arr, np.ndarray):
+                out.append(np.asarray(arr, dtype=np.float32).ravel())
+
+    def _flatten(self, node):
+        out = []
+        self._collect_leaves(node, out)
+        if not out:
+            return np.zeros(0, dtype=np.float32)
+        return np.concatenate(out).astype(np.float32)
+
+    def _extract_proprio(self, obs):
+        """Flatten ``obs['agent']`` (qpos/qvel/...) — works for any robot."""
+        return self._flatten(obs.get('agent', {}))
+
+    def _extract_state(self, obs):
+        """Proprio plus task ``extra`` (tcp/object poses) where present."""
+        return np.concatenate(
+            [self._extract_proprio(obs), self._flatten(obs.get('extra', {}))]
+        ).astype(np.float32)
+
+    def _pick_camera(self, obs):
+        if self._camera is None:
+            sensors = obs.get('sensor_data', {})
+            if self.camera_name is not None and self.camera_name in sensors:
+                self._camera = self.camera_name
+            elif sensors:
+                self._camera = next(iter(sensors))
+        return self._camera
+
+    def _extract_rgb(self, obs):
+        cam = self._pick_camera(obs)
+        if cam is None:
+            return None
+        rgb = self._to_numpy(obs['sensor_data'][cam]['rgb'])
+        if rgb.ndim == 4:  # (num_envs, H, W, 3)
+            rgb = rgb[0]
+        return rgb.astype(np.uint8)
+
+    def _build_info(self, obs, info):
+        info = {k: self._debatch(v) for k, v in info.items()}
+        success = info.get('success', info.get('terminated', False))
+        info['success'] = bool(np.asarray(success).reshape(-1)[0])
+        info['env_name'] = self.env_name
+        info['proprio'] = self._extract_proprio(obs)
+        info['state'] = self._extract_state(obs)
+        get_instr = getattr(
+            self.env.unwrapped, 'get_language_instruction', None
+        )
+        if callable(get_instr):
+            instr = get_instr()
+            info['instruction'] = (
+                instr[0] if isinstance(instr, list) else instr
+            )
+        return info, info['success']
+
+    # ----- gym interface ---------------------------------------------------
+
+    def reset(self, seed=None, options=None):
+        obs, info = self.env.reset(seed=seed, options=options)
+        self._render_frame = self._extract_rgb(obs)
+        info, _ = self._build_info(obs, info)
+        return info['proprio'], info
+
+    def step(self, action):
+        action = np.asarray(action, dtype=np.float32).reshape(1, -1)
+        obs, reward, terminated, truncated, info = self.env.step(action)
+
+        reward = float(np.asarray(self._debatch(reward)).reshape(-1)[0])
+        truncated = bool(np.asarray(self._debatch(truncated)).reshape(-1)[0])
+        self._render_frame = self._extract_rgb(obs)
+        info, success = self._build_info(obs, info)
+        # World.evaluate scores success off `terminated`, so map task success
+        # onto it (taking either the native terminated flag or the detector).
+        terminated = (
+            bool(np.asarray(self._debatch(terminated)).reshape(-1)[0])
+            or success
+        )
+
+        return info['proprio'], reward, terminated, truncated, info
+
+    def render(self):
+        if self._render_frame is None:
+            return None
+        img = self._render_frame
+        if self.render_size is not None and img.shape[:2] != (
+            self.render_size,
+            self.render_size,
+        ):
+            import cv2
+
+            img = cv2.resize(img, (self.render_size, self.render_size))
+        return img

--- a/stable_worldmodel/envs/maniskill/env.py
+++ b/stable_worldmodel/envs/maniskill/env.py
@@ -75,6 +75,7 @@ class ManiSkillWrapper(gym.Wrapper):
             'num_envs': 1,
             'obs_mode': obs_mode,
             'sim_backend': sim_backend,
+            'render_mode': render_mode,
         }
         if robot_uids is not None:
             make_kwargs['robot_uids'] = robot_uids
@@ -86,7 +87,8 @@ class ManiSkillWrapper(gym.Wrapper):
         super().__init__(env)
 
         self.env_name = task_id
-        self.render_mode = render_mode
+        # render_mode is a read-only property on gym.Wrapper (proxied from the
+        # wrapped env); it's passed to gym.make above rather than assigned here.
         self.render_size = resolution
         self.camera_name = camera_name
         self._camera = None

--- a/stable_worldmodel/envs/maniskill/tasks.py
+++ b/stable_worldmodel/envs/maniskill/tasks.py
@@ -29,20 +29,26 @@ TASK_SPECS = [
     dict(id='swm/MSPickSingleYCB-v0', task_id='PickSingleYCB-v1'),
     dict(id='swm/MSRollBall-v0', task_id='RollBall-v1'),
     # --- SIMPLER / real2sim Bridge digital twins (WidowX is the task default) ---
+    # These tasks only support obs_mode='rgb+segmentation' (not plain 'rgb').
     dict(
-        id='swm/SimplerCarrotOnPlate-v0', task_id='PutCarrotOnPlateInScene-v1'
+        id='swm/SimplerCarrotOnPlate-v0',
+        task_id='PutCarrotOnPlateInScene-v1',
+        obs_mode='rgb+segmentation',
     ),
     dict(
         id='swm/SimplerSpoonOnTowel-v0',
         task_id='PutSpoonOnTableClothInScene-v1',
+        obs_mode='rgb+segmentation',
     ),
     dict(
         id='swm/SimplerStackCube-v0',
         task_id='StackGreenCubeOnYellowCubeBakedTexInScene-v1',
+        obs_mode='rgb+segmentation',
     ),
     dict(
         id='swm/SimplerEggplantInBasket-v0',
         task_id='PutEggplantInBasketScene-v1',
+        obs_mode='rgb+segmentation',
     ),
     # --- Examples of extending to other robots (uncomment / copy a line) ---
     # dict(id='swm/MSPickCubeWidowX-v0', task_id='PickCube-v1', robot_uids='widowx'),

--- a/stable_worldmodel/envs/maniskill/tasks.py
+++ b/stable_worldmodel/envs/maniskill/tasks.py
@@ -1,0 +1,51 @@
+"""Declarative ManiSkill3 task registry.
+
+This list is the single extension point for ManiSkill envs. Each entry maps a
+``swm/...`` id to a ManiSkill ``task_id``, with optional per-task overrides
+(``robot_uids``, ``control_mode``, ``camera_name``, ...). Everything except
+``id`` is forwarded to ``ManiSkillWrapper`` as kwargs.
+
+Adding a robot or task is a one-line entry here — no wrapper code changes:
+
+* New task, default robot:
+    ``dict(id='swm/MS<Name>-v0', task_id='<ManiSkillTask-v1>')``
+* Existing task on a different embodiment (ManiSkill swaps it; the wrapper
+  picks up the new action_space automatically):
+    ``dict(id='swm/...-v0', task_id='PickCube-v1', robot_uids='widowx')``
+* Robot-specific task variant: point ``task_id`` at it (e.g. ``'PickCubeSO100-v1'``).
+* Uniform action across arms: add ``control_mode='pd_ee_delta_pose'``.
+"""
+
+TASK_SPECS = [
+    # --- Franka Panda table-top manipulation (Panda is the task default) ---
+    dict(id='swm/MSPickCube-v0', task_id='PickCube-v1'),
+    dict(id='swm/MSPushCube-v0', task_id='PushCube-v1'),
+    dict(id='swm/MSPullCube-v0', task_id='PullCube-v1'),
+    dict(id='swm/MSPokeCube-v0', task_id='PokeCube-v1'),
+    dict(id='swm/MSStackCube-v0', task_id='StackCube-v1'),
+    dict(id='swm/MSLiftPegUpright-v0', task_id='LiftPegUpright-v1'),
+    dict(id='swm/MSPegInsertionSide-v0', task_id='PegInsertionSide-v1'),
+    dict(id='swm/MSPlugCharger-v0', task_id='PlugCharger-v1'),
+    dict(id='swm/MSPickSingleYCB-v0', task_id='PickSingleYCB-v1'),
+    dict(id='swm/MSRollBall-v0', task_id='RollBall-v1'),
+    # --- SIMPLER / real2sim Bridge digital twins (WidowX is the task default) ---
+    dict(
+        id='swm/SimplerCarrotOnPlate-v0', task_id='PutCarrotOnPlateInScene-v1'
+    ),
+    dict(
+        id='swm/SimplerSpoonOnTowel-v0',
+        task_id='PutSpoonOnTableClothInScene-v1',
+    ),
+    dict(
+        id='swm/SimplerStackCube-v0',
+        task_id='StackGreenCubeOnYellowCubeBakedTexInScene-v1',
+    ),
+    dict(
+        id='swm/SimplerEggplantInBasket-v0',
+        task_id='PutEggplantInBasketScene-v1',
+    ),
+    # --- Examples of extending to other robots (uncomment / copy a line) ---
+    # dict(id='swm/MSPickCubeWidowX-v0', task_id='PickCube-v1', robot_uids='widowx'),
+    # dict(id='swm/MSPickCubeSO100-v0', task_id='PickCubeSO100-v1'),
+    # dict(id='swm/MSPickCubeEE-v0', task_id='PickCube-v1', control_mode='pd_ee_delta_pose'),
+]

--- a/stable_worldmodel/envs/maniskill/tasks.py
+++ b/stable_worldmodel/envs/maniskill/tasks.py
@@ -17,7 +17,7 @@ Adding a robot or task is a one-line entry here — no wrapper code changes:
 """
 
 TASK_SPECS = [
-    # --- Franka Panda table-top manipulation (Panda is the task default) ---
+    # Franka Panda table-top manipulation (Panda is the task default)
     dict(id='swm/MSPickCube-v0', task_id='PickCube-v1'),
     dict(id='swm/MSPushCube-v0', task_id='PushCube-v1'),
     dict(id='swm/MSPullCube-v0', task_id='PullCube-v1'),
@@ -28,7 +28,7 @@ TASK_SPECS = [
     dict(id='swm/MSPlugCharger-v0', task_id='PlugCharger-v1'),
     dict(id='swm/MSPickSingleYCB-v0', task_id='PickSingleYCB-v1'),
     dict(id='swm/MSRollBall-v0', task_id='RollBall-v1'),
-    # --- SIMPLER / real2sim Bridge digital twins (WidowX is the task default) ---
+    # SIMPLER / real2sim Bridge digital twins (WidowX is the task default).
     # These tasks only support obs_mode='rgb+segmentation' (not plain 'rgb').
     dict(
         id='swm/SimplerCarrotOnPlate-v0',
@@ -50,7 +50,7 @@ TASK_SPECS = [
         task_id='PutEggplantInBasketScene-v1',
         obs_mode='rgb+segmentation',
     ),
-    # --- Examples of extending to other robots (uncomment / copy a line) ---
+    # Examples of extending to other robots (uncomment / copy a line):
     # dict(id='swm/MSPickCubeWidowX-v0', task_id='PickCube-v1', robot_uids='widowx'),
     # dict(id='swm/MSPickCubeSO100-v0', task_id='PickCubeSO100-v1'),
     # dict(id='swm/MSPickCubeEE-v0', task_id='PickCube-v1', control_mode='pd_ee_delta_pose'),

--- a/tests/envs/test_maniskill.py
+++ b/tests/envs/test_maniskill.py
@@ -48,6 +48,11 @@ def test_maniskill_variation_space_factors():
 def test_maniskill_environment_rollout(env_id):
     pytest.importorskip('mani_skill')
 
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip('ManiSkill rollout needs a CUDA + Vulkan GPU')
+
     env = gym.make(env_id)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert env.observation_space.shape[0] > 0

--- a/tests/envs/test_maniskill.py
+++ b/tests/envs/test_maniskill.py
@@ -4,6 +4,10 @@ import pytest
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.maniskill import TASK_SPECS
+from stable_worldmodel.envs.maniskill.env import (
+    DEFAULT_VARIATIONS,
+    build_variation_space,
+)
 
 
 # --- CPU-safe: registry sanity (no mani_skill / GPU needed) ---------------
@@ -21,6 +25,17 @@ def test_maniskill_specs_have_task_id():
         assert 'id' in spec and 'task_id' in spec, (
             f'spec missing id/task_id: {spec}'
         )
+
+
+def test_maniskill_variation_space_factors():
+    """The env exposes real (verified-applied) Factors of Variation."""
+    vs = build_variation_space()
+    top_level = set(vs.spaces.keys())
+    assert {'light', 'camera', 'object', 'rendering'} <= top_level, top_level
+    names = set(vs.names())
+    assert 'rendering.transparent_arm' in names
+    for key in DEFAULT_VARIATIONS:
+        assert key in names, f'{key} missing from variation_space ({names})'
 
 
 # --- GPU + Vulkan required: skipped cleanly without mani_skill installed ---

--- a/tests/envs/test_maniskill.py
+++ b/tests/envs/test_maniskill.py
@@ -10,7 +10,7 @@ from stable_worldmodel.envs.maniskill.env import (
 )
 
 
-# --- CPU-safe: registry sanity (no mani_skill / GPU needed) ---------------
+# CPU-safe: registry sanity (no mani_skill / GPU needed)
 
 
 def test_maniskill_specs_are_registered():
@@ -38,7 +38,7 @@ def test_maniskill_variation_space_factors():
         assert key in names, f'{key} missing from variation_space ({names})'
 
 
-# --- GPU + Vulkan required: skipped cleanly without mani_skill installed ---
+# GPU + Vulkan required: skipped cleanly without mani_skill installed
 
 
 @pytest.mark.parametrize(

--- a/tests/envs/test_maniskill.py
+++ b/tests/envs/test_maniskill.py
@@ -1,0 +1,56 @@
+import gymnasium as gym
+import numpy as np
+import pytest
+
+import stable_worldmodel as swm
+from stable_worldmodel.envs.maniskill import TASK_SPECS
+
+
+# --- CPU-safe: registry sanity (no mani_skill / GPU needed) ---------------
+
+
+def test_maniskill_specs_are_registered():
+    ids = [spec['id'] for spec in TASK_SPECS]
+    assert len(ids) == len(set(ids)), 'TASK_SPECS ids must be unique'
+    for env_id in ids:
+        assert env_id in swm.envs.WORLDS, f'{env_id} not registered'
+
+
+def test_maniskill_specs_have_task_id():
+    for spec in TASK_SPECS:
+        assert 'id' in spec and 'task_id' in spec, (
+            f'spec missing id/task_id: {spec}'
+        )
+
+
+# --- GPU + Vulkan required: skipped cleanly without mani_skill installed ---
+
+
+@pytest.mark.parametrize(
+    'env_id',
+    ['swm/MSPickCube-v0', 'swm/SimplerCarrotOnPlate-v0'],
+)
+def test_maniskill_environment_rollout(env_id):
+    pytest.importorskip('mani_skill')
+
+    env = gym.make(env_id)
+    assert isinstance(env.observation_space, gym.spaces.Box)
+    assert env.observation_space.shape[0] > 0
+
+    obs, info = env.reset(seed=0)
+    assert 'env_name' in info, 'env_name must be present'
+    assert 'proprio' in info, 'proprio state must be exposed'
+    assert 'state' in info, 'flattened state must be exposed'
+
+    img = env.render()
+    assert img.ndim == 3 and img.shape[-1] == 3, 'render must be (H, W, 3)'
+    assert img.dtype == np.uint8
+
+    obs, reward, terminated, truncated, info = env.step(
+        env.action_space.sample()
+    )
+    assert isinstance(reward, float)
+    assert isinstance(terminated, bool)
+    assert 'success' in info
+
+    env.close()


### PR DESCRIPTION
## Summary

Adds [ManiSkill3](https://github.com/haosulab/ManiSkill) (SAPIEN) manipulation tasks as standard SWM environments via a single robot-agnostic wrapper. Two stationary-arm families:

- **Franka Panda table-top manipulation** (`swm/MS*`) — PickCube, PushCube, PullCube, PokeCube, StackCube, LiftPegUpright, PegInsertionSide, PlugCharger, PickSingleYCB, RollBall.
- **SIMPLER / real2sim Bridge digital twins** (WidowX, `swm/Simpler*`) — carrot-on-plate, spoon-on-towel, stack-cube, eggplant-in-basket.

Includes data **collection** (`collect_maniskill.py`) and **world-model eval** support (LeWM training data config + goal-conditioned MPC eval config). `World.evaluate` + SWM's policies/solvers also handle policy eval via the task's native success detector (mapped onto `terminated`).

## Design

- **`ManiSkillWrapper(gym.Wrapper)`** mirrors `FetchWrapper`: wraps `gym.make(..., num_envs=1)`, debatches torch→numpy, maps `info['success'] → terminated`, lifts `env_name`/`proprio`/`state`/`instruction` into `info`, renders `(H,W,3)` uint8. No robot-specific branching.
- **`TASK_SPECS`** is the single extension point — one line per task/embodiment.
- **Goal-conditioned eval**: `_set_state`/`_set_goal_state` restore/compare the flat ManiSkill sim state (`info['state']`), mirroring the PushT env, so SWM's MPC eval (`eval_wm.py`) works.
- **Opt-in `maniskill` dependency group** (GPU-only — needs CUDA+Vulkan; excluded from `uv sync --all-extras`/`[all]`, installed via `uv sync --group maniskill`), lazily imported so `import stable_worldmodel` stays CPU-importable.
- Assets auto-download on first use (`MS_SKIP_ASSET_DOWNLOAD_PROMPT=1`).

## Factors of Variation

The env declares a `variation_space` of visual distribution-shift knobs (SIMPLER-aligned), applied in `_apply_variations` using ManiSkill's own SAPIEN idioms (cf. `digital_twins/so100_arm/grasp_cube.py`) then `scene.update_render()`+`get_obs()` so the frame reflects them; sampled values flow into `info['variation.*']`. Each was **verified on an A100** to change the rendered frame via `reset(options={'variation_values': ...})`:

| Factor | Mechanism | Δ pixels |
|---|---|---|
| `light.intensity` | `scene.set_ambient_light` | 17074 |
| `camera.angle_delta` | render-camera `set_local_pose` | 15300 |
| `object.color` | cube material `set_base_color` | 102 (small object) |
| `rendering.transparent_arm` | robot-link material alpha | 5129 |

Deferred (documented): `table.color`/`background.color` — those surfaces are **textured**, so `set_base_color` is a verified no-op; they need a texture swap / greenscreen. Distractors and object-pose-as-settable-factor are follow-ups (object pose is already seed-randomized per episode).

## Success rate

**Demo replay.** No trained model is bundled, so `scripts/examples/maniskill_demo_replay.py` replays ManiSkill's official demonstrations through the wrapper — restoring each demo's **initial `env_state`** then replaying its recorded actions, reporting `success_rate`:

```
PickCube-v1 (motionplanning demos, pd_joint_pos): success_rate = 20/20 = 100.0%
```

This confirms the env + `success→terminated` wiring yields and detects real successes (vs. ~0% from a random policy). (Reproduction uses the initial env_state, not the seed — batched-GPU demos aren't seed-reproducible; the absolute-joint demos replay deterministically.)

**World-model MPC.** A LeWM world model trained on a collected PickCube dataset and evaluated with goal-conditioned MPC reached **2% (1/50)** goal-reaching success on `swm/MSPickCube-v0` (random-policy data, 30 epochs, goal threshold 2.0 on the flat sim state) — a real but low baseline:

```
python scripts/data/collect_maniskill.py
python scripts/train/lewm.py data=maniskill output_model_name=lewm_mspickcube wandb.enabled=false
python scripts/plan/eval_wm.py --config-name maniskill
```

## Creating an eval dataset

World-model MPC eval is wired (env callables + collect/train/eval configs), but — exactly like PushT — it runs on a **prepared** dataset, not raw `World.collect` output. The dataset must be in the benchmark layout: per-row `episode_idx`/`step_idx` + `ep_len`/`ep_offset`, with `pixels` (HWC), `action`, `proprio`, and `state` (the flat ManiSkill sim state used by `_set_state`) — the same format as the provided `pusht_expert_train.h5`. `World.collect` output isn't natively in that layout (Lance hides the index columns; HDF5 omits them), so the eval dataset is produced/provided separately. The trained checkpoint's `config.json` must be the model block (`save_pretrained(config_key='model')`). Real Open-X datasets (DROID / BridgeData V2) are for **training policies**, not as MPC-eval datasets (they carry no ManiSkill sim state to restore).

## Verification (A100, CUDA 12.8, NumPy 2)

- `pytest tests/envs/test_maniskill.py` → **5 passed** (registry + variation-space CPU tests + 2 GPU rollouts). On CPU/CI without ManiSkill the GPU tests skip.
- FoV per-factor pixel-diffs above; `render()` frames visually confirmed (real Panda/WidowX scenes).
- collect→train→eval verified on an H100 (LeWM goal-reaching 2% / 1-of-50 on `swm/MSPickCube-v0`).

## Notes
- Panda tasks default to native joint control; pass `control_mode='pd_ee_delta_pose'` for a uniform 7-D EE action.
- Google Robot SIMPLER tasks aren't ported to ManiSkill3 yet (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

