### PR TITLE
LanceVideoDataset: ranged blob reads instead of whole-episode downloads

### DIFF
--- a/stable_worldmodel/data/formats/lance_video.py
+++ b/stable_worldmodel/data/formats/lance_video.py
@@ -24,6 +24,7 @@ drawn from the same episode.
 
 from __future__ import annotations
 
+import io
 import os
 import tempfile
 from collections import OrderedDict
@@ -109,6 +110,37 @@ def _encode_video(frames, fps: int, codec: str) -> bytes:
         os.unlink(path)
 
 
+class _SeekableBlob(io.RawIOBase):
+    """Adapt a lance ``BlobFile`` to the raw-IO protocol video decoders
+    expect, so decoding issues ranged object-store reads instead of
+    materializing the whole episode MP4 in memory."""
+
+    def __init__(self, blob) -> None:
+        self._blob = blob
+
+    def readinto(self, b) -> int:
+        data = self._blob.read(len(b))
+        n = len(data)
+        b[:n] = data
+        return n
+
+    def seek(self, pos: int, whence: int = 0) -> int:
+        return self._blob.seek(pos, whence)
+
+    def tell(self) -> int:
+        return self._blob.tell()
+
+    def seekable(self) -> bool:
+        return True
+
+    def readable(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        self._blob.close()
+        super().close()
+
+
 class LanceVideoDataset(LanceDataset):
     """Reader for the two-table video-blob layout.
 
@@ -122,6 +154,12 @@ class LanceVideoDataset(LanceDataset):
         video_keys: restrict which image columns to load; defaults to all
             present in the videos table.
         decoder_cache_size: per-worker LRU bound on open MP4 decoders.
+        blob_buffer_size: read-buffer size (bytes) for ranged blob reads.
+            Each decoder fetches only the byte ranges it needs from object
+            storage, in chunks of this size, instead of downloading the whole
+            episode MP4. Smaller values minimize bytes transferred
+            (rate-limited stores); larger values minimize round-trips
+            (high-latency links).
         Other args match :class:`LanceDataset`.
     """
 
@@ -132,6 +170,7 @@ class LanceVideoDataset(LanceDataset):
         *,
         video_keys: list[str] | None = None,
         decoder_cache_size: int = 16,
+        blob_buffer_size: int = 4 << 20,
         **kwargs: Any,
     ) -> None:
         loc = path if path is not None else kwargs.get('uri')
@@ -189,6 +228,7 @@ class LanceVideoDataset(LanceDataset):
         self._videos_uri = f'{resolved_uri}/{videos_name}.lance'
         self._storage_options = connect_kwargs.get('storage_options')
         self._decoder_cache_size = decoder_cache_size
+        self._blob_buffer_size = blob_buffer_size
         self._videos_ds = None
         self._decoder_cache: OrderedDict | None = None
 
@@ -244,20 +284,24 @@ class LanceVideoDataset(LanceDataset):
 
         cache = self._decoder_cache
         key = (ep_idx, vkey)
-        dec = cache.get(key)
-        if dec is not None:
+        entry = cache.get(key)
+        if entry is not None:
             cache.move_to_end(key)
-            return dec
+            return entry[0]
         row = self._blob_row[key]
         blob = self._videos_ds.take_blobs(
             blob_column='video_bytes', indices=[row]
         )[0]
-        try:
-            data = blob.readall()
-        finally:
-            blob.close()
-        dec = VideoDecoder(data, seek_mode='approximate')
-        cache[key] = dec
+        # Ranged reads: the decoder pulls only the byte ranges it needs
+        # (moov + touched GOPs) through a buffered seekable view of the
+        # blob, instead of downloading the whole episode MP4. The source
+        # is cached alongside the decoder so the handle stays open for
+        # subsequent windows and is dropped together with it on eviction.
+        src = io.BufferedReader(
+            _SeekableBlob(blob), buffer_size=self._blob_buffer_size
+        )
+        dec = VideoDecoder(src, seek_mode='approximate')
+        cache[key] = (dec, src)
         while len(cache) > self._decoder_cache_size:
             cache.popitem(last=False)
         return dec

--- a/tests/data/test_lance_video.py
+++ b/tests/data/test_lance_video.py
@@ -247,3 +247,68 @@ def test_open_via_format_registry(tmp_path):
         out, num_steps=1, frameskip=1, keys_to_load=['pixels']
     )
     assert tuple(ds[0]['pixels'].shape) == (1, 3, 32, 32)
