### PR TITLE
fix(lance_video): decode full episode in load_episode

### DIFF
--- a/stable_worldmodel/data/formats/lance_video.py
+++ b/stable_worldmodel/data/formats/lance_video.py
@@ -263,12 +263,12 @@ class LanceVideoDataset(LanceDataset):
         return dec
 
     def _decode_video_window(
-        self, ep_idx: int, vkey: str, local_start: int
+        self, ep_idx: int, vkey: str, local_start: int, num_steps: int
     ) -> torch.Tensor:
         self._ensure_videos_open()
         dec = self._decoder_for(ep_idx, vkey)
         indices = [
-            local_start + k * self.frameskip for k in range(self.num_steps)
+            local_start + k * self.frameskip for k in range(num_steps)
         ]
         return dec.get_frames_at(indices=indices).data  # (T, C, H, W) uint8
 
@@ -278,11 +278,16 @@ class LanceVideoDataset(LanceDataset):
         if g_end is None:
             g_end = g_start + self.span
         local_start = g_start - int(self.offsets[ep_idx])
+        # Number of frame-skipped frames spanning [g_start, g_end). For a
+        # fixed window this is `num_steps`, but `load_episode` passes a
+        # full-episode slice — decode every frame it covers, matching the
+        # frame-skipped tabular columns instead of truncating to one window.
+        num_steps = -(-(g_end - g_start) // self.frameskip)
         steps: dict[str, Any] = {}
         for col in self._keys:
             if col in self._video_keys:
                 steps[col] = self._decode_video_window(
-                    ep_idx, col, local_start
+                    ep_idx, col, local_start, num_steps
                 )
             else:
                 steps[col] = self._process_col(col, batch, g_start, g_end)

--- a/tests/data/test_convert_video_formats.py
+++ b/tests/data/test_convert_video_formats.py
@@ -49,24 +49,8 @@ EP_LENGTHS = (6, 8)
 HW = 32
 COLUMNS = {IMG_KEY, 'action', 'proprio'}
 
-# Known bug: LanceVideoDataset._decode_video_window decodes `num_steps` frames
-# (default 1) instead of the full episode, so `load_episode` — the path
-# `convert` reads through — truncates the video column. Every pair that reads a
-# lance_video dataset (as source, or as the destination read back for the
-# parity check) therefore fails until that is fixed. Marked xfail(strict) so
-# the suite stays green and these flip to a visible XPASS once the reader is
-# corrected.
-_LANCE_VIDEO_BUG = pytest.mark.xfail(
-    reason='lance_video load_episode truncates the video column to num_steps '
-    'frames instead of the full episode (LanceVideoDataset._decode_video_'
-    'window uses self.num_steps); convert round-trips a 1-frame episode.',
-    strict=True,
-)
-
-
 def _pair(src: str, dst: str):
-    marks = [_LANCE_VIDEO_BUG] if 'lance_video' in (src, dst) else []
-    return pytest.param(src, dst, id=f'{src}->{dst}', marks=marks)
+    return pytest.param(src, dst, id=f'{src}->{dst}')
 
 
 # Every directed pair among the three compressed-image formats.


### PR DESCRIPTION
LanceVideoDataset._decode_video_window decoded a fixed self.num_steps frames regardless of the requested slice. load_episode() passes a full-episode slice [0, ep_len), so with the default num_steps=1 the video column was truncated to a single frame while the tabular columns returned the whole episode — a misalignment that also broke convert/merge, which read through load_episode.

Derive the frame count from the slice length (frame-skip-downsampled) so the video branch covers the same rows as the tabular branch. For a fixed window this still equals num_steps. Drop the now-obsolete xfail(strict) markers on the lance_video convert round-trip tests.