### PR TITLE
Honor PushT block scale for the default tee

### DIFF
--- a/stable_worldmodel/envs/pusht/env.py
+++ b/stable_worldmodel/envs/pusht/env.py
@@ -648,7 +648,6 @@ class PushT(gym.Env):
         color='LightSlateGray',
         mask=pymunk.ShapeFilter.ALL_MASKS(),
     ):
-        scale = 30
         mass = 1
         length = 4
         vertices1 = [

--- a/tests/envs/test_pusht_env.py
+++ b/tests/envs/test_pusht_env.py
@@ -4,6 +4,27 @@ import pytest
 from stable_worldmodel.envs.pusht.env import PushT
 
 
+@pytest.mark.parametrize('scale', [20, 60])
+def test_pusht_default_tee_respects_block_scale_variation(scale):
+    env = PushT()
+    try:
+        env.reset(
+            seed=0,
+            options={'variation_values': {'block.scale': scale}},
+        )
+        x_coordinates = [
+            vertex.x
+            for shape in env.block.shapes
+            for vertex in shape.get_vertices()
+        ]
+
+        assert max(x_coordinates) - min(x_coordinates) == pytest.approx(
+            4 * scale
+        )
+    finally:
+        env.close()
+
+
 @pytest.mark.parametrize(
     'shape,angle,expected_success,expected_distance',
     [


### PR DESCRIPTION
## Summary

- remove the hard-coded scale override from the default PushT tee constructor
- add public reset-path regression coverage at two non-default block.scale values
- verify the resulting tee width scales as 4 times block.scale

This keeps the default value unchanged while making block.scale variations effective for the built-in T shape. Thanks to @dr-seth for the original report and reproduction in #269.

Fixes #269.

## Testing

- python -m pytest tests/envs/test_pusht_env.py -q
- ruff check stable_worldmodel/envs/pusht/env.py tests/envs/test_pusht_env.py
- ruff format --check stable_worldmodel/envs/pusht/env.py tests/envs/test_pusht_env.py
- python -m compileall -q stable_worldmodel/envs/pusht/env.py tests/envs/test_pusht_env.py
- git diff --check