+
+
+def test_ranged_decode_parity_with_full_bytes(tmp_path):
+    """Decoding through the ranged blob reader must be bit-identical to
+    decoding from fully materialized blob bytes (the previous behavior)."""
+    import torch
+
+    import lance
+
+    _write(tmp_path / 'd')
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    item = ds[0]
+
+    videos_dir = next((tmp_path / 'd').glob('*_videos.lance'))
+    v = lance.dataset(str(videos_dir))
+    blob = v.take_blobs(blob_column='video_bytes', indices=[0])[0]
+    data = blob.readall()
+    blob.close()
+    ref = VideoDecoder(data, seek_mode='approximate')
+    expected = ref.get_frames_at(indices=[0, 1, 2, 3]).data
+    assert torch.equal(item['pixels'], expected)
+
+
+def test_ranged_decode_reads_partial_blob(tmp_path, monkeypatch):
+    """A small window from a long episode must not download the whole MP4."""
+    import stable_worldmodel.data.formats.lance_video as lv
+
+    rng = np.random.default_rng(1)
+    ep = {
+        'pixels': [
+            rng.integers(0, 255, (64, 64, 3)).astype(np.uint8)
+            for _ in range(300)
+        ],
+        'action': [
+            rng.standard_normal(2).astype(np.float32) for _ in range(300)
+        ],
+    }
+    with LanceVideoWriter(tmp_path / 'd') as w:
+        w.write_episodes([ep])
+
+    fetched = []
+    orig = lv._SeekableBlob.readinto
+
+    def counting(self, b):
+        n = orig(self, b)
+        fetched.append(n)
+        return n
+
+    monkeypatch.setattr(lv._SeekableBlob, 'readinto', counting)
+
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4, blob_buffer_size=4096)
+    item = ds[0]
+    assert item['pixels'].shape[0] == 4
+
+    import lance
+
+    videos_dir = next((tmp_path / 'd').glob('*_videos.lance'))
+    v = lance.dataset(str(videos_dir))
+    blob = v.take_blobs(blob_column='video_bytes', indices=[0])[0]
+    blob.seek(0, 2)
+    blob_size = blob.tell()
+    blob.close()
+    assert sum(fetched) < blob_size, (
+        f'ranged reader fetched {sum(fetched)} of {blob_size} bytes'
+    )


### PR DESCRIPTION
## Problem

`_decoder_for` materializes the **entire episode MP4** (`blob.readall()`) to decode a single window. Practical impact observed in training: HF-backed datasets hit rate limits within ~100 iterations, and cross-region S3 reads sit at ~2 GB/batch (effectively 0 it/s from a high-latency link). Each cached decoder also pins the full episode bytes, so DataLoader workers run ~3.8 GB RSS each.

## Fix

Lance blob v2 supports ranged reads, and the `BlobFile` handle the reader already holds is seekable. This PR feeds the decoder a buffered raw-IO view of the blob (`_SeekableBlob` + `io.BufferedReader`) instead of materialized bytes — torchcodec then fetches only the moov atom and the GOPs a window actually touches. The buffered layer keeps ffmpeg's small avio reads from becoming per-request round-trips, so object-store request counts stay flat (~5 GETs/window vs 1–3 before, while bytes drop 13–39×).

New constructor knob `blob_buffer_size` (default 4 MiB): small values minimize bytes on rate-limited stores, large values minimize round-trips on high-latency links.

## Measurements

| reader | bytes/window | time/window |
|---|---:|---:|
| `readall` (current) | 156 MB | 0.6 s |
| ranged, 1 MiB buffer | **4 MB (39×↓)** | 0.6 s |
| ranged, 4 MiB buffer | 12 MB (13×↓) | **0.3 s (2×↑)** |

Decoder-cache memory drops from ~150 MB to ~4 MB per cached episode as a side effect.

## Tests

- All existing `test_lance_video.py` decode/parity tests now exercise the ranged path (13 passed).
- New `test_ranged_decode_parity_with_full_bytes`: bit-identical output vs decoding from fully materialized bytes.
- New `test_ranged_decode_reads_partial_blob`: a small window from a long episode fetches strictly less than the blob size.

## Possible follow-up (independent, not required by this PR)

When `Dataset.read_blob_ranges` (lance#7864) is released, the decode path can batch-plan GOP byte ranges per DataLoader batch — parse each episode's moov once (cacheable), map all windows in the batch to byte ranges, and issue one coalesced fetch (~1 GET per distinct episode per batch). That is a larger redesign of the decode path; this PR's streaming path remains the fallback for episodes whose sample tables aren't cached yet.

(`fetch_blob_files` from lancedb#3578 is the same lazy-handle engine used here behind the lancedb table API — swapping to it changes no behavior and only matters if remote LanceDB Cloud tables become a target or to consolidate on the lancedb API; it can ride along with whichever change next touches these lines.)

