### PR TITLE
HDF5Writer: support variable-length string columns

### DIFF
--- a/stable_worldmodel/data/formats/hdf5.py
+++ b/stable_worldmodel/data/formats/hdf5.py
@@ -233,7 +233,9 @@ class HDF5Writer:
             if h5py.check_string_dtype(ds.dtype):
                 arr = np.array(
                     [
-                        v.decode() if isinstance(v, (bytes, bytearray)) else str(v)
+                        v.decode()
+                        if isinstance(v, (bytes, bytearray))
+                        else str(v)
                         for v in vals
                     ],
                     dtype=object,

--- a/stable_worldmodel/data/formats/hdf5.py
+++ b/stable_worldmodel/data/formats/hdf5.py
@@ -166,6 +166,15 @@ class HDF5Dataset(Dataset):
         return np.prod(data.shape[1:]).item() if data.ndim > 1 else 1
 
 
+def _is_string_col(sample) -> bool:
+    """True if a column's per-step value is text — stored as a variable-length
+    UTF-8 string rather than a numeric array. Covers python ``str``/``bytes`` and
+    numpy string/object (``U``/``S``/``O``) dtypes."""
+    if isinstance(sample, (str, bytes, bytearray)):
+        return True
+    return np.asarray(sample).dtype.kind in ('U', 'S', 'O')
+
+
 class HDF5Writer:
     """Append episodes to a single HDF5 file. Schema is inferred from the
     first episode and locked thereafter.
@@ -221,7 +230,17 @@ class HDF5Writer:
         for col, vals in ep_data.items():
             ds = self._f[col]
             ds.resize(self._global_ptr + ep_len, axis=0)
-            ds[self._global_ptr : self._global_ptr + ep_len] = np.array(vals)
+            if h5py.check_string_dtype(ds.dtype):
+                arr = np.array(
+                    [
+                        v.decode() if isinstance(v, (bytes, bytearray)) else str(v)
+                        for v in vals
+                    ],
+                    dtype=object,
+                )
+            else:
+                arr = np.array(vals)
+            ds[self._global_ptr : self._global_ptr + ep_len] = arr
 
         n = self._f['ep_len'].shape[0]
         self._f['ep_len'].resize(n + 1, axis=0)
@@ -261,6 +280,8 @@ class HDF5Writer:
                 f'unexpected columns: {sorted(extra)}.'
             )
         for col, vals in ep_data.items():
+            if h5py.check_string_dtype(self._f[col].dtype):
+                continue  # variable-length strings have no fixed per-step shape
             sample = np.asarray(vals[0])
             ds_shape = self._f[col].shape[1:]
             if sample.shape != ds_shape:
@@ -272,6 +293,16 @@ class HDF5Writer:
 
     def _init_schema(self, sample_ep: dict) -> None:
         for col, vals in sample_ep.items():
+            if _is_string_col(vals[0]):
+                # Text column: one variable-length UTF-8 string per step.
+                self._f.create_dataset(
+                    col,
+                    shape=(0,),
+                    maxshape=(None,),
+                    dtype=h5py.string_dtype(),
+                    chunks=(1,),
+                )
+                continue
             sample = np.asarray(vals[0])
             self._f.create_dataset(
                 col,

--- a/tests/data/test_format.py
+++ b/tests/data/test_format.py
@@ -216,6 +216,33 @@ class TestHDF5Writer:
         assert ep0['pixels'].shape == (5, 3, 8, 8)  # NCHW
         assert ep0['proprio'].shape == (5, 4)
 
+    def test_string_column_roundtrip(self, tmp_path):
+        # A per-step text column (e.g. a `lang_instr` caption) must be stored as
+        # a variable-length UTF-8 string and decode back to a python `str` on
+        # read — the reader already collapses string columns to one value per
+        # sampled window (see HDF5Dataset._load_slice).
+        out = tmp_path / 'data.h5'
+        eps = [
+            {
+                'action': [np.zeros(2, np.float32) for _ in range(n)],
+                'lang_instr': [f'push the T to goal {i}'] * n,
+            }
+            for i, n in enumerate((5, 7))
+        ]
+        with HDF5Writer(out) as w:
+            for ep in eps:
+                w.write_episode(ep)
+
+        with h5py.File(out, 'r') as f:
+            assert h5py.check_string_dtype(f['lang_instr'].dtype)
+            assert f['lang_instr'].shape == (12,)  # flat, one string per step
+
+        ds = HDF5Dataset(path=out)
+        assert list(ds.lengths) == [5, 7]
+        assert 'lang_instr' in ds.column_names
+        assert ds.load_episode(0)['lang_instr'] == 'push the T to goal 0'
+        assert ds.load_episode(1)['lang_instr'] == 'push the T to goal 1'
+
     def test_open_writer_via_format(self, tmp_path, two_episodes):
         out = tmp_path / 'data.h5'
         with HDF5.open_writer(out) as w:


### PR DESCRIPTION
## What

`HDF5Writer` infers each column's dtype from the first episode via `np.asarray(vals[0]).dtype`. For a text column that yields a numpy `<U` dtype, which h5py has no conversion path for — so any string column (e.g. a per-step `lang_instr` caption) raised on `create_dataset`. This was asymmetric with the reader: `HDF5Dataset._load_slice` already decodes string columns back to python `str`.

## Change

Store text columns (python `str`/`bytes`, or numpy `U`/`S`/`O` dtype) as a per-step variable-length UTF-8 string via `h5py.string_dtype()`:

- **`_init_schema`** — string columns get `shape=(0,)`, `maxshape=(None,)`, `dtype=h5py.string_dtype()`, `chunks=(1,)`; numeric columns unchanged.
- **`write_episode`** — string columns are written as an object array (bytes decoded to `str`); numeric assignment unchanged.
- **`_validate_episode_against_existing`** — skips the per-step-shape check for string columns (variable-length strings have no fixed feature shape).

This makes the reader/writer symmetric and lets `convert()` / `write_episodes` carry a caption column end to end.

## Motivation

Building a captioned dataset (adding a `lang_instr` text column alongside `pixels`/`action`/`state`) previously required a hand-rolled h5py pass because `HDF5Writer` couldn't hold strings. With this change the writer handles it natively.

## Test

Adds `TestHDF5Writer::test_string_column_roundtrip`: writes episodes with a `lang_instr` string column and asserts it stores as `h5py.string_dtype()` and decodes back to `str` via `HDF5Dataset`. Full `test_format.py` writer/convert suite passes (the 2 `TestCollectFormat` failures are pre-existing `No module named 'pygame'` from the uninstalled env extra, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)