### PR TITLE
Modified pyproject.toml to use PyAV ('av') as the macOS alternative for sys_platform='darwin'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,8 @@ env = [
 format = [
     "h5py",
     "hdf5plugin",
-    "decord",
+    "decord; sys_platform != 'darwin'",
+    "av; sys_platform == 'darwin'",
     "imageio[ffmpeg]",
 ]
 
@@ -82,7 +83,8 @@ dev = [
   "mkdocs-shadcn",
   "pymdown-extensions",
   "pillow",
-  "decord",
+  "decord; sys_platform != 'darwin'",
+  "av; sys_platform == 'darwin'",
   "imageio[ffmpeg]",
   "mkdocstrings[python]",
 ]

--- a/stable_worldmodel/data/formats/__init__.py
+++ b/stable_worldmodel/data/formats/__init__.py
@@ -2,7 +2,7 @@
 whose optional dependencies are available; the rest are silently skipped.
 
 Lance and folder ship with the core install. HDF5, video, and lerobot
-need their backing libraries (h5py, decord/imageio, lerobot); install
+need their backing libraries (h5py, decord/av/imageio, lerobot); install
 them together with the umbrella extra ``[format]``.
 """
 

--- a/stable_worldmodel/data/formats/video.py
+++ b/stable_worldmodel/data/formats/video.py
@@ -18,10 +18,94 @@ from stable_worldmodel.data.formats.utils import is_image_column
 from stable_worldmodel.data.formats.folder import FolderDataset
 
 
-class VideoDataset(FolderDataset):
-    """Loads frames from MP4 files (one per episode) using decord."""
+class _AvVideoReader:
+    """Minimal decord-compatible MP4 reader backed by PyAV (``av``).
 
-    _decord: Any = None  # Lazy module reference
+    Implements only the part of decord's ``VideoReader`` API that
+    :class:`VideoDataset` relies on (integer indexing and ``get_batch``),
+    returning ``uint8`` torch tensors laid out as ``(..., H, W, C)`` in RGB,
+    matching decord's torch bridge so the two backends are interchangeable.
+    """
+
+    def __init__(self, path: str) -> None:
+        import av
+
+        self._av = av
+        self.path = path
+
+    def __getitem__(self, index: int) -> torch.Tensor:
+        return self.get_batch([index])[0]
+
+    def get_batch(self, indices) -> torch.Tensor:
+        frames = self._decode(indices)
+        return torch.from_numpy(np.stack([frames[i] for i in indices]))
+
+    def _decode(self, indices) -> dict[int, np.ndarray]:
+        wanted = set(indices)
+        out: dict[int, np.ndarray] = {}
+        with self._av.open(self.path) as container:
+            stream = container.streams.video[0]
+            rate, time_base = stream.average_rate, stream.time_base
+            start = stream.start_time or 0
+            use_pts = bool(rate and time_base)
+            scale = float(time_base * rate) if use_pts else 0.0
+            if use_pts:
+                # Seek to the keyframe at or before the first wanted frame so
+                # reading a slice near the end doesn't decode the whole clip;
+                # frames are matched back to their index via pts.
+                offset = start + int(min(wanted) / rate / time_base)
+                container.seek(
+                    offset, stream=stream, backward=True, any_frame=False
+                )
+            counter = 0
+            for frame in container.decode(stream):
+                if use_pts:
+                    if frame.pts is None:
+                        continue
+                    idx = round((frame.pts - start) * scale)
+                else:
+                    idx, counter = counter, counter + 1
+                if idx in wanted:
+                    out[idx] = frame.to_ndarray(format='rgb24')
+                    if len(out) == len(wanted):
+                        break
+        return out
+
+
+def _make_video_reader():
+    """Return a ``path -> reader`` factory for the first available backend.
+
+    decord is preferred where it ships wheels (Linux, Windows); PyAV is the
+    fallback elsewhere, notably macOS arm64, which has no decord wheel.
+    """
+    try:
+        import decord
+
+        decord.bridge.set_bridge('torch')
+        return lambda path: decord.VideoReader(path, num_threads=1)
+    except ImportError:
+        pass
+
+    try:
+        import av  # noqa: F401
+
+        return _AvVideoReader
+    except ImportError:
+        pass
+
+    raise ImportError('VideoDataset requires decord or av')
+
+
+class VideoDataset(FolderDataset):
+    """Loads frames from MP4 files (one per episode).
+
+    Frames are decoded with decord where it ships wheels (Linux, Windows)
+    and with PyAV (``av``) elsewhere, notably macOS arm64, where decord has
+    no wheel. Both backends share the same reader API, so only the backend
+    selection differs across platforms.
+    """
+
+    _make_reader: Any = None  # cached path -> reader factory
 
     def __init__(
         self,
@@ -29,29 +113,22 @@ class VideoDataset(FolderDataset):
         video_keys: list[str] | None = None,
         **kw: Any,
     ) -> None:
-        # Probe decord up-front so we fail fast if it's missing, but don't
-        # rely on the cached reference surviving DataLoader worker spawn —
-        # _ensure_decord re-imports lazily inside the worker process.
-        self._ensure_decord()
+        # Resolve the backend up-front so we fail fast if neither decord nor
+        # av is installed. The cached factory doesn't survive DataLoader
+        # worker spawn, so it is re-resolved lazily in each worker.
+        self._ensure_reader()
         super().__init__(name=name, folder_keys=video_keys or ['video'], **kw)
 
     @classmethod
-    def _ensure_decord(cls):
-        if cls._decord is None:
-            try:
-                import decord
-
-                decord.bridge.set_bridge('torch')
-                cls._decord = decord
-            except ImportError:
-                raise ImportError('VideoDataset requires decord')
-        return cls._decord
+    def _ensure_reader(cls):
+        if cls._make_reader is None:
+            cls._make_reader = _make_video_reader()
+        return cls._make_reader
 
     @lru_cache(maxsize=8)
     def _reader(self, ep_idx: int, key: str) -> Any:
-        return self._ensure_decord().VideoReader(
-            str(self.path / key / f'ep_{ep_idx}.mp4'), num_threads=1
-        )
+        path = str(self.path / key / f'ep_{ep_idx}.mp4')
+        return self._ensure_reader()(path)
 
     def _load_file(self, ep_idx: int, step: int, key: str) -> np.ndarray:
         return self._reader(ep_idx, key)[step].numpy()

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -656,17 +656,16 @@ def test_video_dataset_load_file(sample_video_dataset):
     assert frame.shape == (64, 64, 3)
 
 
-def test_video_dataset_decord_import_error(sample_video_dataset):
-    """Test VideoDataset raises ImportError when decord is not available."""
+def test_video_dataset_backend_import_error(sample_video_dataset):
+    """VideoDataset raises ImportError when no decoder backend is installed."""
     cache_dir, name = sample_video_dataset
 
-    # Reset the class-level cached decord module
-    VideoDataset._decord = None
-
-    # Mock the import to raise ImportError
-    with patch.dict(sys.modules, {'decord': None}):
-        with pytest.raises(ImportError, match='VideoDataset requires decord'):
+    # Reset the cached factory and hide both backends.
+    VideoDataset._make_reader = None
+    with patch.dict(sys.modules, {'decord': None, 'av': None}):
+        with pytest.raises(ImportError, match='VideoDataset requires'):
             VideoDataset(name, cache_dir=str(cache_dir))
+    VideoDataset._make_reader = None  # re-resolve for later tests
 
 
 ##############################################################################

--- a/tests/data/test_format.py
+++ b/tests/data/test_format.py
@@ -25,7 +25,11 @@ from stable_worldmodel.data import (
 from stable_worldmodel.data.formats.folder import Folder, FolderWriter
 from stable_worldmodel.data.formats.hdf5 import HDF5, HDF5Writer
 from stable_worldmodel.data.formats.lerobot import LeRobot
-from stable_worldmodel.data.formats.video import Video, VideoWriter
+from stable_worldmodel.data.formats.video import (
+    Video,
+    VideoWriter,
+    _AvVideoReader,
+)
 
 
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -522,6 +526,28 @@ class TestVideoWriter:
         ep0 = ds.load_episode(0)
         assert ep0['pixels'].shape[0] == 8
         assert ep0['pixels'].shape[1] == 3  # CHW after reader permute
+
+    def test_av_roundtrip(self, tmp_path):
+        if importlib.util.find_spec('av') is None:
+            pytest.skip('av not available')
+
+        out = tmp_path / 'video_ds'
+        eps = [self._video_episode(8), self._video_episode(10)]
+        with VideoWriter(out, fps=25) as w:
+            for ep in eps:
+                w.write_episode(ep)
+
+        # Force the PyAV backend so this exercises av even where decord
+        # is also installed.
+        VideoDataset._make_reader = _AvVideoReader
+        try:
+            ds = VideoDataset(path=out, video_keys=['pixels'])
+            assert list(ds.lengths) == [8, 10]
+            ep0 = ds.load_episode(0)
+            assert ep0['pixels'].shape[0] == 8
+            assert ep0['pixels'].shape[1] == 3  # CHW after reader permute
+        finally:
+            VideoDataset._make_reader = None
 
     def test_append_extends_existing_video_dir(self, tmp_path):
         out = tmp_path / 'video_ds'


### PR DESCRIPTION
Good day,

I was attempting to install the project from source with the ff. commands:
```
git clone https://github.com/galilai-group/stable-worldmodel
cd stable-worldmodel/
uv venv --python=3.10
source .venv/bin/activate
uv sync --extra all --group dev
```

However, I received an error:
```
warning: The package `typer==0.26.7` does not have an extra named `all`
error: Distribution `decord==0.6.0 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're on macOS (`macosx_26_0_arm64`), but `decord` (v0.6.0) only has wheels for the following platforms: `manylinux2010_x86_64`, `win_amd64`; consider adding "sys_platform == 'darwin' and platform_machine == 'arm64'" to `tool.uv.required-environments` to ensure uv resolves to a version with compatible wheels
```

I modified the pyproject.toml file and did the installation steps again. Got no error on my end. I hope this helps. Thank you.