### PR TITLE
Respect symmetric rotations in PushT success checks

### DIFF
--- a/stable_worldmodel/envs/pusht/env.py
+++ b/stable_worldmodel/envs/pusht/env.py
@@ -51,6 +51,12 @@ class PushT(gym.Env):
         self.goal_state = None
 
         self.shapes = ['o', 'L', 'T', 'Z', 'square', 'I', 'small_tee', '+']
+        self.shape_symmetry_angles = {
+            'square': np.pi / 2,
+            '+': np.pi / 2,
+            'I': np.pi,
+            'Z': np.pi,
+        }
 
         # Velocities are last two components of proprio and state; they can be negative
         # (Pymunk). Declaring low=0 made passive_env_checker reject valid observations.
@@ -346,9 +352,20 @@ class PushT(gym.Env):
 
     def eval_state(self, goal_state, cur_state):
         # success if position difference is < 20, and angle difference < np.pi/9
+        goal_state = np.asarray(goal_state, dtype=np.float64)
+        cur_state = np.asarray(cur_state, dtype=np.float64)
         pos_diff = np.linalg.norm(goal_state[:4] - cur_state[:4])
-        angle_diff = np.abs(goal_state[4] - cur_state[4])
-        angle_diff = np.minimum(angle_diff, 2 * np.pi - angle_diff)
+
+        # Compare angles modulo the block's rotational symmetry: square/+ match
+        # every 90 degrees, and Z/I match every 180 degrees. Other shapes use
+        # a full rotation, preserving the original orientation check.
+        block_shape = self.shapes[
+            int(self.variation_space['block']['shape'].value)
+        ]
+        symmetry = self.shape_symmetry_angles.get(block_shape, 2 * np.pi)
+        angle_diff = np.abs(goal_state[4] - cur_state[4]) % symmetry
+        angle_diff = np.minimum(angle_diff, symmetry - angle_diff)
+
         success = pos_diff < 20 and angle_diff < np.pi / 9
         state_dist = np.linalg.norm(goal_state - cur_state)
 
@@ -803,19 +820,18 @@ class PushT(gym.Env):
         mask=pymunk.ShapeFilter.ALL_MASKS(),
     ):
         mass = 1
-        length = 2
         vertices1 = [
-            (0, 0),
-            (0, length * scale / 2),
-            (length * scale, length * scale / 2),
-            (length * scale, 0),
+            (-scale / 2, 0),
+            (-scale / 2, scale),
+            (3 * scale / 2, scale),
+            (3 * scale / 2, 0),
         ]
         inertia1 = pymunk.moment_for_poly(mass, vertices=vertices1)
         vertices2 = [
-            (-length * scale / 2, 0),
-            (length * scale / 2, 0),
-            (length * scale / 2, -length * scale / 2),
-            (-length * scale / 2, -length * scale / 2),
+            (-3 * scale / 2, 0),
+            (scale / 2, 0),
+            (scale / 2, -scale),
+            (-3 * scale / 2, -scale),
         ]
         inertia2 = pymunk.moment_for_poly(mass, vertices=vertices2)
         body = pymunk.Body(mass, inertia1 + inertia2)

--- a/tests/envs/test_pusht_env.py
+++ b/tests/envs/test_pusht_env.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from stable_worldmodel.envs.pusht.env import PushT
+
+
+@pytest.mark.parametrize(
+    'shape,angle,expected_success,expected_distance',
+    [
+        ('L', np.pi, False, np.pi),
+        ('T', np.pi, False, np.pi),
+        ('Z', np.pi, True, np.pi),
+        ('square', np.pi / 2, True, np.pi / 2),
+        ('I', np.pi, True, np.pi),
+        ('small_tee', np.pi, False, np.pi),
+        ('+', np.pi / 2, True, np.pi / 2),
+    ],
+)
+def test_pusht_eval_state_respects_block_shape_rotation_symmetry(
+    shape,
+    angle,
+    expected_success,
+    expected_distance,
+):
+    env = PushT()
+    env.variation_space.set_value({'block.shape': env.shapes.index(shape)})
+
+    goal_state = np.array([100.0, 100.0, 256.0, 256.0, 0.0, 0.0, 0.0])
+    cur_state = goal_state.copy()
+    cur_state[4] = angle
+
+    success, distance = env.eval_state(goal_state, cur_state)
+
+    assert bool(success) is expected_success
+    assert distance == pytest.approx(expected_distance)


### PR DESCRIPTION
## Summary

This PR fixes PushT success detection for block shapes that look the same after certain rotations.

### Rotation check

Previously, `eval_state` treated every shape as if its full angle had to match the goal. That is too strict for symmetric shapes. A square rotated by 90 degrees is still visually aligned with the goal, and an `I` or `Z` rotated by 180 degrees is also visually the same.

This change compares the block angle using each shape's symmetry:

- `square` and `+`: match every 90 degrees
- `I` and `Z`: match every 180 degrees
- all other shapes: keep the original full-rotation check

The returned `state_dist` is unchanged, so rewards still use the same raw Euclidean distance as before.

### Z shape update

The `Z` shape should count as matching after a 180-degree rotation, but its old vertices were not centered around the rotation point. That made the symmetry check invalid for `Z`.

This PR shifts the local `Z` vertices so the shape rotates around its 180-degree symmetry center. The shape keeps the same size; only its local coordinate frame changes.

<img width="2700" height="1650" alt="image" src="https://github.com/user-attachments/assets/223b9245-e52b-4f7f-8a36-3608e463b3ea" />

## Tests

Adds a PushT eval-state test that checks:

- `L`, `T`, and `small_tee` still fail when rotated 180 degrees
- `Z` and `I` pass when rotated 180 degrees
- `square` and `+` pass when rotated 90 degrees
- `state_dist` is still the raw distance

## Verification

- `git diff --check`
- `python -m py_compile stable_worldmodel/envs/pusht/env.py tests/envs/test_pusht_env.py`
- `uv run --no-dev --with pytest --with gymnasium --with pygame --with pymunk --with opencv-python-headless --with imageio --with shapely pytest tests/envs/test_pusht_env.py -q`