### PR TITLE
Fix collect() dropping the reset frame

### DIFF
--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -307,7 +307,7 @@ class World:
 
         buffers = [defaultdict(list) for _ in range(self.num_envs)]
 
-        def on_step(world):
+        def on_step(world, mask):
             for col, data in world.infos.items():
                 if col.startswith('_'):
                     continue
@@ -318,7 +318,7 @@ class World:
                         data = data.squeeze(1)
                     else:
                         data = np.squeeze(data, axis=1)
-                for i in range(world.num_envs):
+                for i in np.where(mask)[0]:
                     val = data[i]
                     if isinstance(val, torch.Tensor):
                         val = val.detach().cpu().numpy()
@@ -385,6 +385,12 @@ class World:
         """Drive the policy and yield ``(env_idx, ep_count)`` on each
         episode completion. Letting callers consume completions as a
         generator is what makes streaming writes possible without threading.
+
+        ``on_step(world, mask)`` fires after every step and after every
+        reset (initial and per-env auto-reset), so callers see the reset
+        observation as well as stepped ones. ``mask`` marks which envs the
+        call reflects — all envs for a real step, just the reset ones for
+        an auto-reset.
         """
         assert mode in RESET_MODES, f'reset_mode must be one of {RESET_MODES}'
 
@@ -395,6 +401,8 @@ class World:
 
         if seed is not None or options is not None:
             self.reset(seed=seed, options=options)
+            if on_step:
+                on_step(self, mask=np.ones(self.num_envs, dtype=bool))
 
         alive = np.ones(self.num_envs, dtype=bool)
         next_seed = seed + self.num_envs if seed is not None else None
@@ -409,7 +417,7 @@ class World:
             )
 
             if on_step:
-                on_step(self)
+                on_step(self, mask=mask if mask is not None else alive)
 
             done = alive & (self.terminateds | self.truncateds)
             if not done.any():
@@ -439,6 +447,8 @@ class World:
                 self.terminateds[done] = False
                 self.truncateds[done] = False
                 self.infos['_needs_flush'] = done
+                if on_step:
+                    on_step(self, mask=done)
             elif mode == 'wait':
                 alive[done] = False
 
@@ -456,7 +466,7 @@ class World:
         }
         frames: dict[int, list] = defaultdict(list) if video else None
 
-        def on_step(world):
+        def on_step(world, mask):
             if frames is not None:
                 for i in range(world.num_envs):
                     f = world.infos['pixels'][i]
@@ -538,7 +548,7 @@ class World:
         }
         frames: dict[int, list] = defaultdict(list) if video else None
 
-        def on_step(world):
+        def on_step(world, mask):
             world.infos.update(deepcopy(goal_snapshot))
             results['episode_successes'] |= world.terminateds
             if frames is not None:

