### PR TITLE
Add PettingZoo Parallel and AEC environment support

### DIFF
--- a/docs/envs/pettingzoo.md
+++ b/docs/envs/pettingzoo.md
@@ -1,0 +1,64 @@
+---
+title: PettingZoo
+summary: Multi-agent environments through PettingZoo's Parallel and AEC APIs
+---
+
+# PettingZoo
+
+Stable World-Model can run PettingZoo Parallel and AEC environments through
+`World.from_pettingzoo`. Each PettingZoo environment instance is treated as one
+SWM environment, and agents are represented as per-agent columns in
+`world.infos`.
+
+## Parallel API
+
+```python
+import stable_worldmodel as swm
+from pettingzoo.butterfly import pistonball_v6
+
+world = swm.World.from_pettingzoo(
+    lambda: pistonball_v6.parallel_env(render_mode="rgb_array"),
+    num_envs=4,
+)
+world.set_policy(swm.MultiAgentRandomPolicy(seed=0))
+world.collect("pistonball.lance", episodes=16, seed=0)
+```
+
+## AEC API
+
+AEC environments are turn-based: one SWM step advances the currently selected
+PettingZoo agent.
+
+```python
+import stable_worldmodel as swm
+from pettingzoo.classic import rps_v2
+
+world = swm.World.from_pettingzoo(
+    lambda: rps_v2.env(),
+    num_envs=4,
+    api="aec",
+)
+world.set_policy(swm.MultiAgentRandomPolicy(seed=0))
+world.collect("rps.lance", episodes=16, seed=0)
+```
+
+## Info Columns
+
+Agent keys are flattened into stable column names:
+
+| Column | Meaning |
+| --- | --- |
+| `agent_mask` | Boolean mask over `possible_agents` |
+| `current_agent_idx` | Current AEC agent index (`-1` for completed envs) |
+| `observation.<agent>` | Agent observation |
+| `action.<agent>` | Agent action for the transition |
+| `reward.<agent>` | Agent reward |
+| `terminated.<agent>` | Agent termination flag |
+| `truncated.<agent>` | Agent truncation flag |
+
+If an observation or action space is a `gymnasium.spaces.Dict`, nested fields
+are flattened one level deeper, for example
+`observation.player_0.action_mask`.
+
+For AEC envs, `action.<agent>` records the selected action on that agent's turn
+and carries the previous action otherwise.

--- a/docs/envs/pettingzoo.md
+++ b/docs/envs/pettingzoo.md
@@ -10,6 +10,10 @@ Stable World-Model can run PettingZoo Parallel and AEC environments through
 SWM environment, and agents are represented as per-agent columns in
 `world.infos`.
 
