### PR TITLE
fix: resolve Lance table name from Windows paths correctly

### DIFF
--- a/stable_worldmodel/data/formats/lance.py
+++ b/stable_worldmodel/data/formats/lance.py
@@ -255,13 +255,9 @@ class LanceDataset(Dataset):
 
         stripped = loc.rstrip('/')
         if stripped.lower().endswith('.lance'):
-            sep = stripped.rfind('/')
-            parent, leaf = (
-                (stripped[:sep], stripped[sep + 1 :])
-                if sep >= 0
-                else ('.', stripped)
-            )
-            return parent, leaf[: -len('.lance')]
+            p = Path(stripped)
+            parent = str(p.parent)
+            return parent, p.stem
 
         # Directory holding a single *.lance subdir.
         p = Path(loc)


### PR DESCRIPTION
## Problem

On Windows, loading a Lance dataset by path fails with:

thread 'lancedb-tokio-worker' panicked at rust\lancedb\src\database\listing.rs:1153:62:
called `Result::unwrap()` on an `Err` value: InvalidTableName {
  name: "C:\\Users\\...\\datasets\\smoke_test",
  reason: "Table names can only contain alphanumeric characters,
  underscores, hyphens, and periods"
}

## Root cause

`LanceDataset._resolve_uri_and_table` splits a `.lance` path into
`(parent_dir, table_name)` using `stripped.rfind('/')`, which only
recognizes forward slashes. On Windows, absolute paths use
backslashes, so the split fails silently and the entire path is
passed as the table name.

## Fix

Replaced the manual string-splitting logic with `pathlib.Path`,
which correctly parses both `/`- and `\`-separated paths on any
platform:

```python
if stripped.lower().endswith('.lance'):
    p = Path(stripped)
    return str(p.parent), p.stem
```

## Testing

Reproduced the bug on Windows 11 (RTX 3050 laptop) with the exact
panic above. After applying this fix, dataset loading succeeds and
the LeWM training script proceeds past data loading and model
construction. (Note: getting a full training epoch to complete
additionally required a separate, unrelated workaround for a
POSIX-only `signal.SIGUSR1` usage in the `stable-pretraining`
dependency  not part of this PR; happy to file that separately.)

No automated test added yet  will add one if maintainers can
point me to where Lance-format tests live in this repo (I didn't
find an existing `tests/data/test_lance*.py` to follow the
established pattern).