--- a/tests/data/test_integration_real.py
+++ b/tests/data/test_integration_real.py
@@ -235,6 +235,101 @@ def convert_hdf5_to_image_format(
                         img.save(img_dir / f'ep_{ep_idx}_step_{step_idx}.jpeg')
 
 
+class TestCollectResetFrame:
+    """Regression tests: collect() must include the reset observation as
+    frame 0 of every episode, with a trailing-NaN action marking the
+    boundary (matching MegaWrapper's own reset/step action convention)."""
+
+    @pytest.fixture
+    def temp_cache_dir(self, tmp_path):
+        return tmp_path
+
+    def test_first_frame_matches_reset_state(self, temp_cache_dir):
+        """The first buffered/recorded observation of a collected episode
+        must exactly match world.infos right after reset()."""
+        world = World(
+            env_name='swm/TwoRoom-v1',
+            num_envs=1,
+            image_shape=(32, 32),
+            max_episode_steps=6,
+            render_target=True,
+        )
+        policy = RandomPolicy(seed=0)
+        world.set_policy(policy)
+
+        world.reset(seed=0)
+        reset_state = np.array(world.infos['state'][0]).copy()
+
+        h5_path = temp_cache_dir / 'datasets' / 'reset_frame.h5'
+        world.collect(
+            h5_path, episodes=1, seed=0, format='hdf5', progress=False
+        )
+        world.envs.close()
+
+        with h5py.File(h5_path, 'r') as f:
+            first_state = f['state'][0]
+
+        np.testing.assert_allclose(first_state, reset_state.squeeze())
+
+    def test_action_has_single_trailing_nan(self, temp_cache_dir):
+        """Recorded action arrays should contain exactly one NaN entry per
+        episode, at the last index of that episode."""
+        world = World(
+            env_name='swm/TwoRoom-v1',
+            num_envs=1,
+            image_shape=(32, 32),
+            max_episode_steps=15,
+            render_target=True,
+        )
+        policy = RandomPolicy(seed=0)
+        world.set_policy(policy)
+
+        h5_path = temp_cache_dir / 'datasets' / 'trailing_nan.h5'
+        world.collect(
+            h5_path, episodes=3, seed=0, format='hdf5', progress=False
+        )
+        world.envs.close()
+
+        with h5py.File(h5_path, 'r') as f:
+            action = f['action'][:]
+            ep_offsets = f['ep_offset'][:]
+            ep_lengths = f['ep_len'][:]
+
+        nan_rows = np.where(np.isnan(action).any(axis=1))[0]
+
+        assert len(nan_rows) == len(ep_offsets)
+        for offset, length in zip(ep_offsets, ep_lengths):
+            assert (offset + length - 1) in nan_rows
+            # no NaN anywhere else in this episode
+            episode_actions = action[offset : offset + length - 1]
+            assert not np.isnan(episode_actions).any()
+
+    def test_short_episode_no_spurious_length(self, temp_cache_dir):
+        """An env that resets then terminates almost immediately should
+        still yield a well-formed episode (reset frame + terminal frame),
+        not a spurious length-0 episode."""
+        world = World(
+            env_name='swm/TwoRoom-v1',
+            num_envs=1,
+            image_shape=(32, 32),
+            max_episode_steps=1,
+            render_target=True,
+        )
+        policy = RandomPolicy(seed=0)
+        world.set_policy(policy)
+
+        h5_path = temp_cache_dir / 'datasets' / 'short_episode.h5'
+        world.collect(
+            h5_path, episodes=2, seed=0, format='hdf5', progress=False
+        )
+        world.envs.close()
+
+        with h5py.File(h5_path, 'r') as f:
+            ep_lengths = f['ep_len'][:]
+
+        assert (ep_lengths >= 2).all()
+
+
 class TestImageDatasetReal:
     """Test ImageDataset with real collected data."""
 

--- a/tests/test_new_world.py
+++ b/tests/test_new_world.py
@@ -177,21 +177,24 @@ class TestRunAutoMode:
         def on_done(env_idx, ep_idx, w):
             pass
 
-        def on_step(w):
+        def on_step(w, mask):
             infos_after_reset.append(w.infos['state'][0].copy())
 
         world._run(
             episodes=2, seed=0, mode='auto', on_step=on_step, on_done=on_done
         )
 
-        # after reset, state should go back to low values
-        # episode 1: state goes 1, 2 (terminates)
-        # episode 2: state goes 1, 2 (terminates)
+        # on_step now also fires right after each reset (initial + auto),
+        # so the reset frame (state=0) is captured before the step frames.
+        # episode 1: reset (0), step 1, step 2 (terminates)
+        # episode 2: reset (0), step 1, step 2 (terminates)
         states = [s[0] for s in infos_after_reset]
-        assert states[0] == 1.0
-        assert states[1] == 2.0  # terminates
-        assert states[2] == 1.0  # reset happened, fresh env
-        assert states[3] == 2.0
+        assert states[0] == 0.0  # initial reset
+        assert states[1] == 1.0
+        assert states[2] == 2.0  # terminates
+        assert states[3] == 0.0  # reset happened, fresh env
+        assert states[4] == 1.0
+        assert states[5] == 2.0
 
 
 class TestRunWaitMode:
@@ -260,12 +263,14 @@ class TestRunCallbacks:
 
         step_count = [0]
 
-        def on_step(w):
+        def on_step(w, mask):
             step_count[0] += 1
 
         world._run(max_steps=3, mode='wait', seed=0, on_step=on_step)
 
-        assert step_count[0] == 3
+        # +1 for the initial reset (seed is passed) firing on_step once
+        # before the 3 step-loop iterations.
+        assert step_count[0] == 4
 
     def test_on_done_receives_correct_ep_idx(self):
         world = _make_world(num_envs=2, max_steps=2)

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -177,21 +177,24 @@ class TestRunAutoMode:
         def on_done(env_idx, ep_idx, w):
             pass
 
-        def on_step(w):
+        def on_step(w, mask):
             infos_after_reset.append(w.infos['state'][0].copy())
 
         world._run(
             episodes=2, seed=0, mode='auto', on_step=on_step, on_done=on_done
         )
 
-        # after reset, state should go back to low values
-        # episode 1: state goes 1, 2 (terminates)
-        # episode 2: state goes 1, 2 (terminates)
+        # on_step now also fires right after each reset (initial + auto),
+        # so the reset frame (state=0) is captured before the step frames.
+        # episode 1: reset (0), step 1, step 2 (terminates)
+        # episode 2: reset (0), step 1, step 2 (terminates)
         states = [s[0] for s in infos_after_reset]
-        assert states[0] == 1.0
-        assert states[1] == 2.0  # terminates
-        assert states[2] == 1.0  # reset happened, fresh env
-        assert states[3] == 2.0
+        assert states[0] == 0.0  # initial reset
+        assert states[1] == 1.0
+        assert states[2] == 2.0  # terminates
+        assert states[3] == 0.0  # reset happened, fresh env
+        assert states[4] == 1.0
+        assert states[5] == 2.0
 
 
 class TestRunWaitMode:
@@ -260,12 +263,14 @@ class TestRunCallbacks:
 
         step_count = [0]
 
-        def on_step(w):
+        def on_step(w, mask):
             step_count[0] += 1
 
         world._run(max_steps=3, mode='wait', seed=0, on_step=on_step)
 
-        assert step_count[0] == 3
+        # +1 for the initial reset (seed is passed) firing on_step once
+        # before the 3 step-loop iterations.
+        assert step_count[0] == 4
 
     def test_on_done_receives_correct_ep_idx(self):
         world = _make_world(num_envs=2, max_steps=2)


### PR DESCRIPTION
## Summary

- have `on_step` fire once after the initial reset and once after each per-env auto-reset in `_run_iter`, scoped to the envs that were just reset, so `World.collect()` buffers the true first frame of every episode
- update `collect()`'s `on_step` to take the reset mask and only append for the affected envs, avoiding double-buffering for envs still mid-episode
- add regression tests: first recorded frame matches the post-reset observation, action arrays have exactly one NaN entry per episode at the last index, and short episodes don't come out length 0/1
- update the two existing `on_step` unit tests whose expected call counts/sequences change now that `on_step` also fires on reset

Fixes #293.

## Testing

- python -m pytest tests/ -q
- python -m pytest tests/data/test_integration_real.py::TestCollectResetFrame -v
- ruff check stable_worldmodel/world/world.py tests/data/test_integration_real.py tests/test_new_world.py tests/test_world.py
- ruff format --check stable_worldmodel/world/world.py tests/data/test_integration_real.py tests/test_new_world.py tests/test_world.py
