### PR TITLE
Fix PLDM goal embedding handling and deduplicate Costable protocol

### DIFF
--- a/stable_worldmodel/solver/solver.py
+++ b/stable_worldmodel/solver/solver.py
@@ -3,37 +3,7 @@ from typing import Any, Protocol, runtime_checkable
 import gymnasium as gym
 import torch
 
-
-class Costable(Protocol):
-    """Protocol for world model cost functions."""
-
-    def criterion(
-        self, info_dict: dict, action_candidates: torch.Tensor
-    ) -> torch.Tensor:
-        """Compute the cost criterion for action candidates.
-
-        Args:
-            info_dict: Dictionary containing environment state information.
-            action_candidates: Tensor of proposed actions.
-
-        Returns:
-            A tensor of cost values for each action candidate.
-        """
-        ...
-
-    def get_cost(
-        self, info_dict: dict, action_candidates: torch.Tensor
-    ) -> torch.Tensor:  # pragma: no cover
-        """Compute cost for given action candidates based on info dictionary.
-
-        Args:
-            info_dict: Dictionary containing environment state information.
-            action_candidates: Tensor of proposed actions.
-
-        Returns:
-            A tensor of cost values for each action candidate.
-        """
-        ...
+from stable_worldmodel.protocols import Costable  # noqa: F401
 
 
 @runtime_checkable

--- a/stable_worldmodel/wm/pldm/pldm.py
+++ b/stable_worldmodel/wm/pldm/pldm.py
@@ -114,9 +114,9 @@ class PLDM(nn.Module):
     def criterion(self, info_dict: dict):
         """Compute the cost between predicted embeddings and goal embeddings."""
         pred_emb = info_dict['predicted_emb']  # (B,S, T-1, dim)
-        goal_emb = info_dict['goal_emb']  # (B, S, T, dim)
+        goal_emb = info_dict['goal_emb']  # (B, T, dim)
 
