### PR TITLE
Fix RandomPolicy seed not applied in set_env

### DIFF
--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -174,6 +174,11 @@ class RandomPolicy(BasePolicy):
         """
         return self.env.action_space.sample()
 
+    def set_env(self, env: Any) -> None:
+        super().set_env(env)
+        if self.seed is not None:
+            self.set_seed(self.seed)
+
     def set_seed(self, seed: int) -> None:
         """Set the random seed for action sampling.
 

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -155,7 +155,9 @@ class RandomPolicy(BasePolicy):
         """Initialize the random policy.
 
         Args:
-            seed: Optional random seed for the action space.
+            seed: Random seed applied to the action space when the environment
+                is attached. If None, the action space uses its own default RNG,
+                making action sampling non-deterministic across runs.
             **kwargs: Additional configuration parameters.
         """
         super().__init__(**kwargs)
@@ -177,14 +179,9 @@ class RandomPolicy(BasePolicy):
     def set_env(self, env: Any) -> None:
         super().set_env(env)
         if self.seed is not None:
-            self.set_seed(self.seed)
+            self._set_seed(self.seed)
 
-    def set_seed(self, seed: int) -> None:
-        """Set the random seed for action sampling.
-
-        Args:
-            seed: The seed value.
-        """
+    def _set_seed(self, seed: int) -> None:
         if self.env is not None:
             self.env.action_space.seed(seed)
 

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -169,12 +169,12 @@ class World:
         """Attach a policy and configure it for this world's envs.
 
         Calls ``policy.set_env(self.envs)``. If the policy exposes a
-        ``seed`` attribute and ``set_seed`` method, the seed is applied.
+        ``seed`` attribute and ``_set_seed`` method, the seed is applied.
         """
         self.policy = policy
         self.policy.set_env(self.envs)
-        if hasattr(self.policy, 'seed') and self.policy.seed is not None:
-            self.policy.set_seed(self.policy.seed)
+        if hasattr(self.policy, '_set_seed') and self.policy.seed is not None:
+            self.policy._set_seed(self.policy.seed)
 
     def reset(self, seed=None, options=None) -> None:
         """Reset every env and refresh ``self.infos``.

--- a/tests/test_new_world.py
+++ b/tests/test_new_world.py
@@ -450,7 +450,7 @@ class TestSetPolicy:
                 self.seed = 1234
                 self.seed_calls = []
 
-            def set_seed(self, seed):
+            def _set_seed(self, seed):
                 self.seed_calls.append(seed)
 
         world = _make_world(num_envs=2)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -114,19 +114,19 @@ def test_random_policy_get_action():
 
 
 def test_random_policy_set_seed():
-    """Test RandomPolicy.set_seed method."""
-    policy = RandomPolicy(seed=42)
+    """Test that set_env auto-applies the constructor seed to the action space."""
+    policy = RandomPolicy(seed=123)
     mock_env = MagicMock()
     policy.set_env(mock_env)
-    policy.set_seed(123)
     mock_env.action_space.seed.assert_called_once_with(123)
 
 
-def test_random_policy_set_seed_no_env():
-    """Test RandomPolicy.set_seed when env is None."""
-    policy = RandomPolicy(seed=42)
-    # Should not raise
-    policy.set_seed(123)
+def test_random_policy_set_env_no_seed_skips_seeding():
+    """Test that set_env does not seed the action space when seed is None."""
+    policy = RandomPolicy()
+    mock_env = MagicMock()
+    policy.set_env(mock_env)
+    mock_env.action_space.seed.assert_not_called()
 
 
 ###########################

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -450,7 +450,7 @@ class TestSetPolicy:
                 self.seed = 1234
                 self.seed_calls = []
 
-            def set_seed(self, seed):
+            def _set_seed(self, seed):
                 self.seed_calls.append(seed)
 
         world = _make_world(num_envs=2)


### PR DESCRIPTION
If `set_env()` is called after construction, the `self.seed` configured in `__init__` is silently not applied to the new
environment's action space.