### PR TITLE
Fix public Lance dataset URI in HF notebook

### DIFF
--- a/scripts/notebooks/train_from_hf_buckets.ipynb
+++ b/scripts/notebooks/train_from_hf_buckets.ipynb
@@ -162,7 +162,7 @@
     "import time\n",
     "from stable_worldmodel.data.formats.lance import Lance\n",
     "\n",
-    "URI = 'hf://buckets/galilai-group/swm/pusht_expert_train.lance'\n",
+    "URI = 'hf://datasets/galilai-group/lewm-pusht/pusht_expert_train.lance'\n",
     "\n",
     "t = time.perf_counter()\n",
     "dataset = Lance.open_reader(\n",
@@ -200,7 +200,7 @@
       "\u001b[32m07:03:42\u001b[0m | \u001b[1mINFO \u001b[0m | \u001b[36m__init__.py \u001b[0m| \u001b[1mTensorFlow version 2.20.0 available.\u001b[0m\n",
       "\u001b[32m07:03:42\u001b[0m | \u001b[1mINFO \u001b[0m | \u001b[36m__init__.py \u001b[0m| \u001b[1mJAX version 0.7.2 available.\u001b[0m\n",
       "\u001b[32m07:03:47\u001b[0m | \u001b[1mINFO \u001b[0m | \u001b[36matomic_chec~\u001b[0m| \u001b[1m[atomic_save] installed crash-safe checkpoint plugin (write to sibling .tmp + fsync + atomic rename)\u001b[0m\n",
-      "Loading dataset \"hf://buckets/galilai-group/swm/pusht_expert_train.lance\" from default location\n",
+      "Loading dataset \"hf://datasets/galilai-group/lewm-pusht/pusht_expert_train.lance\" from default location\n",
       "[2026-06-02 07:03:50,711][root][WARNING] - LanceDataset: keys_to_cache=['action', 'proprio', 'state'] is not required — Lance has efficient random access via batched __getitems__.\n",
       "\u001b[32m07:04:22\u001b[0m | \u001b[1mINFO \u001b[0m | \u001b[36mutils.py    \u001b[0m| \u001b[1mCreated ViT-tiny from scratch with config: {'hidden_size': 192, 'num_hidden_layers': 12, 'num_attention_heads': 3, 'intermediate_size': 768, 'image_size': 224, 'patch_size': 14}\u001b[0m\n",
       "\u001b[32m07:04:23\u001b[0m | \u001b[1mINFO \u001b[0m | \u001b[36mmodule.py   \u001b[0m| \u001b[1mSetting up DataModule\u001b[0m\n",
@@ -1127,7 +1127,7 @@
       "    │   │              │             └ {'output_model_name': 'lewm', 'subdir': '${hydra:job.id}', 'num_workers': 6, 'train_split': 0.9, 'seed': 3072, 'img_size': 22...\n",
       "    │   │              └ <function run at 0x7a775b316f20>\n",
       "    │   └ <property object at 0x7a79236f6750>\n",
-      "    └ JobReturn(overrides=['data.dataset.name=hf://buckets/galilai-group/swm/pusht_expert_train.lance', 'loader.batch_size=32', 'lo...\n",
+      "    └ JobReturn(overrides=['data.dataset.name=hf://datasets/galilai-group/lewm-pusht/pusht_expert_train.lance', 'loader.batch_size=32', 'lo...\n",
       "\n",
       "  File \"\u001b[32m/content/stable-worldmodel/scripts/train/\u001b[0m\u001b[32m\u001b[1mlewm.py\u001b[0m\", line \u001b[33m212\u001b[0m, in \u001b[35mrun\u001b[0m\n",
       "    \u001b[1mmanager\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\n",
@@ -1158,7 +1158,7 @@
    ],
    "source": [
     "#%cd stable-worldmodel\n",
-    "!python scripts/train/lewm.py data.dataset.name='hf://buckets/galilai-group/swm/pusht_expert_train.lance' loader.batch_size=32 loader.num_workers=2"
+    "!python scripts/train/lewm.py data.dataset.name='hf://datasets/galilai-group/lewm-pusht/pusht_expert_train.lance' loader.batch_size=32 loader.num_workers=2"
    ]
   },
   {


### PR DESCRIPTION
Updates the Hugging Face bucket training notebook to use the public Lance dataset URI instead of the private bucket URI reported in #262.\n\nVerification:\n- Opened hf://datasets/galilai-group/lewm-pusht/pusht_expert_train.lance with Lance.open_reader(num_steps=4, frameskip=5, keys_to_load=['pixels', 'action', 'proprio']).\n- Confirmed len=1,981,721.\n- Fetched row 0 successfully with sample shapes: pixels=(4, 3, 224, 224), action=(4, 10), proprio=(4, 4).\n- Ran git diff --check.