-        goal_emb = goal_emb[..., -1:, :].expand_as(pred_emb)
+        goal_emb = goal_emb[:, None, -1:, :].expand_as(pred_emb)
 
         # return last-step cost per action candidate
         cost = F.mse_loss(
@@ -132,17 +132,21 @@ class PLDM(nn.Module):
 
         assert 'goal' in info_dict, 'goal not in info_dict'
 
-        goal = {k: v[:, 0] for k, v in info_dict.items() if torch.is_tensor(v)}
-        goal['pixels'] = goal['goal']
+        if 'goal_emb' not in info_dict:
+            goal = {
+                k: v[:, 0] for k, v in info_dict.items() if torch.is_tensor(v)
+            }
+            goal['pixels'] = goal['goal']
 
-        for k in info_dict:
-            if k.startswith('goal_'):
-                goal[k[len('goal_') :]] = goal.pop(k)
+            for k in info_dict:
+                if k.startswith('goal_'):
+                    goal[k[len('goal_') :]] = goal.pop(k)
 
-        goal.pop('action')
-        goal = self.encode(goal)
+            goal.pop('action')
+            goal = self.encode(goal)
 
-        info_dict['goal_emb'] = goal['emb']
+            info_dict['goal_emb'] = goal['emb']
+
         info_dict = self.rollout(info_dict, action_candidates)
 
         cost = self.criterion(info_dict)

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,24 @@
+"""Protocol import-contract tests (PR1 G8).
+
+Verifies that Costable has a single canonical definition in protocols.py and that
+all historical import paths remain resolvable after the dedup.
+"""
+
+
+def test_costable_protocol_has_single_canonical_identity():
+    """solver.solver.Costable must be the same object as protocols.Costable."""
+    from stable_worldmodel.protocols import Costable as PublicCostable
+    from stable_worldmodel.solver.solver import Costable as SolverCostable
+
+    assert PublicCostable is SolverCostable
+
+
+def test_existing_protocol_import_paths_remain_available():
+    """All previously importable protocols must still resolve after the dedup."""
+    from stable_worldmodel.protocols import Actionable, Costable, Transformable
+    from stable_worldmodel.solver.solver import Solver
+
+    assert Actionable is not None
+    assert Costable is not None
+    assert Transformable is not None
+    assert Solver is not None

--- a/tests/wm/test_lewm.py
+++ b/tests/wm/test_lewm.py
@@ -1,0 +1,133 @@
+"""Regression tests for LeWM.get_cost goal_emb shape handling (PR1 G1/G2).
+
+Shape contract (matching upstream commit 1986aae):
+  get_cost stores goal_emb as (B, T, D)
+  criterion broadcasts via goal_emb[:, None, -1:, :].expand_as(pred_emb)
+"""
+
+import torch
+
+from stable_worldmodel.wm.lewm.lewm import LeWM
+
+# CEM-like dimensions
+B, S, T, D, H, A = 2, 3, 2, 5, 4, 2
+
+
+def _make_info_dict():
+    """Return a CEM-expanded info_dict mimicking what CEMSolver passes to get_cost."""
+    return {
+        'pixels': torch.randn(B, S, T, 3, 8, 8),
+        'goal': torch.randn(B, S, T, 3, 8, 8),
+        'action': torch.randn(B, S, H, A),
+    }
+
+
+def _make_action_candidates():
+    return torch.randn(B, S, H, A)
+
+
+def _bare_model():
+    """Bypass LeWM.__init__; we only need get_cost to run."""
+    return object.__new__(LeWM)
+
+
+# ---------------------------------------------------------------------------
+# G1: get_cost must store goal_emb as (B, T, D) for criterion to broadcast
+# ---------------------------------------------------------------------------
+
+
+def test_lewm_get_cost_stores_goal_emb_for_criterion_broadcast():
+    """
+    get_cost encodes the goal once (stripping the S axis with v[:, 0]) and
+    stores goal['emb'] as (B, T, D).  criterion then inserts the S axis itself
+    via goal_emb[:, None, -1:, :].expand_as(pred_emb).
+
+    Before upstream commit 1986aae this was broken end-to-end (3D → 4D mismatch
+    in the old expand_as path).  After 1986aae LeWM.criterion was fixed; our
+    branch regression test guards that get_cost still delivers the 3D tensor
+    that the fixed criterion expects.
+    """
+    torch.manual_seed(0)
+    model = _bare_model()
+    info_dict = _make_info_dict()
+    action_candidates = _make_action_candidates()
+
+    encode_call_count = []
+
+    def mock_encode(goal_dict):
+        encode_call_count.append(1)
+        # get_cost strips the S axis with v[:, 0], so pixels must be (B, T, ...)
+        assert goal_dict['pixels'].shape == (B, T, 3, 8, 8), (
+            f'encode received wrong pixels shape: {goal_dict["pixels"].shape}'
+        )
+        return {'emb': torch.randn(B, T, D)}
+
+    def mock_rollout(info, ac):
+        info['predicted_emb'] = torch.randn(B, S, T, D)
+        return info
+
+    def mock_criterion(info):
+        pred_emb = info['predicted_emb']  # (B, S, T, D)
+        goal_emb = info['goal_emb']  # (B, T, D)
+
+        assert goal_emb.shape == (B, T, D), (
+            f'goal_emb shape mismatch: expected ({B},{T},{D}), '
+            f'got {tuple(goal_emb.shape)}'
+        )
+        # verify the broadcast the real criterion will perform works
+        broadcast_goal = goal_emb[:, None, -1:, :].expand_as(pred_emb)
+        assert broadcast_goal.shape == pred_emb.shape
+
+        return torch.zeros(B, S)
+
+    model.encode = mock_encode
+    model.rollout = mock_rollout
+    model.criterion = mock_criterion
+
+    cost = LeWM.get_cost(model, info_dict, action_candidates)
+
+    assert len(encode_call_count) == 1, 'encode should be called exactly once'
+    assert cost.shape == (B, S), (
+        f'cost shape: expected ({B},{S}), got {cost.shape}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# G2 symmetry: pre-injected goal_emb must not be overwritten
+# ---------------------------------------------------------------------------
+
+
+def test_lewm_get_cost_respects_preinjected_goal_emb():
+    """
+    When goal_emb is already present in info_dict, encode must not be called
+    and the stored tensor must pass through to criterion unchanged.
+    Pre-injected goal_emb follows the same (B, T, D) contract.
+    """
+    torch.manual_seed(0)
+    model = _bare_model()
+    info_dict = _make_info_dict()
+    preinjected = torch.randn(B, T, D)
+    info_dict['goal_emb'] = preinjected
+    action_candidates = _make_action_candidates()
+
+    def encode_must_not_be_called(_):
+        raise AssertionError(
+            'LeWM.encode must not be called when goal_emb is already in info_dict'
+        )
+
+    def mock_rollout(info, ac):
+        info['predicted_emb'] = torch.randn(B, S, T, D)
+        return info
+
+    def mock_criterion(info):
+        assert info['goal_emb'] is preinjected, (
+            'pre-injected goal_emb tensor was replaced instead of reused'
+        )
+        return torch.zeros(B, S)
+
+    model.encode = encode_must_not_be_called
+    model.rollout = mock_rollout
+    model.criterion = mock_criterion
+
+    cost = LeWM.get_cost(model, info_dict, action_candidates)
+    assert cost.shape == (B, S)

--- a/tests/wm/test_pldm.py
+++ b/tests/wm/test_pldm.py
@@ -1,0 +1,135 @@
+"""Regression tests for PLDM.get_cost goal_emb shape handling (PR1 G1/G2).
+
+Shape contract (matching upstream LeWM contract from commit 1986aae):
+  get_cost stores goal_emb as (B, T, D)
+  criterion broadcasts via goal_emb[:, None, -1:, :].expand_as(pred_emb)
+"""
+
+import torch
+
+from stable_worldmodel.wm.pldm.pldm import PLDM
+
+# CEM-like dimensions
+B, S, T, D, H, A = 2, 3, 2, 5, 4, 2
+
+
+def _make_info_dict():
+    """Return a CEM-expanded info_dict mimicking what CEMSolver passes to get_cost."""
+    return {
+        'pixels': torch.randn(B, S, T, 3, 8, 8),
+        'goal': torch.randn(B, S, T, 3, 8, 8),
+        'action': torch.randn(B, S, H, A),
+    }
+
+
+def _make_action_candidates():
+    return torch.randn(B, S, H, A)
+
+
+def _bare_model():
+    """Bypass PLDM.__init__; we only need get_cost to run."""
+    return object.__new__(PLDM)
+
+
+# ---------------------------------------------------------------------------
+# G1: get_cost must store goal_emb as (B, T, D) for criterion to broadcast
+# ---------------------------------------------------------------------------
+
+
+def test_pldm_get_cost_stores_goal_emb_for_criterion_broadcast():
+    """
+    PLDM.get_cost encodes the goal once (stripping the S axis with v[:, 0])
+    and stores goal['emb'] as (B, T, D).  PLDM.criterion then inserts the S
+    axis itself via goal_emb[:, None, -1:, :].expand_as(pred_emb), matching
+    the LeWM contract introduced upstream in commit 1986aae.
+
+    Before this PR: PLDM.get_cost expanded to (B, S, T, D) while
+    PLDM.criterion tried expand_as on that 4D tensor against a differently
+    shaped pred_emb — a shape mismatch.
+    """
+    torch.manual_seed(0)
+    model = _bare_model()
+    info_dict = _make_info_dict()
+    action_candidates = _make_action_candidates()
+
+    encode_call_count = []
+
+    def mock_encode(goal_dict):
+        encode_call_count.append(1)
+        # get_cost strips the S axis with v[:, 0], so pixels must be (B, T, ...)
+        assert goal_dict['pixels'].shape == (B, T, 3, 8, 8), (
+            f'encode received wrong pixels shape: {goal_dict["pixels"].shape}'
+        )
+        return {'emb': torch.randn(B, T, D)}
+
+    def mock_rollout(info, ac):
+        info['predicted_emb'] = torch.randn(B, S, T, D)
+        return info
+
+    def mock_criterion(info):
+        pred_emb = info['predicted_emb']  # (B, S, T, D)
+        goal_emb = info['goal_emb']  # (B, T, D)
+
+        assert goal_emb.shape == (B, T, D), (
+            f'goal_emb shape mismatch: expected ({B},{T},{D}), '
+            f'got {tuple(goal_emb.shape)}'
+        )
+        # verify the broadcast the real criterion will perform works
+        broadcast_goal = goal_emb[:, None, -1:, :].expand_as(pred_emb)
+        assert broadcast_goal.shape == pred_emb.shape
+
+        return torch.zeros(B, S)
+
+    model.encode = mock_encode
+    model.rollout = mock_rollout
+    model.criterion = mock_criterion
+
+    cost = PLDM.get_cost(model, info_dict, action_candidates)
+
+    assert len(encode_call_count) == 1, 'encode should be called exactly once'
+    assert cost.shape == (B, S), (
+        f'cost shape: expected ({B},{S}), got {cost.shape}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# G2: missing guard — encode must not be called when goal_emb is pre-injected
+# ---------------------------------------------------------------------------
+
+
+def test_pldm_get_cost_respects_preinjected_goal_emb():
+    """
+    Before this PR, PLDM.get_cost had no 'if goal_emb not in info_dict' guard,
+    so it always re-encoded the goal and overwrote any pre-injected value.
+
+    After this PR, get_cost must skip encoding entirely and leave the
+    pre-injected (B, T, D) tensor untouched.
+    """
+    torch.manual_seed(0)
+    model = _bare_model()
+    info_dict = _make_info_dict()
+    preinjected = torch.randn(B, T, D)
+    info_dict['goal_emb'] = preinjected
+    action_candidates = _make_action_candidates()
+
+    def encode_must_not_be_called(_):
+        raise AssertionError(
+            'PLDM.encode must not be called when goal_emb is already in info_dict'
+        )
+
+    def mock_rollout(info, ac):
+        info['predicted_emb'] = torch.randn(B, S, T, D)
+        return info
+
+    def mock_criterion(info):
+        assert info['goal_emb'] is preinjected, (
+            'pre-injected goal_emb tensor was replaced instead of reused'
+        )
+        return torch.zeros(B, S)
+
+    model.encode = encode_must_not_be_called
+    model.rollout = mock_rollout
+    model.criterion = mock_criterion
+
+    cost = PLDM.get_cost(model, info_dict, action_candidates)
+    assert cost.shape == (B, S)


### PR DESCRIPTION
## Summary

This PR makes a small set of planning-related maintenance fixes:

* Applies the same goal-embedding broadcast contract recently added for LeWM in #247 to PLDM.
* Adds PLDM's missing `if "goal_emb" not in info_dict:` guard, so pre-injected goal embeddings are respected and goals are not re-encoded on every CEM iteration.
* Deduplicates the `Costable` protocol by making `stable_worldmodel.protocols.Costable` canonical and re-exporting it from `stable_worldmodel.solver.solver`.
* Adds regression tests for LeWM/PLDM goal embedding behavior and protocol import compatibility.

## Motivation

After #247, LeWM stores `goal_emb` as `(B, T, D)` and broadcasts it inside `criterion` with:

```python
goal_emb = goal_emb[:, None, -1:, :].expand_as(pred_emb)
```

PLDM still used the old criterion path, which treated `goal_emb` as `(B, S, T, D)` even though `get_cost` stores the encoded goal as `(B, T, D)`. This PR brings PLDM into alignment with LeWM's current contract.

The PLDM guard also matters for latent-goal injection use cases: if `goal_emb` is already present in `info_dict`, PLDM should preserve it rather than re-encoding the image goal.

## Changes

* `stable_worldmodel/wm/pldm/pldm.py`

  * Updates `criterion` to broadcast `goal_emb` with `goal_emb[:, None, -1:, :]`, matching LeWM.
  * Adds `if "goal_emb" not in info_dict:` around the goal encoding block.
  * Stores internally encoded goals as `(B, T, D)`.

* `stable_worldmodel/solver/solver.py`

  * Replaces the duplicate `Costable` protocol body with a re-export from `stable_worldmodel.protocols`.

* Tests:

  * Adds LeWM/PLDM regression tests for:

    * internally computed `goal_emb` shape,
    * criterion-compatible broadcasting,
    * preservation of pre-injected `goal_emb`.
  * Adds protocol import identity tests.

## Tests

Ran:

```bash
.venv/bin/python -m pytest tests/wm/test_lewm.py tests/wm/test_pldm.py tests/test_protocols.py -q
.venv/bin/python -m pytest tests/wm -q
.venv/bin/python -m pytest tests/solver/test_continuous.py -q
.venv/bin/python -m pytest tests/solver/test_callbacks.py -q
.venv/bin/python -m pytest tests/test_policy.py -k worldmodel -q
.venv/bin/python -m compileall stable_worldmodel
```

Results:

* Focused new tests: 6/6 passed.
* `tests/wm`: 42/42 passed.
* `tests/solver/test_continuous.py`: 19/19 passed.
* `tests/solver/test_callbacks.py`: 24/24 passed.
* `tests/test_policy.py -k worldmodel`: 16/16 passed, 33 deselected.
* `compileall`: zero errors.
