### PR TITLE
[Docs] Updates to missing documentation throughout 

### DIFF
--- a/docs/api/planning.md
+++ b/docs/api/planning.md
@@ -5,6 +5,8 @@ summary: Composable objectives and cost evaluators for planning
 
 Solvers optimize action sequences against a [`Costable`][stable_worldmodel.planning.Costable] — anything exposing `get_cost(info_dict, action_candidates)`. Some world models implement it natively (e.g. TD-MPC2); for the others, this module provides the glue: a [`ShootingCostEvaluator`][stable_worldmodel.planning.ShootingCostEvaluator] composes any model exposing the [`Dynamics`][stable_worldmodel.planning.Dynamics] surface (`encode`/`rollout`) with a swappable [`Objective`][stable_worldmodel.planning.Objective], so changing the planning cost never requires subclassing the world model.
 
+
+
 ## **[ Quick Tour ]**
 
 ```python

--- a/docs/api/planning.md
+++ b/docs/api/planning.md
@@ -1,0 +1,129 @@
+---
+title: Planning
+summary: Composable objectives and cost evaluators for planning
+---
+
+Solvers optimize action sequences against a [`Costable`][stable_worldmodel.planning.Costable] — anything exposing `get_cost(info_dict, action_candidates)`. Some world models implement it natively (e.g. TD-MPC2); for the others, this module provides the glue: a [`ShootingCostEvaluator`][stable_worldmodel.planning.ShootingCostEvaluator] composes any model exposing the [`Dynamics`][stable_worldmodel.planning.Dynamics] surface (`encode`/`rollout`) with a swappable [`Objective`][stable_worldmodel.planning.Objective], so changing the planning cost never requires subclassing the world model.
+
+## **[ Quick Tour ]**
+
+```python
+import stable_worldmodel as swm
+from stable_worldmodel.planning import (
+    CEMSolver,
+    ControlPenalty,
+    GoalMSE,
+    ShootingCostEvaluator,
+    WeightedSum,
+)
+
+model = swm.wm.utils.load_pretrained('lewm/pusht')
+
+# 1. Single-term cost: last-step MSE to the goal embedding
+cost = ShootingCostEvaluator(model, GoalMSE())
+
+# 2. Multi-term cost: goal distance + action magnitude penalty
+cost = ShootingCostEvaluator(
+    model,
+    WeightedSum([(1.0, GoalMSE()), (0.1, ControlPenalty())]),
+)
+
+# 3. Plug into any solver — the evaluator duck-types as a Costable
+solver = CEMSolver(cost=cost, n_steps=30, num_samples=300, topk=30)
+config = swm.PlanConfig(horizon=10, receding_horizon=1, action_block=1)
+policy = swm.policy.WorldModelPolicy(solver=solver, config=config)
+```
+
+To plan under inequality constraints, pass objectives as `constraints=` — the
+evaluator then exposes `get_constraints` and satisfies the
+[`Constrainable`][stable_worldmodel.planning.Constrainable] protocol that
+[`LagrangianSolver`](solver.md#example-constrained-planning-with-lagrangiansolver)
+feature-detects:
+
+```python
+cost = ShootingCostEvaluator(
+    model,
+    GoalMSE(),
+    constraints=[ControlPenalty()],  # satisfied when <= 0
+)
+```
+
+### Writing a custom objective
+
+An objective is any callable mapping a populated `info_dict` to a
+per-candidate cost of shape `(B, S)`. The evaluator rolls candidates out
+first, so the `info_dict` already holds the rollout outputs (e.g.
+`predicted_emb`) plus the raw candidates under `action_candidates`:
+
+```python
+import torch.nn as nn
+
+
+class SmoothnessPenalty(nn.Module):
+    """Penalizes large action changes between consecutive steps."""
+
+    def forward(self, info_dict: dict) -> torch.Tensor:
+        actions = info_dict['action_candidates']  # (B, S, H, action_dim)
+        deltas = actions[..., 1:, :] - actions[..., :-1, :]
+        return deltas.pow(2).sum(dim=tuple(range(2, actions.ndim)))
+```
+
+## **[ Evaluator ]**
+
+::: stable_worldmodel.planning.ShootingCostEvaluator
+    options:
+        heading_level: 3
+        members: false
+        show_source: false
+
+::: stable_worldmodel.planning.ShootingCostEvaluator.get_cost
+
+::: stable_worldmodel.planning.ShootingCostEvaluator.criterion
+
+::: stable_worldmodel.planning.default_goal_encode
+
+## **[ Objectives ]**
+
+::: stable_worldmodel.planning.GoalMSE
+    options:
+        heading_level: 3
+        members: false
+        show_source: false
+
+::: stable_worldmodel.planning.ControlPenalty
+    options:
+        heading_level: 3
+        members: false
+        show_source: false
+
+::: stable_worldmodel.planning.WeightedSum
+    options:
+        heading_level: 3
+        members: false
+        show_source: false
+
+## **[ Protocols ]**
+
+The structural contracts live in `stable_worldmodel.protocols` and are
+re-exported from `stable_worldmodel.planning`. They are `Protocol` classes:
+nothing subclasses them, anything with the right methods satisfies them.
+
+::: stable_worldmodel.planning.Costable
+    options:
+        heading_level: 3
+        show_source: false
+
+::: stable_worldmodel.planning.Constrainable
+    options:
+        heading_level: 3
+        show_source: false
+
+::: stable_worldmodel.planning.Dynamics
+    options:
+        heading_level: 3
+        show_source: false
+
+::: stable_worldmodel.planning.Objective
+    options:
+        heading_level: 3
+        show_source: false

--- a/docs/api/planning.md
+++ b/docs/api/planning.md
@@ -5,6 +5,7 @@ summary: Composable objectives and cost evaluators for planning
 
 Solvers optimize action sequences against a [`Costable`][stable_worldmodel.planning.Costable] — anything exposing `get_cost(info_dict, action_candidates)`. Some world models implement it natively (e.g. TD-MPC2); for the others, this module provides the glue: a [`ShootingCostEvaluator`][stable_worldmodel.planning.ShootingCostEvaluator] composes any model exposing the [`Dynamics`][stable_worldmodel.planning.Dynamics] surface (`encode`/`rollout`) with a swappable [`Objective`][stable_worldmodel.planning.Objective], so changing the planning cost never requires subclassing the world model.
 
+
 ## **[ Quick Tour ]**
 
 ```python