+PettingZoo's per-agent action spaces are exposed to SWM as one flat ndarray
+action per environment. The wrapper reconstructs the PettingZoo agent-action
+mapping internally before stepping the underlying env.
+
 ## Parallel API
 
 ```python

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -28,6 +28,7 @@ nav:
       - envs/gymnasium_control.md
       - envs/craftax.md
       - envs/ale.md
+      - envs/pettingzoo.md
   - Guides:
       - guides/checkpoints.md
       - guides/online_learning.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ env = [
     "stable_baselines3>=2.0.0",
     "craftax>=1.5.0",
     "ale-py",
+    "pettingzoo",
 ]
 
 format = [

--- a/stable_worldmodel/__init__.py
+++ b/stable_worldmodel/__init__.py
@@ -9,12 +9,13 @@ from stable_worldmodel import (
     wrapper,
 )
 from stable_worldmodel.world import World
-from stable_worldmodel.policy import PlanConfig
+from stable_worldmodel.policy import MultiAgentRandomPolicy, PlanConfig
 from stable_worldmodel.utils import pretraining
 
 __all__ = [
     'World',
     'PlanConfig',
+    'MultiAgentRandomPolicy',
     'pretraining',
     'data',
     'envs',

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -184,6 +184,14 @@ class RandomPolicy(BasePolicy):
             self.env.action_space.seed(seed)
 
 
+class MultiAgentRandomPolicy(RandomPolicy):
+    """Random policy for worlds whose action space is keyed by agent."""
+
+    def __init__(self, seed: int | None = None, **kwargs: Any) -> None:
+        super().__init__(seed=seed, **kwargs)
+        self.type = 'multi_agent_random'
+
+
 class ExpertPolicy(BasePolicy):
     """Policy using expert demonstrations or heuristics."""
 

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -185,7 +185,7 @@ class RandomPolicy(BasePolicy):
 
 
 class MultiAgentRandomPolicy(RandomPolicy):
-    """Random policy for worlds whose action space is keyed by agent."""
+    """Random policy alias for PettingZoo-backed worlds."""
 
     def __init__(self, seed: int | None = None, **kwargs: Any) -> None:
         super().__init__(seed=seed, **kwargs)

--- a/stable_worldmodel/world/env_pool.py
+++ b/stable_worldmodel/world/env_pool.py
@@ -116,12 +116,14 @@ class EnvPool:
         return None, self._stacked_infos
 
     def step(
-        self, actions: np.ndarray, mask: np.ndarray | None = None
+        self, actions: Any, mask: np.ndarray | None = None
     ) -> tuple[None, np.ndarray, np.ndarray, np.ndarray, dict]:
         """Step envs and return ``(None, rewards, terminateds, truncateds, infos)``.
 
         Args:
-            actions: Array of shape ``(num_envs, ...)`` — one action per env.
+            actions: Batched action container with one action per env. Arrays
+                use shape ``(num_envs, ...)``. Nested dict/list containers are
+                sliced recursively, which supports batched Dict action spaces.
             mask: If provided, only envs where ``mask[i]`` is truthy are
                 stepped. Masked envs contribute zero reward and ``False``
                 termination/truncation, and their slot in the stacked
@@ -135,7 +137,7 @@ class EnvPool:
             if mask is not None and not mask[i]:
                 continue
             _, rewards[i], terminateds[i], truncateds[i], info = env.step(
-                actions[i]
+                _slice_action(actions, i)
             )
             _write_env_info(self._stacked_infos, i, info)
 
@@ -196,3 +198,17 @@ def _write_env_info(stacked: dict, idx: int, info: dict) -> None:
             buf[idx, 0] = v
         elif isinstance(buf, list):
             buf[idx][0] = v
+
+
+def _slice_action(actions: Any, idx: int) -> Any:
+    if isinstance(actions, dict):
+        return {k: _slice_action(v, idx) for k, v in actions.items()}
+    if isinstance(actions, tuple):
+        return tuple(_slice_action(v, idx) for v in actions)
+    if isinstance(actions, np.ndarray):
+        return actions[idx]
+    if torch.is_tensor(actions):
+        return actions[idx]
+    if isinstance(actions, list):
+        return actions[idx]
+    return actions

--- a/stable_worldmodel/world/env_pool.py
+++ b/stable_worldmodel/world/env_pool.py
@@ -116,14 +116,13 @@ class EnvPool:
         return None, self._stacked_infos
 
     def step(
-        self, actions: Any, mask: np.ndarray | None = None
+        self, actions: np.ndarray, mask: np.ndarray | None = None
     ) -> tuple[None, np.ndarray, np.ndarray, np.ndarray, dict]:
         """Step envs and return ``(None, rewards, terminateds, truncateds, infos)``.
 
         Args:
-            actions: Batched action container with one action per env. Arrays
-                use shape ``(num_envs, ...)``. Nested dict/list containers are
-                sliced recursively, which supports batched Dict action spaces.
+            actions: Batched action array with one action per env. The first
+                dimension must be ``num_envs``.
             mask: If provided, only envs where ``mask[i]`` is truthy are
                 stepped. Masked envs contribute zero reward and ``False``
                 termination/truncation, and their slot in the stacked
@@ -137,7 +136,7 @@ class EnvPool:
             if mask is not None and not mask[i]:
                 continue
             _, rewards[i], terminateds[i], truncateds[i], info = env.step(
-                _slice_action(actions, i)
+                actions[i]
             )
             _write_env_info(self._stacked_infos, i, info)
 
@@ -198,17 +197,3 @@ def _write_env_info(stacked: dict, idx: int, info: dict) -> None:
             buf[idx, 0] = v
         elif isinstance(buf, list):
             buf[idx][0] = v
-
-
-def _slice_action(actions: Any, idx: int) -> Any:
-    if isinstance(actions, dict):
-        return {k: _slice_action(v, idx) for k, v in actions.items()}
-    if isinstance(actions, tuple):
-        return tuple(_slice_action(v, idx) for v in actions)
-    if isinstance(actions, np.ndarray):
-        return actions[idx]
-    if torch.is_tensor(actions):
-        return actions[idx]
-    if isinstance(actions, list):
-        return actions[idx]
-    return actions

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -156,6 +156,45 @@ class World:
         self.terminateds: np.ndarray | None = None
         self.truncateds: np.ndarray | None = None
 
+    @classmethod
+    def from_pettingzoo(
+        cls,
+        env_fn: Callable[[], Any],
+        num_envs: int,
+        *,
+        api: str = 'parallel',
+        reward_aggregation: str | Callable[[dict[Any, float]], float] = 'sum',
+    ) -> World:
+        """Build a ``World`` from a PettingZoo environment factory.
+
+        Each PettingZoo environment instance is one SWM env; agents are
+        represented as per-agent columns in ``world.infos``.
+        """
+        if api not in ('parallel', 'aec'):
+            raise ValueError("api must be one of {'parallel', 'aec'}.")
+        from stable_worldmodel.wrapper import (
+            PettingZooAECWrapper,
+            PettingZooParallelWrapper,
+        )
+
+        def make_env():
+            if api == 'aec':
+                return PettingZooAECWrapper(
+                    env_fn(), reward_aggregation=reward_aggregation
+                )
+            return PettingZooParallelWrapper(
+                env_fn(), reward_aggregation=reward_aggregation
+            )
+
+        world = object.__new__(cls)
+        world.envs = EnvPool([make_env for _ in range(num_envs)])
+        world.policy = None
+        world.infos = {}
+        world.rewards = None
+        world.terminateds = None
+        world.truncateds = None
+        return world
+
     @property
     def num_envs(self) -> int:
         """Number of envs in the pool."""
@@ -343,8 +382,9 @@ class World:
                 ):
                     ep = {k: list(v) for k, v in buffers[env_idx].items()}
                     buffers[env_idx].clear()
-                    if 'action' in ep:
-                        ep['action'].append(ep['action'].pop(0))
+                    for key in list(ep):
+                        if key == 'action' or key.startswith('action.'):
+                            ep[key].append(ep[key].pop(0))
                     pbar.update(1)
                     yield ep
 
@@ -393,7 +433,7 @@ class World:
         if episodes is None and max_steps is None:
             raise ValueError('Provide episodes or max_steps (or both).')
 
-        if seed is not None or options is not None:
+        if seed is not None or options is not None or not self.infos:
             self.reset(seed=seed, options=options)
 
         alive = np.ones(self.num_envs, dtype=bool)

--- a/stable_worldmodel/wrapper/__init__.py
+++ b/stable_worldmodel/wrapper/__init__.py
@@ -8,6 +8,10 @@ from stable_worldmodel.wrapper.default import (
     MegaWrapper,
     ResizeGoalWrapper,
 )
+from stable_worldmodel.wrapper.pettingzoo import (
+    PettingZooAECWrapper,
+    PettingZooParallelWrapper,
+)
 from stable_worldmodel.wrapper.visual import (
     BlurWrapper,
     ChromaKeyWrapper,
@@ -44,6 +48,8 @@ __all__ = [
     'MovingPatchWrapper',
     'NoiseWrapper',
     'OcclusionWrapper',
+    'PettingZooAECWrapper',
+    'PettingZooParallelWrapper',
     'RandomConvWrapper',
     'RandomShiftWrapper',
     'ResizeGoalWrapper',

--- a/stable_worldmodel/wrapper/pettingzoo.py
+++ b/stable_worldmodel/wrapper/pettingzoo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import gymnasium as gym
@@ -45,13 +46,11 @@ class PettingZooParallelWrapper(gym.Env):
             agent: _empty_action(env.action_space(agent))
             for agent in self.possible_agents
         }
-
-        self.action_space = gym.spaces.Dict(
-            {
-                self._agent_to_key[agent]: env.action_space(agent)
-                for agent in self.possible_agents
-            }
+        self._action_adapter = _FlatPettingZooActionAdapter(
+            {agent: env.action_space(agent) for agent in self.possible_agents}
         )
+
+        self.action_space = self._action_adapter.space
         self.observation_space = gym.spaces.Dict(
             {
                 self._agent_to_key[agent]: env.observation_space(agent)
@@ -128,9 +127,7 @@ class PettingZooParallelWrapper(gym.Env):
 
     def _to_pettingzoo_actions(self, action) -> dict[Any, Any]:
         if not isinstance(action, dict):
-            raise TypeError(
-                'PettingZooParallelWrapper.step expects a dict keyed by agent.'
-            )
+            action = self._action_adapter.to_agent_actions(action)
         actions = {}
         live_agents = set(self.agents)
         for key, value in action.items():
@@ -249,6 +246,9 @@ class PettingZooAECWrapper(gym.Env):
         self._step_counter = 0
         self._id = 0
         self._current_agent = self.possible_agents[0]
+        self._current_reward = 0.0
+        self._current_termination = False
+        self._current_truncation = False
         self._last_actions = {
             agent: _empty_action(env.action_space(agent))
             for agent in self.possible_agents
@@ -258,13 +258,11 @@ class PettingZooAECWrapper(gym.Env):
             for agent in self.possible_agents
         }
         self._last_infos = {agent: {} for agent in self.possible_agents}
-
-        self.action_space = gym.spaces.Dict(
-            {
-                self._agent_to_key[agent]: env.action_space(agent)
-                for agent in self.possible_agents
-            }
+        self._action_adapter = _FlatPettingZooActionAdapter(
+            {agent: env.action_space(agent) for agent in self.possible_agents}
         )
+
+        self.action_space = self._action_adapter.space
         self.observation_space = gym.spaces.Dict(
             {
                 self._agent_to_key[agent]: env.observation_space(agent)
@@ -294,11 +292,18 @@ class PettingZooAECWrapper(gym.Env):
             for agent in self.possible_agents
         }
         self._last_infos = {agent: {} for agent in self.possible_agents}
+        self._current_reward = 0.0
+        self._current_termination = False
+        self._current_truncation = False
         self._capture_current_agent()
 
         rewards = _agent_attr_dict(self.env, 'rewards')
         terminations = _agent_attr_dict(self.env, 'terminations')
         truncations = _agent_attr_dict(self.env, 'truncations')
+        if self.agents:
+            rewards[self._current_agent] = self._current_reward
+            terminations[self._current_agent] = self._current_termination
+            truncations[self._current_agent] = self._current_truncation
         info = self._build_info(
             rewards=rewards,
             terminations=terminations,
@@ -322,13 +327,19 @@ class PettingZooAECWrapper(gym.Env):
             return self._last_observations, 0.0, True, False, info
 
         agent = self._current_agent
-        actions = self._to_agent_actions(action)
-        agent_action = actions.get(agent)
-        if agent_action is None:
-            agent_action = _empty_action(self.env.action_space(agent))
+        if self._current_termination or self._current_truncation:
+            agent_action = None
+        else:
+            actions = self._to_agent_actions(action)
+            if agent not in actions:
+                raise KeyError(
+                    f'Missing action for current PettingZoo agent {agent!r}.'
+                )
+            agent_action = actions[agent]
         self.env.step(agent_action)
         self._step_counter += 1
-        self._last_actions[agent] = agent_action
+        if agent_action is not None:
+            self._last_actions[agent] = agent_action
 
         rewards = _agent_attr_dict(self.env, 'rewards')
         terminations = _agent_attr_dict(self.env, 'terminations')
@@ -372,14 +383,11 @@ class PettingZooAECWrapper(gym.Env):
         agent = getattr(self.env, 'agent_selection', self.agents[0])
         observation, reward, termination, truncation, info = self.env.last()
         self._current_agent = agent
+        self._current_reward = float(reward)
+        self._current_termination = bool(termination)
+        self._current_truncation = bool(truncation)
         self._last_observations[agent] = observation
         self._last_infos[agent] = info or {}
-        rewards = _agent_attr_dict(self.env, 'rewards')
-        rewards[agent] = reward
-        terminations = _agent_attr_dict(self.env, 'terminations')
-        terminations[agent] = termination
-        truncations = _agent_attr_dict(self.env, 'truncations')
-        truncations[agent] = truncation
 
     def _to_agent_actions(self, action) -> dict[Any, Any]:
         if isinstance(action, dict):
@@ -387,7 +395,7 @@ class PettingZooAECWrapper(gym.Env):
                 self._key_to_agent.get(key, key): value
                 for key, value in action.items()
             }
-        return {self._current_agent: action}
+        return self._action_adapter.to_agent_actions(action)
 
     def _aggregate_reward(self, rewards: dict[Any, float]) -> float:
         if callable(self.reward_aggregation):
@@ -475,6 +483,198 @@ def _episode_id(env: Any) -> int:
         if hasattr(rng, 'randint'):
             return int(rng.randint(0, max_int))
     return int(np.random.default_rng().integers(0, np.iinfo(np.int64).max))
+
+
+@dataclass(frozen=True)
+class _ActionSpec:
+    space: gym.Space
+    start: int
+    stop: int
+
+
+class _FlatPettingZooActionAdapter:
+    """Expose per-agent PettingZoo actions as one flat ndarray action."""
+
+    def __init__(self, agent_spaces: dict[Any, gym.Space]) -> None:
+        self.agent_spaces = agent_spaces
+        self._specs: dict[Any, _ActionSpec] = {}
+        lows = []
+        highs = []
+        cursor = 0
+
+        for agent, space in agent_spaces.items():
+            low, high = _flat_action_bounds(space)
+            size = int(low.size)
+            self._specs[agent] = _ActionSpec(
+                space=space,
+                start=cursor,
+                stop=cursor + size,
+            )
+            cursor += size
+            lows.append(low)
+            highs.append(high)
+
+        self.low = np.concatenate(lows).astype(np.float64)
+        self.high = np.concatenate(highs).astype(np.float64)
+        self.size = int(self.low.size)
+        self.space = self._build_space()
+
+    def to_agent_actions(self, action: Any) -> dict[Any, Any]:
+        values = np.asarray(action)
+        if values.shape == ():
+            values = values.reshape(1)
+        values = values.reshape(-1)
+        if values.size != self.size:
+            raise ValueError(
+                f'Expected flat PettingZoo action with {self.size} values, '
+                f'got shape {np.asarray(action).shape}.'
+            )
+        return {
+            agent: _unflatten_space_action(
+                spec.space, values[spec.start : spec.stop]
+            )
+            for agent, spec in self._specs.items()
+        }
+
+    def _build_space(self) -> gym.Space:
+        if np.all(np.isfinite(self.low)) and _all_integer_action_spaces(
+            self.agent_spaces.values()
+        ):
+            starts = self.low.astype(np.int64)
+            nvec = (self.high - self.low + 1).astype(np.int64)
+            return gym.spaces.MultiDiscrete(nvec=nvec, start=starts)
+
+        dtype = np.result_type(
+            *[
+                np.dtype(getattr(space, 'dtype', np.float32))
+                for space in self.agent_spaces.values()
+            ]
+        )
+        if not np.issubdtype(dtype, np.floating):
+            dtype = np.float32
+        return gym.spaces.Box(
+            low=self.low.astype(dtype),
+            high=self.high.astype(dtype),
+            dtype=dtype,
+        )
+
+
+def _flat_action_bounds(space: gym.Space) -> tuple[np.ndarray, np.ndarray]:
+    if isinstance(space, gym.spaces.Discrete):
+        start = int(getattr(space, 'start', 0))
+        return (
+            np.array([start], dtype=np.float64),
+            np.array([start + int(space.n) - 1], dtype=np.float64),
+        )
+    if isinstance(space, gym.spaces.MultiDiscrete):
+        start = np.asarray(
+            getattr(space, 'start', np.zeros_like(space.nvec)),
+            dtype=np.float64,
+        )
+        nvec = np.asarray(space.nvec, dtype=np.float64)
+        return start.reshape(-1), (start + nvec - 1).reshape(-1)
+    if isinstance(space, gym.spaces.MultiBinary):
+        size = int(np.prod(space.shape))
+        return np.zeros(size, dtype=np.float64), np.ones(
+            size, dtype=np.float64
+        )
+    if isinstance(space, gym.spaces.Box):
+        return (
+            np.asarray(space.low, dtype=np.float64).reshape(-1),
+            np.asarray(space.high, dtype=np.float64).reshape(-1),
+        )
+    if isinstance(space, gym.spaces.Tuple):
+        bounds = [_flat_action_bounds(subspace) for subspace in space.spaces]
+        return _concat_bounds(bounds)
+    if isinstance(space, gym.spaces.Dict):
+        bounds = [
+            _flat_action_bounds(subspace) for subspace in space.spaces.values()
+        ]
+        return _concat_bounds(bounds)
+    raise TypeError(
+        f'Unsupported PettingZoo action space {type(space).__name__}.'
+    )
+
+
+def _concat_bounds(
+    bounds: list[tuple[np.ndarray, np.ndarray]],
+) -> tuple[np.ndarray, np.ndarray]:
+    lows = [low for low, _ in bounds]
+    highs = [high for _, high in bounds]
+    return np.concatenate(lows), np.concatenate(highs)
+
+
+def _unflatten_space_action(space: gym.Space, values: np.ndarray) -> Any:
+    if isinstance(space, gym.spaces.Discrete):
+        start = int(getattr(space, 'start', 0))
+        value = int(np.rint(values[0]))
+        return int(np.clip(value, start, start + int(space.n) - 1))
+    if isinstance(space, gym.spaces.MultiDiscrete):
+        start = np.asarray(
+            getattr(space, 'start', np.zeros_like(space.nvec)),
+            dtype=np.int64,
+        )
+        high = start + np.asarray(space.nvec, dtype=np.int64) - 1
+        action = np.asarray(np.rint(values), dtype=np.int64).reshape(
+            space.nvec.shape
+        )
+        return np.clip(action, start, high).astype(space.dtype)
+    if isinstance(space, gym.spaces.MultiBinary):
+        action = np.asarray(np.rint(values), dtype=space.dtype).reshape(
+            space.shape
+        )
+        return np.clip(action, 0, 1).astype(space.dtype)
+    if isinstance(space, gym.spaces.Box):
+        action = np.asarray(values, dtype=space.dtype).reshape(space.shape)
+        return np.clip(action, space.low, space.high).astype(space.dtype)
+    if isinstance(space, gym.spaces.Tuple):
+        items = []
+        cursor = 0
+        for subspace in space.spaces:
+            low, _ = _flat_action_bounds(subspace)
+            next_cursor = cursor + int(low.size)
+            items.append(
+                _unflatten_space_action(subspace, values[cursor:next_cursor])
+            )
+            cursor = next_cursor
+        return tuple(items)
+    if isinstance(space, gym.spaces.Dict):
+        items = {}
+        cursor = 0
+        for key, subspace in space.spaces.items():
+            low, _ = _flat_action_bounds(subspace)
+            next_cursor = cursor + int(low.size)
+            items[key] = _unflatten_space_action(
+                subspace, values[cursor:next_cursor]
+            )
+            cursor = next_cursor
+        return items
+    raise TypeError(
+        f'Unsupported PettingZoo action space {type(space).__name__}.'
+    )
+
+
+def _all_integer_action_spaces(spaces) -> bool:
+    for space in spaces:
+        if isinstance(
+            space,
+            (
+                gym.spaces.Discrete,
+                gym.spaces.MultiDiscrete,
+                gym.spaces.MultiBinary,
+            ),
+        ):
+            continue
+        if isinstance(space, gym.spaces.Tuple):
+            if _all_integer_action_spaces(space.spaces):
+                continue
+            return False
+        if isinstance(space, gym.spaces.Dict):
+            if _all_integer_action_spaces(space.spaces.values()):
+                continue
+            return False
+        return False
+    return True
 
 
 def _empty_observation(space: gym.Space) -> np.ndarray:

--- a/stable_worldmodel/wrapper/pettingzoo.py
+++ b/stable_worldmodel/wrapper/pettingzoo.py
@@ -1,0 +1,582 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import gymnasium as gym
+import numpy as np
+
+
+class PettingZooParallelWrapper(gym.Env):
+    """Adapt a PettingZoo ParallelEnv to the ``World``/``EnvPool`` contract.
+
+    One wrapped PettingZoo environment is treated as one SWM environment.
+    PettingZoo agents are exposed as stable per-agent info columns such as
+    ``observation.player_0``, ``action.player_0`` and ``reward.player_0``.
+    """
+
+    metadata = {'render_modes': []}
+
+    def __init__(
+        self,
+        env: Any,
+        *,
+        reward_aggregation: str | Callable[[dict[Any, float]], float] = 'sum',
+    ) -> None:
+        super().__init__()
+        self.env = env
+        self.possible_agents = list(env.possible_agents)
+        if not self.possible_agents:
+            raise ValueError('PettingZoo env must define possible_agents.')
+
+        self._agent_to_key = {
+            agent: _agent_key(agent) for agent in self.possible_agents
+        }
+        if len(set(self._agent_to_key.values())) != len(self._agent_to_key):
+            raise ValueError(
+                'PettingZoo agent names must be unique after string '
+                f'conversion: {self._agent_to_key!r}'
+            )
+        self._key_to_agent = {v: k for k, v in self._agent_to_key.items()}
+        self.reward_aggregation = reward_aggregation
+        self._step_counter = 0
+        self._id = 0
+        self._last_actions = {
+            agent: _empty_action(env.action_space(agent))
+            for agent in self.possible_agents
+        }
+
+        self.action_space = gym.spaces.Dict(
+            {
+                self._agent_to_key[agent]: env.action_space(agent)
+                for agent in self.possible_agents
+            }
+        )
+        self.observation_space = gym.spaces.Dict(
+            {
+                self._agent_to_key[agent]: env.observation_space(agent)
+                for agent in self.possible_agents
+            }
+        )
+        self.metadata = getattr(env, 'metadata', self.metadata)
+
+    @property
+    def agents(self) -> list[Any]:
+        return list(getattr(self.env, 'agents', []))
+
+    @property
+    def unwrapped(self):
+        return getattr(self.env, 'unwrapped', self.env)
+
+    def reset(self, *, seed=None, options=None):
+        self._step_counter = 0
+        observations, infos = self.env.reset(seed=seed, options=options)
+        self._id = _episode_id(self.env)
+        self._last_actions = {
+            agent: _empty_action(self.env.action_space(agent))
+            for agent in self.possible_agents
+        }
+        info = self._build_info(
+            observations=observations,
+            rewards={},
+            terminations={},
+            truncations={},
+            infos=infos,
+            env_reward=np.nan,
+            env_terminated=False,
+            env_truncated=False,
+        )
+        return observations, info
+
+    def step(self, action):
+        actions = self._to_pettingzoo_actions(action)
+        observations, rewards, terminations, truncations, infos = (
+            self.env.step(actions)
+        )
+        self._step_counter += 1
+
+        for agent, value in actions.items():
+            self._last_actions[agent] = value
+
+        env_reward = self._aggregate_reward(rewards)
+        env_done = _env_done(self.env, terminations, truncations)
+        env_terminated = env_done and any(
+            bool(v) for v in terminations.values()
+        )
+        env_truncated = (
+            env_done
+            and not env_terminated
+            and any(bool(v) for v in truncations.values())
+        )
+        info = self._build_info(
+            observations=observations,
+            rewards=rewards,
+            terminations=terminations,
+            truncations=truncations,
+            infos=infos,
+            env_reward=env_reward,
+            env_terminated=env_terminated,
+            env_truncated=env_truncated,
+        )
+        return observations, env_reward, env_terminated, env_truncated, info
+
+    def render(self):
+        return self.env.render()
+
+    def close(self):
+        self.env.close()
+
+    def _to_pettingzoo_actions(self, action) -> dict[Any, Any]:
+        if not isinstance(action, dict):
+            raise TypeError(
+                'PettingZooParallelWrapper.step expects a dict keyed by agent.'
+            )
+        actions = {}
+        live_agents = set(self.agents)
+        for key, value in action.items():
+            agent = self._key_to_agent.get(key, key)
+            if agent in live_agents:
+                actions[agent] = value
+        return actions
+
+    def _aggregate_reward(self, rewards: dict[Any, float]) -> float:
+        if callable(self.reward_aggregation):
+            return float(self.reward_aggregation(rewards))
+        values = [float(v) for v in rewards.values()]
+        if not values:
+            return 0.0
+        if self.reward_aggregation == 'sum':
+            return float(np.sum(values))
+        if self.reward_aggregation == 'mean':
+            return float(np.mean(values))
+        raise ValueError(
+            "reward_aggregation must be 'sum', 'mean', or a callable."
+        )
+
+    def _build_info(
+        self,
+        *,
+        observations: dict[Any, Any],
+        rewards: dict[Any, float],
+        terminations: dict[Any, bool],
+        truncations: dict[Any, bool],
+        infos: dict[Any, dict],
+        env_reward: float,
+        env_terminated: bool,
+        env_truncated: bool,
+    ) -> dict[str, Any]:
+        live_agents = set(self.agents)
+        info: dict[str, Any] = {
+            'agent_mask': np.array(
+                [agent in live_agents for agent in self.possible_agents],
+                dtype=bool,
+            ),
+            'reward': env_reward,
+            'terminated': bool(env_terminated),
+            'truncated': bool(env_truncated),
+            'step_idx': self._step_counter,
+            'id': self._id,
+        }
+
+        for agent in self.possible_agents:
+            key = self._agent_to_key[agent]
+            obs = observations.get(
+                agent, _empty_observation(self.env.observation_space(agent))
+            )
+            _write_space_value(
+                info,
+                f'observation.{key}',
+                obs,
+                self.env.observation_space(agent),
+                _empty_observation,
+            )
+            _write_space_value(
+                info,
+                f'action.{key}',
+                self._last_actions[agent],
+                self.env.action_space(agent),
+                _empty_action,
+            )
+            info[f'reward.{key}'] = float(rewards.get(agent, np.nan))
+            info[f'terminated.{key}'] = bool(terminations.get(agent, False))
+            info[f'truncated.{key}'] = bool(truncations.get(agent, False))
+
+            for sub_key, value in (infos.get(agent) or {}).items():
+                if _is_stackable(value):
+                    info[f'info.{key}.{sub_key}'] = value
+
+        return info
+
+
+def _agent_key(agent: Any) -> str:
+    return str(agent).replace('.', '_')
+
+
+class PettingZooAECWrapper(gym.Env):
+    """Adapt a PettingZoo AECEnv to the ``World``/``EnvPool`` contract.
+
+    One SWM step advances one selected PettingZoo agent turn. The current
+    agent is exposed through ``current_agent`` and ``current_agent_idx``.
+    """
+
+    metadata = {'render_modes': []}
+
+    def __init__(
+        self,
+        env: Any,
+        *,
+        reward_aggregation: str | Callable[[dict[Any, float]], float] = 'sum',
+    ) -> None:
+        super().__init__()
+        self.env = env
+        self.possible_agents = list(env.possible_agents)
+        if not self.possible_agents:
+            raise ValueError('PettingZoo env must define possible_agents.')
+
+        self._agent_to_key = {
+            agent: _agent_key(agent) for agent in self.possible_agents
+        }
+        if len(set(self._agent_to_key.values())) != len(self._agent_to_key):
+            raise ValueError(
+                'PettingZoo agent names must be unique after string '
+                f'conversion: {self._agent_to_key!r}'
+            )
+        self._key_to_agent = {v: k for k, v in self._agent_to_key.items()}
+        self._agent_indices = {
+            agent: i for i, agent in enumerate(self.possible_agents)
+        }
+        self.reward_aggregation = reward_aggregation
+        self._step_counter = 0
+        self._id = 0
+        self._current_agent = self.possible_agents[0]
+        self._last_actions = {
+            agent: _empty_action(env.action_space(agent))
+            for agent in self.possible_agents
+        }
+        self._last_observations = {
+            agent: _empty_observation(env.observation_space(agent))
+            for agent in self.possible_agents
+        }
+        self._last_infos = {agent: {} for agent in self.possible_agents}
+
+        self.action_space = gym.spaces.Dict(
+            {
+                self._agent_to_key[agent]: env.action_space(agent)
+                for agent in self.possible_agents
+            }
+        )
+        self.observation_space = gym.spaces.Dict(
+            {
+                self._agent_to_key[agent]: env.observation_space(agent)
+                for agent in self.possible_agents
+            }
+        )
+        self.metadata = getattr(env, 'metadata', self.metadata)
+
+    @property
+    def agents(self) -> list[Any]:
+        return list(getattr(self.env, 'agents', []))
+
+    @property
+    def unwrapped(self):
+        return getattr(self.env, 'unwrapped', self.env)
+
+    def reset(self, *, seed=None, options=None):
+        self._step_counter = 0
+        self.env.reset(seed=seed, options=options)
+        self._id = _episode_id(self.env)
+        self._last_actions = {
+            agent: _empty_action(self.env.action_space(agent))
+            for agent in self.possible_agents
+        }
+        self._last_observations = {
+            agent: _empty_observation(self.env.observation_space(agent))
+            for agent in self.possible_agents
+        }
+        self._last_infos = {agent: {} for agent in self.possible_agents}
+        self._capture_current_agent()
+
+        rewards = _agent_attr_dict(self.env, 'rewards')
+        terminations = _agent_attr_dict(self.env, 'terminations')
+        truncations = _agent_attr_dict(self.env, 'truncations')
+        info = self._build_info(
+            rewards=rewards,
+            terminations=terminations,
+            truncations=truncations,
+            env_reward=np.nan,
+            env_terminated=False,
+            env_truncated=False,
+        )
+        return self._last_observations, info
+
+    def step(self, action):
+        if not self.agents:
+            info = self._build_info(
+                rewards={},
+                terminations={},
+                truncations={},
+                env_reward=0.0,
+                env_terminated=True,
+                env_truncated=False,
+            )
+            return self._last_observations, 0.0, True, False, info
+
+        agent = self._current_agent
+        actions = self._to_agent_actions(action)
+        agent_action = actions.get(agent)
+        if agent_action is None:
+            agent_action = _empty_action(self.env.action_space(agent))
+        self.env.step(agent_action)
+        self._step_counter += 1
+        self._last_actions[agent] = agent_action
+
+        rewards = _agent_attr_dict(self.env, 'rewards')
+        terminations = _agent_attr_dict(self.env, 'terminations')
+        truncations = _agent_attr_dict(self.env, 'truncations')
+        env_reward = self._aggregate_reward(rewards)
+        env_done = not self.agents
+        env_terminated = env_done and any(
+            bool(v) for v in terminations.values()
+        )
+        env_truncated = (
+            env_done
+            and not env_terminated
+            and any(bool(v) for v in truncations.values())
+        )
+        self._capture_current_agent()
+        info = self._build_info(
+            rewards=rewards,
+            terminations=terminations,
+            truncations=truncations,
+            env_reward=env_reward,
+            env_terminated=env_terminated,
+            env_truncated=env_truncated,
+        )
+        return (
+            self._last_observations,
+            env_reward,
+            env_terminated,
+            env_truncated,
+            info,
+        )
+
+    def render(self):
+        return self.env.render()
+
+    def close(self):
+        self.env.close()
+
+    def _capture_current_agent(self) -> None:
+        if not self.agents:
+            return
+        agent = getattr(self.env, 'agent_selection', self.agents[0])
+        observation, reward, termination, truncation, info = self.env.last()
+        self._current_agent = agent
+        self._last_observations[agent] = observation
+        self._last_infos[agent] = info or {}
+        rewards = _agent_attr_dict(self.env, 'rewards')
+        rewards[agent] = reward
+        terminations = _agent_attr_dict(self.env, 'terminations')
+        terminations[agent] = termination
+        truncations = _agent_attr_dict(self.env, 'truncations')
+        truncations[agent] = truncation
+
+    def _to_agent_actions(self, action) -> dict[Any, Any]:
+        if isinstance(action, dict):
+            return {
+                self._key_to_agent.get(key, key): value
+                for key, value in action.items()
+            }
+        return {self._current_agent: action}
+
+    def _aggregate_reward(self, rewards: dict[Any, float]) -> float:
+        if callable(self.reward_aggregation):
+            return float(self.reward_aggregation(rewards))
+        values = [float(v) for v in rewards.values()]
+        if not values:
+            return 0.0
+        if self.reward_aggregation == 'sum':
+            return float(np.sum(values))
+        if self.reward_aggregation == 'mean':
+            return float(np.mean(values))
+        raise ValueError(
+            "reward_aggregation must be 'sum', 'mean', or a callable."
+        )
+
+    def _build_info(
+        self,
+        *,
+        rewards: dict[Any, float],
+        terminations: dict[Any, bool],
+        truncations: dict[Any, bool],
+        env_reward: float,
+        env_terminated: bool,
+        env_truncated: bool,
+    ) -> dict[str, Any]:
+        live_agents = set(self.agents)
+        current_agent = self._current_agent if self.agents else None
+        info: dict[str, Any] = {
+            'agent_mask': np.array(
+                [agent in live_agents for agent in self.possible_agents],
+                dtype=bool,
+            ),
+            'current_agent_idx': (
+                self._agent_indices[current_agent]
+                if current_agent is not None
+                else -1
+            ),
+            'current_agent': (
+                self._agent_to_key[current_agent]
+                if current_agent is not None
+                else ''
+            ),
+            'reward': env_reward,
+            'terminated': bool(env_terminated),
+            'truncated': bool(env_truncated),
+            'step_idx': self._step_counter,
+            'id': self._id,
+        }
+
+        for agent in self.possible_agents:
+            key = self._agent_to_key[agent]
+            _write_space_value(
+                info,
+                f'observation.{key}',
+                self._last_observations[agent],
+                self.env.observation_space(agent),
+                _empty_observation,
+            )
+            _write_space_value(
+                info,
+                f'action.{key}',
+                self._last_actions[agent],
+                self.env.action_space(agent),
+                _empty_action,
+            )
+            info[f'reward.{key}'] = float(rewards.get(agent, 0.0))
+            info[f'terminated.{key}'] = bool(terminations.get(agent, False))
+            info[f'truncated.{key}'] = bool(truncations.get(agent, False))
+
+            for sub_key, value in self._last_infos.get(agent, {}).items():
+                if _is_stackable(value):
+                    info[f'info.{key}.{sub_key}'] = value
+
+        return info
+
+
+def _episode_id(env: Any) -> int:
+    rng = getattr(env, 'np_random', None)
+    if rng is None:
+        rng = getattr(getattr(env, 'unwrapped', None), 'np_random', None)
+    if rng is not None:
+        max_int = np.iinfo(np.int64).max
+        if hasattr(rng, 'integers'):
+            return int(rng.integers(0, max_int))
+        if hasattr(rng, 'randint'):
+            return int(rng.randint(0, max_int))
+    return int(np.random.default_rng().integers(0, np.iinfo(np.int64).max))
+
+
+def _empty_observation(space: gym.Space) -> np.ndarray:
+    if isinstance(space, gym.spaces.Dict):
+        return {
+            key: _empty_observation(subspace)
+            for key, subspace in space.spaces.items()
+        }
+    if isinstance(space, gym.spaces.Tuple):
+        return tuple(_empty_observation(subspace) for subspace in space.spaces)
+    if isinstance(space, gym.spaces.Box):
+        return np.zeros(space.shape, dtype=space.dtype)
+    if isinstance(space, gym.spaces.Discrete):
+        return np.array(-1, dtype=np.int64)
+    if isinstance(space, gym.spaces.MultiDiscrete):
+        return np.full(space.nvec.shape, -1, dtype=np.int64)
+    if isinstance(space, gym.spaces.MultiBinary):
+        return np.full(space.shape, -1, dtype=np.int8)
+    sample = space.sample()
+    return np.zeros_like(_as_array(sample))
+
+
+def _empty_action(space: gym.Space) -> np.ndarray:
+    if isinstance(space, gym.spaces.Dict):
+        return {
+            key: _empty_action(subspace)
+            for key, subspace in space.spaces.items()
+        }
+    if isinstance(space, gym.spaces.Tuple):
+        return tuple(_empty_action(subspace) for subspace in space.spaces)
+    if isinstance(space, gym.spaces.Box):
+        if np.issubdtype(space.dtype, np.floating):
+            return np.full(space.shape, np.nan, dtype=space.dtype)
+        return np.zeros(space.shape, dtype=space.dtype)
+    if isinstance(space, gym.spaces.Discrete):
+        return np.array(-1, dtype=np.int64)
+    if isinstance(space, gym.spaces.MultiDiscrete):
+        return np.full(space.nvec.shape, -1, dtype=np.int64)
+    if isinstance(space, gym.spaces.MultiBinary):
+        return np.full(space.shape, -1, dtype=np.int8)
+    sample = _as_array(space.sample())
+    if np.issubdtype(sample.dtype, np.floating):
+        return np.full_like(sample, np.nan)
+    return np.zeros_like(sample)
+
+
+def _as_array(value: Any) -> np.ndarray:
+    if isinstance(value, np.ndarray):
+        return value.copy()
+    return np.asarray(value)
+
+
+def _is_stackable(value: Any) -> bool:
+    return isinstance(value, (np.ndarray, bool, int, float, np.number))
+
+
+def _write_space_value(
+    info: dict[str, Any],
+    prefix: str,
+    value: Any,
+    space: gym.Space,
+    empty_value: Callable[[gym.Space], Any],
+) -> None:
+    if isinstance(space, gym.spaces.Dict):
+        value = value if isinstance(value, dict) else empty_value(space)
+        for key, subspace in space.spaces.items():
+            sub_value = value.get(key, empty_value(subspace))
+            _write_space_value(
+                info,
+                f'{prefix}.{_agent_key(key)}',
+                sub_value,
+                subspace,
+                empty_value,
+            )
+        return
+    if isinstance(space, gym.spaces.Tuple):
+        if not isinstance(value, tuple | list):
+            value = empty_value(space)
+        for i, subspace in enumerate(space.spaces):
+            sub_value = value[i] if i < len(value) else empty_value(subspace)
+            _write_space_value(
+                info, f'{prefix}.{i}', sub_value, subspace, empty_value
+            )
+        return
+    info[prefix] = _as_array(value)
+
+
+def _env_done(
+    env: Any,
+    terminations: dict[Any, bool],
+    truncations: dict[Any, bool],
+) -> bool:
+    live = list(getattr(env, 'agents', []))
+    if not live:
+        return True
+    return all(
+        bool(terminations.get(agent, False))
+        or bool(truncations.get(agent, False))
+        for agent in live
+    )
+
+
+def _agent_attr_dict(env: Any, name: str) -> dict[Any, Any]:
+    value = getattr(env, name, {})
+    return dict(value) if value is not None else {}

--- a/tests/test_env_pool.py
+++ b/tests/test_env_pool.py
@@ -54,6 +54,40 @@ class CounterEnv(gym.Env):
         }
 
 
+class TupleActionEnv(gym.Env):
+    def __init__(self):
+        super().__init__()
+        self.observation_space = gym.spaces.Box(0, 1, shape=(1,))
+        self.action_space = gym.spaces.Tuple(
+            (
+                gym.spaces.Discrete(3),
+                gym.spaces.Box(-1, 1, shape=(1,), dtype=np.float32),
+            )
+        )
+        self.last_action = None
+
+    def reset(self, *, seed=None, options=None):
+        self.last_action = None
+        return np.zeros(1, dtype=np.float32), self._make_info(-1, [-1.0])
+
+    def step(self, action):
+        self.last_action = action
+        discrete, continuous = action
+        return (
+            np.zeros(1, dtype=np.float32),
+            0.0,
+            False,
+            False,
+            self._make_info(discrete, continuous),
+        )
+
+    def _make_info(self, discrete, continuous):
+        return {
+            'discrete_action': np.array([discrete], dtype=np.int64),
+            'continuous_action': np.asarray(continuous, dtype=np.float32),
+        }
+
+
 def _make_pool(n: int = 3, max_steps: int = 5) -> EnvPool:
     return EnvPool([lambda ms=max_steps: CounterEnv(ms) for _ in range(n)])
 
@@ -175,6 +209,25 @@ def test_step_all():
     assert not np.any(truncs)
     # all envs at step 1
     np.testing.assert_array_equal(infos['state'], [[[1.0]], [[1.0]], [[1.0]]])
+    pool.close()
+
+
+def test_step_slices_tuple_action_space_components():
+    pool = EnvPool([lambda: TupleActionEnv() for _ in range(2)])
+    pool.reset()
+
+    actions = (
+        np.array([1, 2], dtype=np.int64),
+        np.array([[0.5], [0.75]], dtype=np.float32),
+    )
+    _, _, _, _, infos = pool.step(actions)
+
+    assert pool.envs[0].last_action[0] == 1
+    assert pool.envs[1].last_action[0] == 2
+    np.testing.assert_array_equal(infos['discrete_action'][:, 0, 0], [1, 2])
+    np.testing.assert_allclose(
+        infos['continuous_action'][:, 0, 0], [0.5, 0.75]
+    )
     pool.close()
 
 

--- a/tests/test_env_pool.py
+++ b/tests/test_env_pool.py
@@ -54,40 +54,6 @@ class CounterEnv(gym.Env):
         }
 
 
-class TupleActionEnv(gym.Env):
-    def __init__(self):
-        super().__init__()
-        self.observation_space = gym.spaces.Box(0, 1, shape=(1,))
-        self.action_space = gym.spaces.Tuple(
-            (
-                gym.spaces.Discrete(3),
-                gym.spaces.Box(-1, 1, shape=(1,), dtype=np.float32),
-            )
-        )
-        self.last_action = None
-
-    def reset(self, *, seed=None, options=None):
-        self.last_action = None
-        return np.zeros(1, dtype=np.float32), self._make_info(-1, [-1.0])
-
-    def step(self, action):
-        self.last_action = action
-        discrete, continuous = action
-        return (
-            np.zeros(1, dtype=np.float32),
-            0.0,
-            False,
-            False,
-            self._make_info(discrete, continuous),
-        )
-
-    def _make_info(self, discrete, continuous):
-        return {
-            'discrete_action': np.array([discrete], dtype=np.int64),
-            'continuous_action': np.asarray(continuous, dtype=np.float32),
-        }
-
-
 def _make_pool(n: int = 3, max_steps: int = 5) -> EnvPool:
     return EnvPool([lambda ms=max_steps: CounterEnv(ms) for _ in range(n)])
 
@@ -209,25 +175,6 @@ def test_step_all():
     assert not np.any(truncs)
     # all envs at step 1
     np.testing.assert_array_equal(infos['state'], [[[1.0]], [[1.0]], [[1.0]]])
-    pool.close()
-
-
-def test_step_slices_tuple_action_space_components():
-    pool = EnvPool([lambda: TupleActionEnv() for _ in range(2)])
-    pool.reset()
-
-    actions = (
-        np.array([1, 2], dtype=np.int64),
-        np.array([[0.5], [0.75]], dtype=np.float32),
-    )
-    _, _, _, _, infos = pool.step(actions)
-
-    assert pool.envs[0].last_action[0] == 1
-    assert pool.envs[1].last_action[0] == 2
-    np.testing.assert_array_equal(infos['discrete_action'][:, 0, 0], [1, 2])
-    np.testing.assert_allclose(
-        infos['continuous_action'][:, 0, 0], [0.5, 0.75]
-    )
     pool.close()
 
 

--- a/tests/test_pettingzoo.py
+++ b/tests/test_pettingzoo.py
@@ -1,0 +1,331 @@
+import gymnasium as gym
+import numpy as np
+import pytest
+
+from stable_worldmodel import MultiAgentRandomPolicy
+from stable_worldmodel.world import EnvPool, World
+from stable_worldmodel.wrapper import (
+    PettingZooAECWrapper,
+    PettingZooParallelWrapper,
+)
+
+
+class TinyParallelEnv:
+    metadata = {'render_modes': ['rgb_array']}
+
+    def __init__(self, max_cycles: int = 2):
+        self.possible_agents = ['player_0', 'player_1']
+        self.agents = []
+        self.max_cycles = max_cycles
+        self.cycles = 0
+        self.np_random = np.random.default_rng()
+        self.action_log = []
+        self.observation_spaces = {
+            agent: gym.spaces.Dict(
+                {
+                    'obs': gym.spaces.Box(
+                        low=0, high=10, shape=(1,), dtype=np.float32
+                    ),
+                    'action_mask': gym.spaces.MultiBinary(2),
+                }
+            )
+            for agent in self.possible_agents
+        }
+        self.action_spaces = {
+            agent: gym.spaces.Discrete(2) for agent in self.possible_agents
+        }
+
+    @property
+    def unwrapped(self):
+        return self
+
+    def observation_space(self, agent):
+        return self.observation_spaces[agent]
+
+    def action_space(self, agent):
+        return self.action_spaces[agent]
+
+    def reset(self, seed=None, options=None):
+        if seed is not None:
+            self.np_random = np.random.default_rng(seed)
+        self.agents = list(self.possible_agents)
+        self.cycles = 0
+        self.action_log.clear()
+        return self._observations(), self._infos()
+
+    def step(self, actions):
+        assert set(actions) <= set(self.agents)
+        self.action_log.append({k: int(v) for k, v in actions.items()})
+        self.cycles += 1
+        rewards = {agent: float(actions[agent]) for agent in self.agents}
+        terminations = {
+            agent: self.cycles >= self.max_cycles for agent in self.agents
+        }
+        truncations = {agent: False for agent in self.agents}
+        if all(terminations.values()):
+            observations = {}
+            infos = {
+                agent: {'score': float(self.cycles)} for agent in self.agents
+            }
+            self.agents = []
+        else:
+            observations = self._observations()
+            infos = self._infos()
+        return observations, rewards, terminations, truncations, infos
+
+    def render(self):
+        return np.zeros((8, 8, 3), dtype=np.uint8)
+
+    def close(self):
+        pass
+
+    def _observations(self):
+        return {
+            agent: {
+                'obs': np.array([self.cycles], dtype=np.float32),
+                'action_mask': np.ones(2, dtype=np.int8),
+            }
+            for agent in self.agents
+        }
+
+    def _infos(self):
+        return {
+            agent: {'score': np.array([self.cycles], dtype=np.float32)}
+            for agent in self.agents
+        }
+
+
+class TinyAECEnv:
+    metadata = {'render_modes': ['rgb_array']}
+
+    def __init__(self, max_cycles: int = 4):
+        self.possible_agents = ['player_0', 'player_1']
+        self.agents = []
+        self.max_cycles = max_cycles
+        self.agent_selection = None
+        self.turns = 0
+        self.np_random = np.random.default_rng()
+        self.rewards = {}
+        self.terminations = {}
+        self.truncations = {}
+        self.infos = {}
+        self.action_log = []
+        self.observation_spaces = {
+            agent: gym.spaces.Box(low=0, high=10, shape=(1,), dtype=np.float32)
+            for agent in self.possible_agents
+        }
+        self.action_spaces = {
+            agent: gym.spaces.Discrete(2) for agent in self.possible_agents
+        }
+
+    @property
+    def unwrapped(self):
+        return self
+
+    def observation_space(self, agent):
+        return self.observation_spaces[agent]
+
+    def action_space(self, agent):
+        return self.action_spaces[agent]
+
+    def reset(self, seed=None, options=None):
+        if seed is not None:
+            self.np_random = np.random.default_rng(seed)
+        self.agents = list(self.possible_agents)
+        self.agent_selection = self.agents[0]
+        self.turns = 0
+        self.rewards = {agent: 0.0 for agent in self.possible_agents}
+        self.terminations = {agent: False for agent in self.possible_agents}
+        self.truncations = {agent: False for agent in self.possible_agents}
+        self.infos = {
+            agent: {'turns': np.array([0], dtype=np.float32)}
+            for agent in self.possible_agents
+        }
+        self.action_log.clear()
+
+    def last(self):
+        agent = self.agent_selection
+        return (
+            np.array([self.turns], dtype=np.float32),
+            self.rewards.get(agent, 0.0),
+            self.terminations.get(agent, False),
+            self.truncations.get(agent, False),
+            self.infos.get(agent, {}),
+        )
+
+    def step(self, action):
+        agent = self.agent_selection
+        self.action_log.append((agent, int(action)))
+        self.rewards = {a: 0.0 for a in self.possible_agents}
+        self.rewards[agent] = float(action)
+        self.turns += 1
+        if self.turns >= self.max_cycles:
+            self.terminations = {a: True for a in self.possible_agents}
+            self.agents = []
+            self.agent_selection = None
+            return
+        self.agent_selection = self.agents[
+            self.turns % len(self.possible_agents)
+        ]
+        self.infos[self.agent_selection] = {
+            'turns': np.array([self.turns], dtype=np.float32)
+        }
+
+    def render(self):
+        return np.zeros((8, 8, 3), dtype=np.uint8)
+
+    def close(self):
+        pass
+
+
+class MemoryWriter:
+    def __init__(self):
+        self.episodes = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return None
+
+    def write_episode(self, ep_data):
+        self.episodes.append(ep_data)
+
+    def write_episodes(self, episodes):
+        self.episodes.extend(list(episodes))
+
+
+def test_parallel_wrapper_flattens_agent_columns():
+    env = PettingZooParallelWrapper(TinyParallelEnv(max_cycles=2))
+
+    _, info = env.reset(seed=123)
+
+    np.testing.assert_array_equal(info['agent_mask'], [True, True])
+    np.testing.assert_array_equal(info['observation.player_0.obs'], [0.0])
+    np.testing.assert_array_equal(
+        info['observation.player_0.action_mask'], [1, 1]
+    )
+    assert info['action.player_0'] == -1
+    assert np.isnan(info['reward'])
+    assert not info['terminated']
+
+    _, reward, terminated, truncated, info = env.step(
+        {'player_0': 1, 'player_1': 0}
+    )
+
+    assert reward == 1.0
+    assert not terminated
+    assert not truncated
+    assert info['action.player_0'] == 1
+    assert info['reward.player_0'] == 1.0
+    assert env.env.action_log[-1] == {'player_0': 1, 'player_1': 0}
+    env.close()
+
+
+def test_env_pool_slices_batched_dict_actions():
+    pool = EnvPool(
+        [
+            lambda: PettingZooParallelWrapper(TinyParallelEnv(max_cycles=2))
+            for _ in range(2)
+        ]
+    )
+    pool.reset(seed=0)
+
+    actions = {
+        'player_0': np.array([1, 0], dtype=np.int64),
+        'player_1': np.array([0, 1], dtype=np.int64),
+    }
+    _, rewards, terminateds, truncateds, infos = pool.step(actions)
+
+    np.testing.assert_array_equal(rewards, [1.0, 1.0])
+    np.testing.assert_array_equal(terminateds, [False, False])
+    np.testing.assert_array_equal(truncateds, [False, False])
+    assert pool.envs[0].env.action_log[-1] == {'player_0': 1, 'player_1': 0}
+    assert pool.envs[1].env.action_log[-1] == {'player_0': 0, 'player_1': 1}
+    np.testing.assert_array_equal(infos['action.player_0'][:, 0], [1, 0])
+    pool.close()
+
+
+def test_world_from_pettingzoo_collects_parallel_episodes():
+    world = World.from_pettingzoo(
+        lambda: TinyParallelEnv(max_cycles=2), num_envs=2
+    )
+    writer = MemoryWriter()
+    world.set_policy(MultiAgentRandomPolicy(seed=0))
+
+    world.collect(writer=writer, episodes=3, progress=False)
+
+    assert len(writer.episodes) == 3
+    for episode in writer.episodes:
+        assert set(
+            [
+                'agent_mask',
+                'observation.player_0.obs',
+                'observation.player_0.action_mask',
+                'action.player_0',
+                'reward.player_0',
+                'terminated.player_0',
+            ]
+        ) <= set(episode)
+        assert len(episode['reward.player_0']) == 2
+        assert all(
+            not isinstance(value, dict)
+            for values in episode.values()
+            for value in values
+        )
+    world.close()
+
+
+def test_aec_wrapper_advances_one_agent_turn_per_step():
+    env = PettingZooAECWrapper(TinyAECEnv(max_cycles=3))
+
+    _, info = env.reset(seed=123)
+
+    assert info['current_agent'] == 'player_0'
+    assert info['current_agent_idx'] == 0
+    np.testing.assert_array_equal(info['agent_mask'], [True, True])
+    np.testing.assert_array_equal(info['observation.player_0'], [0.0])
+    assert info['action.player_0'] == -1
+
+    _, reward, terminated, truncated, info = env.step(
+        {'player_0': 1, 'player_1': 0}
+    )
+
+    assert reward == 1.0
+    assert not terminated
+    assert not truncated
+    assert env.env.action_log[-1] == ('player_0', 1)
+    assert info['current_agent'] == 'player_1'
+    assert info['action.player_0'] == 1
+    np.testing.assert_array_equal(info['observation.player_1'], [1.0])
+    env.close()
+
+
+def test_world_from_pettingzoo_collects_aec_episodes():
+    world = World.from_pettingzoo(
+        lambda: TinyAECEnv(max_cycles=4), num_envs=2, api='aec'
+    )
+    writer = MemoryWriter()
+    world.set_policy(MultiAgentRandomPolicy(seed=0))
+
+    world.collect(writer=writer, episodes=3, progress=False)
+
+    assert len(writer.episodes) == 3
+    for episode in writer.episodes:
+        assert set(
+            [
+                'agent_mask',
+                'current_agent_idx',
+                'observation.player_0',
+                'action.player_0',
+                'reward.player_0',
+                'terminated.player_0',
+            ]
+        ) <= set(episode)
+        assert len(episode['reward.player_0']) == 4
+    world.close()
+
+
+def test_world_from_pettingzoo_rejects_unknown_api():
+    with pytest.raises(ValueError, match='api'):
+        World.from_pettingzoo(lambda: TinyParallelEnv(), num_envs=1, api='bad')

--- a/tests/test_pettingzoo.py
+++ b/tests/test_pettingzoo.py
@@ -275,16 +275,14 @@ def test_world_from_pettingzoo_collects_parallel_episodes():
 
     assert len(writer.episodes) == 3
     for episode in writer.episodes:
-        assert set(
-            [
-                'agent_mask',
-                'observation.player_0.obs',
-                'observation.player_0.action_mask',
-                'action.player_0',
-                'reward.player_0',
-                'terminated.player_0',
-            ]
-        ) <= set(episode)
+        assert {
+            'agent_mask',
+            'observation.player_0.obs',
+            'observation.player_0.action_mask',
+            'action.player_0',
+            'reward.player_0',
+            'terminated.player_0',
+        } <= set(episode)
         assert len(episode['reward.player_0']) == 2
         assert all(
             not isinstance(value, dict)
@@ -349,16 +347,14 @@ def test_world_from_pettingzoo_collects_aec_episodes():
 
     assert len(writer.episodes) == 3
     for episode in writer.episodes:
-        assert set(
-            [
-                'agent_mask',
-                'current_agent_idx',
-                'observation.player_0',
-                'action.player_0',
-                'reward.player_0',
-                'terminated.player_0',
-            ]
-        ) <= set(episode)
+        assert {
+            'agent_mask',
+            'current_agent_idx',
+            'observation.player_0',
+            'action.player_0',
+            'reward.player_0',
+            'terminated.player_0',
+        } <= set(episode)
         assert len(episode['reward.player_0']) == 4
     world.close()
 

--- a/tests/test_pettingzoo.py
+++ b/tests/test_pettingzoo.py
@@ -178,6 +178,25 @@ class TinyAECEnv:
         pass
 
 
+class DeadTurnAECEnv(TinyAECEnv):
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed, options=options)
+        self.terminations['player_0'] = True
+
+    def step(self, action):
+        agent = self.agent_selection
+        self.action_log.append((agent, action))
+        assert action is None
+        self.agents = ['player_1']
+        self.agent_selection = 'player_1'
+        self.rewards = {a: 0.0 for a in self.possible_agents}
+        self.terminations = {'player_0': True, 'player_1': False}
+        self.truncations = {a: False for a in self.possible_agents}
+        self.infos['player_1'] = {
+            'turns': np.array([self.turns], dtype=np.float32)
+        }
+
+
 class MemoryWriter:
     def __init__(self):
         self.episodes = []
@@ -200,6 +219,8 @@ def test_parallel_wrapper_flattens_agent_columns():
 
     _, info = env.reset(seed=123)
 
+    assert env.action_space.shape == (2,)
+    assert isinstance(env.action_space.sample(), np.ndarray)
     np.testing.assert_array_equal(info['agent_mask'], [True, True])
     np.testing.assert_array_equal(info['observation.player_0.obs'], [0.0])
     np.testing.assert_array_equal(
@@ -210,7 +231,7 @@ def test_parallel_wrapper_flattens_agent_columns():
     assert not info['terminated']
 
     _, reward, terminated, truncated, info = env.step(
-        {'player_0': 1, 'player_1': 0}
+        np.array([1, 0], dtype=np.int64)
     )
 
     assert reward == 1.0
@@ -222,7 +243,7 @@ def test_parallel_wrapper_flattens_agent_columns():
     env.close()
 
 
-def test_env_pool_slices_batched_dict_actions():
+def test_env_pool_steps_batched_pettingzoo_ndarray_actions():
     pool = EnvPool(
         [
             lambda: PettingZooParallelWrapper(TinyParallelEnv(max_cycles=2))
@@ -231,10 +252,7 @@ def test_env_pool_slices_batched_dict_actions():
     )
     pool.reset(seed=0)
 
-    actions = {
-        'player_0': np.array([1, 0], dtype=np.int64),
-        'player_1': np.array([0, 1], dtype=np.int64),
-    }
+    actions = np.array([[1, 0], [0, 1]], dtype=np.int64)
     _, rewards, terminateds, truncateds, infos = pool.step(actions)
 
     np.testing.assert_array_equal(rewards, [1.0, 1.0])
@@ -288,7 +306,7 @@ def test_aec_wrapper_advances_one_agent_turn_per_step():
     assert info['action.player_0'] == -1
 
     _, reward, terminated, truncated, info = env.step(
-        {'player_0': 1, 'player_1': 0}
+        np.array([1, 0], dtype=np.int64)
     )
 
     assert reward == 1.0
@@ -298,6 +316,25 @@ def test_aec_wrapper_advances_one_agent_turn_per_step():
     assert info['current_agent'] == 'player_1'
     assert info['action.player_0'] == 1
     np.testing.assert_array_equal(info['observation.player_1'], [1.0])
+    env.close()
+
+
+def test_aec_wrapper_passes_none_for_dead_agent_turn():
+    env = PettingZooAECWrapper(DeadTurnAECEnv())
+
+    _, info = env.reset(seed=123)
+
+    assert info['current_agent'] == 'player_0'
+    assert info['terminated.player_0']
+
+    _, _, terminated, truncated, info = env.step(
+        np.array([1, 0], dtype=np.int64)
+    )
+
+    assert not terminated
+    assert not truncated
+    assert env.env.action_log[-1] == ('player_0', None)
+    assert info['current_agent'] == 'player_1'
     env.close()
 
 


### PR DESCRIPTION
## Summary
- Add `World.from_pettingzoo(...)` for PettingZoo Parallel and AEC environments.
- Wrap PettingZoo multi-agent action spaces as a flat ndarray-compatible action space so `EnvPool` can keep its normal `actions[i]` stepping path.
- Record per-agent observations, actions, rewards, termination flags, masks, and AEC current-agent metadata as stable `world.infos` columns.
- Add docs, exports, and focused tests for Parallel collection, AEC turn stepping, dead-agent cleanup turns, and ndarray batched actions.

## Scope
Closes #243.

This treats each PettingZoo env instance as one SWM env:
- Parallel API: one SWM step advances all live agents.
- AEC API: one SWM step advances the currently selected PettingZoo agent, including `None` cleanup actions for dead-agent turns.

## Validation
- `ruff check` passed on touched Python files.
- `ruff format --check` passed on touched Python files.
- `pytest tests/test_pettingzoo.py tests/test_env_pool.py -q` passed: `52 passed`.
- GPU host smoke-tested real `pettingzoo.classic.rps_v2` for Parallel and AEC collection/evaluation on an NVIDIA RTX 4090.
- Collected on-disk Lance datasets and trained small CUDA transition-model smoke tests for both Parallel and AEC datasets.