--- a/docs/api/planning.md
+++ b/docs/api/planning.md
@@ -5,7 +5,6 @@ summary: Composable objectives and cost evaluators for planning
 
 Solvers optimize action sequences against a [`Costable`][stable_worldmodel.planning.Costable] — anything exposing `get_cost(info_dict, action_candidates)`. Some world models implement it natively (e.g. TD-MPC2); for the others, this module provides the glue: a [`ShootingCostEvaluator`][stable_worldmodel.planning.ShootingCostEvaluator] composes any model exposing the [`Dynamics`][stable_worldmodel.planning.Dynamics] surface (`encode`/`rollout`) with a swappable [`Objective`][stable_worldmodel.planning.Objective], so changing the planning cost never requires subclassing the world model.
 
-
 ## **[ Quick Tour ]**
 
 ```python

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,6 +80,28 @@ One `ep<idx>.mp4` is written per sampled episode. For a multi-view dataset (seve
 
 Rendering MP4s needs the optional video stack; install it with `pip install "stable-worldmodel[format]"`.
 
+## `swm convert <name> [output]`
+
+Convert a dataset to another storage format (e.g. HDF5 → video). The source format is auto-detected through the format registry — `lance`, `lance_video`, `hdf5`, `folder`, `video`, `lerobot` — and the converted copy is written next to the source in your cache directory.
+
+```bash
+swm convert pusht_expert_train                    # → pusht_expert_train-video
+swm convert pusht_expert_train pusht_h5 -f hdf5   # explicit output name
+```
+
+```
+Converting pusht_expert_train → video as pusht_expert_train-video
+Done. Output: ~/.stable_worldmodel/pusht_expert_train-video
+```
+
+| Option | Description |
+| --- | --- |
+| `output` | Output dataset name. Defaults to `<name>-<dest-format>`. |
+| `-f, --dest-format` | Destination format (default `video`). |
+| `--source-format` | Force the source format instead of auto-detecting it. |
+
+For a quick visual check of a few episodes, prefer [`swm preview`](#swm-preview-name) — it renders a sample without transcoding the whole dataset.
+
 ## `swm merge <sources...>`
 
 Concatenate several datasets into a single one. Episodes from each source are appended in the order given and renumbered into one contiguous episode range. Sources must share the same columns; a mismatch fails before anything is written.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -40,6 +40,7 @@ nav:
       - api/world.md
       - api/policy.md
       - api/solver.md
+      - api/planning.md
       - api/spaces.md
       - api/dataset.md
       - api/wrapper.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ swm = "stable_worldmodel.cli:app"
 [project.optional-dependencies]
 train = [
     "transformers>=4.50.0",
-    "stable-pretraining>=0.1.7",
+    "stable-pretraining>=0.1.8",
     "hydra-submitit-launcher",
     "wandb",
 ]

--- a/stable_worldmodel/data/dataset.py
+++ b/stable_worldmodel/data/dataset.py
@@ -56,6 +56,7 @@ class Dataset:
 
     @property
     def column_names(self) -> list[str]:
+        """Names of the columns stored in the dataset."""
         raise NotImplementedError
 
     def _load_slice(self, ep_idx: int, start: int, end: int) -> dict:
@@ -65,6 +66,15 @@ class Dataset:
         return len(self.clip_indices)
 
     def __getitem__(self, idx: int) -> dict:
+        """Load one clip of ``num_steps`` observations (``frameskip`` apart).
+
+        Args:
+            idx: Clip index into ``clip_indices``.
+
+        Returns:
+            Dict of per-column tensors for the clip; ``action`` is reshaped
+            to ``(num_steps, -1)`` so skipped actions stay grouped per step.
+        """
         ep_idx, start = self.clip_indices[idx]
         steps = self._load_slice(ep_idx, start, start + self.span)
         if 'action' in steps:
@@ -74,6 +84,17 @@ class Dataset:
     def load_chunk(
         self, episodes_idx: np.ndarray, start: np.ndarray, end: np.ndarray
     ) -> list[dict]:
+        """Load one step-range per episode, in bulk.
+
+        Args:
+            episodes_idx: Episode index for each slice to load.
+            start: Start step (inclusive) of each slice, per episode.
+            end: End step (exclusive) of each slice, per episode.
+
+        Returns:
+            One dict of per-column tensors per requested slice, in order;
+            ``action`` is reshaped to ``((end - start) // frameskip, -1)``.
+        """
         chunk = []
         for ep, s, e in zip(episodes_idx, start, end):
             steps = self._load_slice(ep, s, e)
@@ -85,15 +106,26 @@ class Dataset:
         return chunk
 
     def load_episode(self, episode_idx: int) -> dict:
+        """Load a full episode as a dict of per-column tensors.
+
+        Args:
+            episode_idx: Index of the episode to load.
+
+        Returns:
+            Dict of per-column tensors covering every step of the episode.
+        """
         return self._load_slice(episode_idx, 0, self.lengths[episode_idx])
 
     def get_col_data(self, col: str) -> np.ndarray:
+        """Return every value of column ``col`` across the whole dataset."""
         raise NotImplementedError
 
     def get_dim(self, col: str) -> int:
+        """Return the per-step dimensionality of column ``col``."""
         raise NotImplementedError
 
     def get_row_data(self, row_idx: int | list[int]) -> dict:
+        """Return all columns for the given flat storage row(s)."""
         raise NotImplementedError
 
     def merge_col(
@@ -102,6 +134,13 @@ class Dataset:
         target: str,
         dim: int = -1,
     ) -> None:
+        """Concatenate ``source`` column(s) into a new ``target`` column.
+
+        Args:
+            source: Column name(s) to combine.
+            target: Name of the resulting column.
+            dim: Axis along which the source columns are concatenated.
+        """
         raise NotImplementedError
 
 
@@ -136,6 +175,7 @@ class MergeDataset:
 
     @property
     def column_names(self) -> list[str]:
+        """Union of the columns contributed by each dataset, in order."""
         cols = []
         for keys in self.keys_map:
             cols.extend(keys)
@@ -143,6 +183,7 @@ class MergeDataset:
 
     @property
     def lengths(self) -> np.ndarray:
+        """Episode lengths, taken from the first dataset."""
         return self.datasets[0].lengths
 
     def __len__(self) -> int:
@@ -160,6 +201,7 @@ class MergeDataset:
     def load_chunk(
         self, episodes_idx: np.ndarray, start: np.ndarray, end: np.ndarray
     ) -> list[dict]:
+        """Load slices from every dataset and merge them column-wise."""
         all_chunks = [
             ds.load_chunk(episodes_idx, start, end) for ds in self.datasets
         ]
@@ -172,12 +214,14 @@ class MergeDataset:
         return merged
 
     def get_col_data(self, col: str) -> np.ndarray:
+        """Return column ``col`` from the dataset that contributes it."""
         for ds, keys in zip(self.datasets, self.keys_map):
             if col in keys:
                 return ds.get_col_data(col)
         raise KeyError(col)
 
     def get_row_data(self, row_idx: int | list[int]) -> dict:
+        """Return the given row(s) with columns gathered from all datasets."""
         out = {}
         for ds, keys in zip(self.datasets, self.keys_map):
             data = ds.get_row_data(row_idx)
@@ -188,7 +232,12 @@ class MergeDataset:
 
 
 class ConcatDataset:
-    """Concatenate datasets sequentially (vertical join, more episodes)."""
+    """Concatenate datasets sequentially (vertical join, more episodes).
+
+    Args:
+        datasets: Datasets to concatenate, in order. Episode and clip
+            indices of later datasets are shifted past the earlier ones.
+    """
 
     def __init__(self, datasets: list[Any]) -> None:
         if not datasets:
@@ -203,6 +252,7 @@ class ConcatDataset:
 
     @property
     def column_names(self) -> list[str]:
+        """Union of all datasets' columns, first occurrence order."""
         seen = set()
         cols = []
         for ds in self.datasets:
@@ -253,6 +303,7 @@ class ConcatDataset:
     def load_chunk(
         self, episodes_idx: np.ndarray, start: np.ndarray, end: np.ndarray
     ) -> list[dict]:
+        """Route each slice to its dataset using global episode indices."""
         episodes_idx = np.asarray(episodes_idx)
         start = np.asarray(start)
         end = np.asarray(end)
@@ -276,6 +327,7 @@ class ConcatDataset:
         return results  # type: ignore[return-value]
 
     def get_col_data(self, col: str) -> np.ndarray:
+        """Concatenate column ``col`` from every dataset that has it."""
         data = []
         for ds in self.datasets:
             if col in ds.column_names:
@@ -285,6 +337,7 @@ class ConcatDataset:
         return np.concatenate(data)
 
     def get_row_data(self, row_idx: int | list[int]) -> dict:
+        """Return the given global row(s), stacked when a list is given."""
         if isinstance(row_idx, int):
             ds_idx, local_idx = self._loc(row_idx)
             return self.datasets[ds_idx].get_row_data(local_idx)
@@ -310,6 +363,19 @@ class GoalDataset:
       - uniform future state in same episode
       - current state
     with probabilities (0.3, 0.5, 0.0, 0.2) by default.
+
+    Args:
+        dataset: The dataset to wrap.
+        goal_probabilities: 4-tuple of probabilities (random,
+            geometric_future, uniform_future, current); must sum to 1.
+        gamma: Discount for the geometric future sampler; the future offset
+            is drawn from ``Geom(1 - gamma)``.
+        current_goal_offset: Step offset (in clip steps) defining the
+            "current" state used as goal. Defaults to ``dataset.num_steps``.
+        goal_keys: Mapping of source column to goal column (e.g.
+            ``{'pixels': 'goal_pixels'}``). Defaults to ``pixels`` and
+            ``proprio`` when present in the dataset.
+        seed: Seed for the goal-sampling RNG.
     """
 
     def __init__(
@@ -382,6 +448,7 @@ class GoalDataset:
 
     @property
     def clip_indices(self):
+        """Clip indices, filtered to clips that still have a future frame."""
         return self._clip_indices
 
     def __len__(self):
@@ -389,6 +456,7 @@ class GoalDataset:
 
     @property
     def column_names(self):
+        """Columns of the wrapped dataset (goal columns are added per item)."""
         return self.dataset.column_names
 
     def _sample_goal_kind(self) -> str:

--- a/stable_worldmodel/data/normalization.py
+++ b/stable_worldmodel/data/normalization.py
@@ -50,15 +50,19 @@ class IdentityScaler:
     """No-op scaler. Use for columns that should pass through unchanged."""
 
     def fit(self, X):
+        """Do nothing; kept for sklearn-interface compatibility."""
         return self
 
     def transform(self, X):
+        """Return ``X`` unchanged."""
         return X
 
     def inverse_transform(self, X):
+        """Return ``X`` unchanged."""
         return X
 
     def fit_transform(self, X):
+        """Return ``X`` unchanged."""
         return X
 
     def __call__(self, X):
@@ -78,22 +82,26 @@ class ZScoreScaler:
         self.eps = eps
 
     def fit(self, X):
+        """Compute per-dim mean/std from ``X`` (NaN rows are dropped)."""
         data = _to_numpy_2d(X)
         self.mean = data.mean(axis=0, keepdims=True)
         self.std = data.std(axis=0, keepdims=True)
         return self
 
     def transform(self, X):
+        """Standardize ``X`` to ``(x - mean) / max(std, eps)``."""
         mean, std = _as_like(self.mean, self.std, X)
         if isinstance(X, torch.Tensor):
             return (X - mean) / std.clamp(min=self.eps)
         return (X - mean) / np.maximum(std, self.eps)
 
     def inverse_transform(self, X):
+        """Map standardized values back to the original scale."""
         mean, std = _as_like(self.mean, self.std, X)
         return X * std + mean
 
     def fit_transform(self, X):
+        """Fit on ``X`` then transform it."""
         return self.fit(X).transform(X)
 
     def __call__(self, X):
@@ -120,12 +128,14 @@ class PercentileScaler:
         self.eps = eps
 
     def fit(self, X):
+        """Compute the per-dim ``low``/``high`` percentile bounds from ``X``."""
         data = _to_numpy_2d(X)
         self.q_low = np.percentile(data, self.low, axis=0)
         self.q_high = np.percentile(data, self.high, axis=0)
         return self
 
     def transform(self, X):
+        """Map ``X`` linearly from ``[q_low, q_high]`` to ``[-1, 1]``, clipped."""
         q_low, q_high = _as_like(self.q_low, self.q_high, X)
         if isinstance(X, torch.Tensor):
             scale = (q_high - q_low).clamp(min=self.eps)
@@ -134,10 +144,12 @@ class PercentileScaler:
         return np.clip(2 * (X - q_low) / scale - 1, -1, 1)
 
     def inverse_transform(self, X):
+        """Map values from ``[-1, 1]`` back to ``[q_low, q_high]``."""
         q_low, q_high = _as_like(self.q_low, self.q_high, X)
         return (X + 1) * (q_high - q_low) / 2 + q_low
 
     def fit_transform(self, X):
+        """Fit on ``X`` then transform it."""
         return self.fit(X).transform(X)
 
     def __call__(self, X):

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -174,6 +174,13 @@ class RandomPolicy(BasePolicy):
         return self.env.action_space.sample()
 
     def set_env(self, env: Any) -> None:
+        """Attach the environment and seed its action space.
+
+        Args:
+            env: The environment to attach. If the policy was constructed
+                with a seed, the environment's action space is seeded so
+                action sampling is reproducible.
+        """
         super().set_env(env)
         if self.seed is not None:
             self._set_seed(self.seed)

--- a/stable_worldmodel/protocols.py
+++ b/stable_worldmodel/protocols.py
@@ -74,11 +74,30 @@ class Dynamics(Protocol):
     """The dynamics surface a ``ShootingCostEvaluator`` needs from a world model."""
 
     def encode(self, x: dict) -> dict:  # pragma: no cover
+        """Embed raw observations into the model's latent space.
+
+        Args:
+            x: Dictionary of observations (e.g. ``pixels``, proprioception).
+
+        Returns:
+            The dictionary augmented with latent embeddings (e.g. ``emb``).
+        """
         ...
 
     def rollout(
         self, info_dict: dict, action_candidates: torch.Tensor
     ) -> dict:  # pragma: no cover
+        """Roll candidate action sequences forward through the dynamics.
+
+        Args:
+            info_dict: Dictionary containing environment state information.
+            action_candidates: Tensor of proposed action sequences of shape
+                ``(B, S, H, action_dim)``.
+
+        Returns:
+            The dictionary populated with rollout outputs (e.g.
+            ``predicted_emb`` of shape ``(B, S, T-1, dim)``).
+        """
         ...
 
 
@@ -95,6 +114,15 @@ class Objective(Protocol):
     """
 
     def __call__(self, info_dict: dict) -> torch.Tensor:  # pragma: no cover
+        """Score a rolled-out ``info_dict``.
+
+        Args:
+            info_dict: Dictionary already populated with rollout outputs
+                (e.g. ``predicted_emb``) and any goal/conditioning keys.
+
+        Returns:
+            Per-candidate cost tensor of shape ``(B, S)``.
+        """
         ...
 
 

--- a/stable_worldmodel/wrapper/visual.py
+++ b/stable_worldmodel/wrapper/visual.py
@@ -124,14 +124,17 @@ class ChromaKeyWrapper(gym.Wrapper):
         return info
 
     def render(self):
+        """Render the wrapped env and chroma-key the returned frame."""
         frame = self.env.render()
         return frame if frame is None else self._apply(frame)
 
     def reset(self, **kwargs):
+        """Reset the wrapped env and chroma-key ``info['pixels*']``."""
         obs, info = self.env.reset(**kwargs)
         return obs, self._apply_to_info(info)
 
     def step(self, action):
+        """Step the wrapped env and chroma-key ``info['pixels*']``."""
         obs, reward, term, trunc, info = self.env.step(action)
         return obs, reward, term, trunc, self._apply_to_info(info)
 
@@ -153,6 +156,7 @@ class NoiseWrapper(_PixelTransform):
 
     @property
     def step_count(self):
+        """Number of ``env.step`` calls seen — the value fed to the schedule."""
         return self._step
 
     def _apply(self, frame):
@@ -165,6 +169,7 @@ class NoiseWrapper(_PixelTransform):
         )
 
     def step(self, action):
+        """Step the wrapped env, then advance the noise schedule counter."""
         out = super().step(action)
         self._step += 1
         return out
@@ -208,6 +213,7 @@ class ColorJitterWrapper(_PixelTransform):
         return out.astype(frame.dtype)
 
     def reset(self, **kwargs):
+        """Reset the wrapped env and resample the jitter factors."""
         self._sample()
         return super().reset(**kwargs)
 
@@ -259,6 +265,7 @@ class OcclusionWrapper(_PixelTransform):
         return out
 
     def reset(self, **kwargs):
+        """Reset the wrapped env and resample the occlusion patches."""
         self._patches = None
         return super().reset(**kwargs)
 
@@ -337,11 +344,13 @@ class MovingPatchWrapper(_PixelTransform):
         return out
 
     def reset(self, **kwargs):
+        """Reset the wrapped env and resample patch positions/velocities."""
         self._patches = None
         self._frame_shape = None
         return super().reset(**kwargs)
 
     def step(self, action):
+        """Step the wrapped env, then advance the patches by one velocity step."""
         out = super().step(action)
         self._advance()
         return out
@@ -412,6 +421,7 @@ class RandomConvWrapper(_PixelTransform):
         return np.clip(out, 0, 255).astype(frame.dtype)
 
     def reset(self, **kwargs):
+        """Reset the wrapped env and resample the conv weights."""
         self._sample()
         return super().reset(**kwargs)
 


### PR DESCRIPTION
This PR closes several documentation gaps found across the docs site and the codebase. No runtime behavior is changed — the only non-docstring code change is adding the new docs page to the mkdocs nav.

New docs

- docs/api/planning.md — new API reference page for the planning module, covering ShootingCostEvaluator, the built-in objectives (GoalMSE, ControlPenalty, WeightedSum), and the structural protocols (Costable, Constrainable, Dynamics, Objective). Includes a quick tour showing single-term and multi-term costs, plugging the evaluator into a solver, constrained planning via constraints=, and how to write a custom objective. Registered in the mkdocs.yaml nav.
- docs/cli.md — documents the previously undocumented swm convert command: usage, examples, option table (output, -f/--dest-format, --source-format), and a pointer to swm preview for quick visual checks.

New docstrings (no logic changes)

- data/dataset.py — documented the Dataset interface methods (__getitem__, load_chunk, load_episode, get_col_data, get_dim, get_row_data, merge_col) and filled in MergeDataset, ConcatDataset, and GoalDataset (including full Args for GoalDataset's goal-sampling parameters).
- data/normalization.py — documented the fit/transform/inverse_transform methods on IdentityScaler, ZScoreScaler, and PercentileScaler.
- protocols.py — documented Dynamics.encode/rollout and Objective.__call__, including expected tensor shapes ((B, S, H, action_dim) candidates, (B, S) costs).
- policy.py — documented RandomPolicy.set_env and its action-space seeding behavior.
- wrapper/visual.py — documented the render/reset/step overrides on the visual wrappers (ChromaKeyWrapper, NoiseWrapper, ColorJitterWrapper, OcclusionWrapper, MovingPatchWrapper, RandomConvWrapper), clarifying what each override resamples