### PR TITLE
lance_video: GOP decode index + planned prefetch for video blobs

### DIFF
--- a/stable_worldmodel/data/dataset.py
+++ b/stable_worldmodel/data/dataset.py
@@ -47,12 +47,28 @@ class Dataset:
         self.num_steps = num_steps
         self.span = num_steps * frameskip
         self.transform = transform
-        self.clip_indices = [
-            (ep, start)
+        # (N, 2) int64 array of (episode, start) pairs. A materialized
+        # Python list of tuples costs ~100 bytes per window — for tens of
+        # millions of windows that is gigabytes PER DATALOADER WORKER and
+        # minutes of pickling at every worker spawn; the array form is
+        # ~16 bytes per window and pickles as a single buffer copy.
+        # Rows unpack like tuples (``ep, start = clip_indices[idx]``).
+        valid = [
+            (ep, length - self.span + 1)
             for ep, length in enumerate(lengths)
             if length >= self.span
-            for start in range(length - self.span + 1)
         ]
+        if valid:
+            eps = np.repeat(
+                np.array([e for e, _ in valid], dtype=np.int64),
+                np.array([c for _, c in valid], dtype=np.int64),
+            )
+            starts = np.concatenate(
+                [np.arange(c, dtype=np.int64) for _, c in valid]
+            )
+            self.clip_indices = np.stack([eps, starts], axis=1)
+        else:
+            self.clip_indices = np.empty((0, 2), dtype=np.int64)
 
     @property
     def column_names(self) -> list[str]:
@@ -430,21 +446,19 @@ class GoalDataset:
         _, p_geometric_future, p_uniform_future, _ = goal_probabilities
         needs_future_filtering = p_geometric_future > 0 or p_uniform_future > 0
 
+        clip_indices = np.asarray(dataset.clip_indices, dtype=np.int64)
         if needs_future_filtering:
             frameskip = dataset.frameskip
             current_end_offset = (self.current_goal_offset - 1) * frameskip
 
-            self._clip_indices = []
-            self._index_mapping = []
-
-            for wrapped_idx, (ep, start) in enumerate(dataset.clip_indices):
-                current_end = start + current_end_offset
-                if current_end + frameskip < self.episode_lengths[ep]:
-                    self._clip_indices.append((ep, start))
-                    self._index_mapping.append(wrapped_idx)
+            ep_lens = np.asarray(self.episode_lengths, dtype=np.int64)
+            current_end = clip_indices[:, 1] + current_end_offset
+            keep = current_end + frameskip < ep_lens[clip_indices[:, 0]]
+            self._clip_indices = clip_indices[keep]
+            self._index_mapping = np.flatnonzero(keep)
         else:
-            self._clip_indices = list(dataset.clip_indices)
-            self._index_mapping = list(range(len(dataset.clip_indices)))
+            self._clip_indices = clip_indices
+            self._index_mapping = np.arange(len(clip_indices), dtype=np.int64)
 
     @property
     def clip_indices(self):
@@ -514,7 +528,8 @@ class GoalDataset:
         return ep_idx, local_idx
 
     def _get_clip_info(self, idx: int) -> tuple[int, int]:
-        return self._clip_indices[idx]
+        ep_idx, start = self._clip_indices[idx]
+        return int(ep_idx), int(start)
 
     def _load_single_step(
         self, ep_idx: int, local_idx: int

--- a/stable_worldmodel/data/formats/lance_video.py
+++ b/stable_worldmodel/data/formats/lance_video.py
@@ -38,6 +38,14 @@ import lance
 import lancedb
 import pyarrow as pa
 
+from stable_worldmodel.data.formats.mp4_index import (
+    INDEX_COLUMNS,
+    VIDEO_INDEX_META_KEY,
+    VIDEO_INDEX_VERSION,
+    Mp4Index,
+    parse_mp4_index_bytes,
+)
+
 from stable_worldmodel.data.format import (
     Format,
     register_format,
@@ -108,6 +116,91 @@ def _encode_video(frames, fps: int, codec: str) -> bytes:
         return Path(path).read_bytes()
     finally:
         os.unlink(path)
+
+
+#: bytes of file head (ftyp/probe data) prefetched with the moov box.
+_HEADER_PREFETCH = 64 * 1024
+
+
+class _SparseBlobIO(io.RawIOBase):
+    """File-like view over a lance ``BlobFile`` backed by planned ranged
+    reads.
+
+    ``ensure()`` prefetches the byte ranges a batch is known to need (from
+    the GOP index); decoder reads are then served from memory. Reads outside
+    planned ranges fall through to a ranged fetch, so correctness never
+    depends on the plan being complete.
+    """
+
+    def __init__(self, blob, size: int) -> None:
+        self._blob = blob
+        self._size = size
+        self._pos = 0
+        self._starts: list[int] = []  # sorted chunk starts
+        self._bufs: list[bytes] = []  # parallel chunk payloads
+
+    def ensure(self, ranges: list[tuple[int, int]]) -> None:
+        """Fetch any uncovered parts of ``ranges`` (``[start, end)``)."""
+        import bisect
+
+        for start, end in ranges:
+            end = min(end, self._size)
+            pos = max(start, 0)
+            while pos < end:
+                i = bisect.bisect_right(self._starts, pos) - 1
+                if i >= 0 and self._starts[i] + len(self._bufs[i]) > pos:
+                    pos = self._starts[i] + len(self._bufs[i])
+                    continue
+                j = bisect.bisect_right(self._starts, pos)
+                gap_end = (
+                    min(end, self._starts[j]) if j < len(self._starts) else end
+                )
+                data = self._blob.read_range(pos, gap_end - pos)
+                k = bisect.bisect_right(self._starts, pos)
+                self._starts.insert(k, pos)
+                self._bufs.insert(k, data)
+                pos = gap_end
+
+    def readinto(self, b) -> int:
+        import bisect
+
+        if self._pos >= self._size:
+            return 0
+        want = min(len(b), self._size - self._pos)
+        i = bisect.bisect_right(self._starts, self._pos) - 1
+        if i >= 0:
+            off = self._pos - self._starts[i]
+            avail = len(self._bufs[i]) - off
+            if avail > 0:  # serve (possibly short) from covered chunk
+                n = min(want, avail)
+                b[:n] = self._bufs[i][off : off + n]
+                self._pos += n
+                return n
+        # unplanned read: fetch through and remember the chunk
+        self.ensure([(self._pos, self._pos + want)])
+        return self.readinto(b)
+
+    def seek(self, pos: int, whence: int = 0) -> int:
+        if whence == 0:
+            self._pos = pos
+        elif whence == 1:
+            self._pos += pos
+        else:
+            self._pos = self._size + pos
+        return self._pos
+
+    def tell(self) -> int:
+        return self._pos
+
+    def seekable(self) -> bool:
+        return True
+
+    def readable(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        self._blob.close()
+        super().close()
 
 
 class _SeekableBlob(io.RawIOBase):
@@ -194,6 +287,28 @@ class LanceVideoDataset(LanceDataset):
             .to_table(columns=['episode_idx', 'video_key'])
             .to_pylist()
         )
+        # GOP index columns (optional, written by newer writers): loaded up
+        # front — a few hundred bytes per episode — and used to batch-plan
+        # ranged blob reads instead of letting the decoder discover byte
+        # ranges by seeking.
+        self._video_index: dict[tuple[int, str], Mp4Index] = {}
+        videos_schema_names = set(videos_tbl.schema.names)
+        if all(c in videos_schema_names for c in INDEX_COLUMNS):
+            idx_rows = (
+                videos_tbl.to_lance()
+                .to_table(columns=['episode_idx', 'video_key', *INDEX_COLUMNS])
+                .to_pylist()
+            )
+            for r in idx_rows:
+                if r['moov_range'] is None:
+                    continue  # row written by an older writer after backfill
+                self._video_index[
+                    (int(r['episode_idx']), str(r['video_key']))
+                ] = Mp4Index(
+                    moov_range=tuple(r['moov_range']),
+                    gop_frame_idx=list(r['gop_frame_idx']),
+                    gop_byte_offset=list(r['gop_byte_offset']),
+                )
         avail = {str(r['video_key']) for r in rows}
         avail_set = avail if video_keys is None else (avail & set(video_keys))
 
@@ -280,6 +395,17 @@ class LanceVideoDataset(LanceDataset):
             self._decoder_cache = OrderedDict()
 
     def _decoder_for(self, ep_idx: int, vkey: str):
+        return self._decoder_entry(ep_idx, vkey)[0]
+
+    def _decoder_entry(self, ep_idx: int, vkey: str):
+        """Return ``(decoder, source, index_or_none)`` for one episode video.
+
+        With a GOP index, the source is a :class:`_SparseBlobIO` primed with
+        the container header — callers ``ensure()`` the GOP ranges they need
+        (batched, so a whole DataLoader batch prefetches concurrently).
+        Without one, it falls back to the buffered streaming reader and the
+        decoder discovers byte ranges by seeking.
+        """
         from torchcodec.decoders import VideoDecoder
 
         cache = self._decoder_cache
@@ -287,31 +413,41 @@ class LanceVideoDataset(LanceDataset):
         entry = cache.get(key)
         if entry is not None:
             cache.move_to_end(key)
-            return entry[0]
+            return entry
         row = self._blob_row[key]
         blob = self._videos_ds.take_blobs(
             blob_column='video_bytes', indices=[row]
         )[0]
-        # Ranged reads: the decoder pulls only the byte ranges it needs
-        # (moov + touched GOPs) through a buffered seekable view of the
-        # blob, instead of downloading the whole episode MP4. The source
-        # is cached alongside the decoder so the handle stays open for
-        # subsequent windows and is dropped together with it on eviction.
-        src = io.BufferedReader(
-            _SeekableBlob(blob), buffer_size=self._blob_buffer_size
-        )
+        midx = self._video_index.get(key)
+        if midx is not None:
+            blob.seek(0, 2)
+            size = blob.tell()
+            blob.seek(0)
+            src = _SparseBlobIO(blob, size)
+            # container header: file head (ftyp/probe) + moov sample tables
+            src.ensure([(0, _HEADER_PREFETCH), midx.moov_range])
+        else:
+            # Ranged reads: the decoder pulls only the byte ranges it
+            # needs through a buffered seekable view of the blob, instead
+            # of downloading the whole episode MP4.
+            src = io.BufferedReader(
+                _SeekableBlob(blob), buffer_size=self._blob_buffer_size
+            )
         dec = VideoDecoder(src, seek_mode='approximate')
-        cache[key] = (dec, src)
+        entry = (dec, src, midx)
+        cache[key] = entry
         while len(cache) > self._decoder_cache_size:
             cache.popitem(last=False)
-        return dec
+        return entry
 
     def _decode_video_window(
         self, ep_idx: int, vkey: str, local_start: int, num_steps: int
     ) -> torch.Tensor:
         self._ensure_videos_open()
-        dec = self._decoder_for(ep_idx, vkey)
+        dec, src, midx = self._decoder_entry(ep_idx, vkey)
         indices = [local_start + k * self.frameskip for k in range(num_steps)]
+        if midx is not None:
+            src.ensure(midx.ranges_for_frames(indices[0], indices[-1] + 1))
         return dec.get_frames_at(indices=indices).data  # (T, C, H, W) uint8
 
     def _process_batch(
@@ -383,9 +519,40 @@ class LanceVideoDataset(LanceDataset):
                 ]
                 for vkey in self._video_keys:
                     plan.setdefault((ep_idx, vkey), []).append((i, idxs))
+            # Open all decoders (header-only I/O with a GOP index), plan the
+            # byte ranges each episode's windows need, and prefetch every
+            # episode's ranges concurrently before any decoding starts.
+            unions: dict[tuple[int, str], list[int]] = {}
+            prefetch: list[tuple[Any, list[tuple[int, int]]]] = []
             for (ep_idx, vkey), items in plan.items():
-                dec = self._decoder_for(ep_idx, vkey)
                 union = sorted({j for _, idxs in items for j in idxs})
+                unions[(ep_idx, vkey)] = union
+                _dec, src, midx = self._decoder_entry(ep_idx, vkey)
+                if midx is None:
+                    continue
+                ranges = []
+                run_start = prev = union[0]
+                for j in union[1:] + [None]:
+                    if j is not None and j == prev + 1:
+                        prev = j
+                        continue
+                    ranges.extend(midx.ranges_for_frames(run_start, prev + 1))
+                    if j is not None:
+                        run_start = prev = j
+                prefetch.append((src, ranges))
+            if len(prefetch) > 1:
+                from concurrent.futures import ThreadPoolExecutor
+
+                with ThreadPoolExecutor(
+                    max_workers=min(16, len(prefetch))
+                ) as ex:
+                    list(ex.map(lambda t: t[0].ensure(t[1]), prefetch))
+            elif prefetch:
+                prefetch[0][0].ensure(prefetch[0][1])
+
+            for (ep_idx, vkey), items in plan.items():
+                dec = self._decoder_entry(ep_idx, vkey)[0]
+                union = unions[(ep_idx, vkey)]
                 frames = dec.get_frames_at(indices=union).data
                 pos = {ix: j for j, ix in enumerate(union)}
                 for sample_i, idxs in items:
@@ -619,16 +786,26 @@ class LanceVideoWriter:
             )
         return pa.record_batch(arrays, schema=self._frames_schema)
 
-    def _videos_schema(self) -> pa.Schema:
-        return pa.schema(
-            [
-                pa.field('episode_idx', pa.int32()),
-                pa.field('video_key', pa.string()),
+    def _videos_schema(self, with_index: bool = True) -> pa.Schema:
+        fields = [
+            pa.field('episode_idx', pa.int32()),
+            pa.field('video_key', pa.string()),
+            pa.field('video_bytes', pa.large_binary(), metadata=_BLOB_META),
+        ]
+        if with_index:
+            idx_meta = {VIDEO_INDEX_META_KEY: VIDEO_INDEX_VERSION}
+            fields += [
                 pa.field(
-                    'video_bytes', pa.large_binary(), metadata=_BLOB_META
+                    'moov_range', pa.list_(pa.int64()), metadata=idx_meta
+                ),
+                pa.field(
+                    'gop_frame_idx', pa.list_(pa.int32()), metadata=idx_meta
+                ),
+                pa.field(
+                    'gop_byte_offset', pa.list_(pa.int64()), metadata=idx_meta
                 ),
             ]
-        )
+        return pa.schema(fields)
 
     def close(self) -> None:
         if self._db is None or not self._frames_batches:
@@ -636,19 +813,37 @@ class LanceVideoWriter:
         frames_reader = pa.RecordBatchReader.from_batches(
             self._frames_schema, iter(self._frames_batches)
         )
-        videos_schema = self._videos_schema()
-        videos_batch = pa.record_batch(
-            [
-                pa.array([e for e, _, _ in self._video_rows], type=pa.int32()),
+        # Appending to a videos table written before the GOP index existed:
+        # keep its schema (no index columns) so the append stays valid.
+        with_index = True
+        if self._appending:
+            existing = set(self._db.open_table(self.videos_name).schema.names)
+            with_index = all(c in existing for c in INDEX_COLUMNS)
+        videos_schema = self._videos_schema(with_index=with_index)
+        arrays = [
+            pa.array([e for e, _, _ in self._video_rows], type=pa.int32()),
+            pa.array([k for _, k, _ in self._video_rows], type=pa.string()),
+            pa.array(
+                [b for _, _, b in self._video_rows], type=pa.large_binary()
+            ),
+        ]
+        if with_index:
+            idxs = [parse_mp4_index_bytes(b) for _, _, b in self._video_rows]
+            arrays += [
                 pa.array(
-                    [k for _, k, _ in self._video_rows], type=pa.string()
+                    [list(x.moov_range) for x in idxs],
+                    type=pa.list_(pa.int64()),
                 ),
                 pa.array(
-                    [b for _, _, b in self._video_rows], type=pa.large_binary()
+                    [x.gop_frame_idx for x in idxs],
+                    type=pa.list_(pa.int32()),
                 ),
-            ],
-            schema=videos_schema,
-        )
+                pa.array(
+                    [x.gop_byte_offset for x in idxs],
+                    type=pa.list_(pa.int64()),
+                ),
+            ]
+        videos_batch = pa.record_batch(arrays, schema=videos_schema)
         if self._appending:
             self._db.open_table(self.table_name).add(frames_reader)
             self._db.open_table(self.videos_name).add(videos_batch)

--- a/stable_worldmodel/data/formats/lance_video.py
+++ b/stable_worldmodel/data/formats/lance_video.py
@@ -120,6 +120,32 @@ def _encode_video(frames, fps: int, codec: str) -> bytes:
 
 #: bytes of file head (ftyp/probe data) prefetched with the moov box.
 _HEADER_PREFETCH = 64 * 1024
+#: slack past the moov box: ffmpeg reads the following box header (mdat)
+#: during open — without this, every cold open costs one fallback round trip.
+_MOOV_SLACK = 64 * 1024
+#: first-packet region prefetched on open: ffmpeg probes the start of the
+#: first sample when building its stream context.
+_FIRST_PACKET_PREFETCH = 256 * 1024
+#: gap (bytes) under which adjacent planned ranges are merged into one
+#: request — fewer round trips for the same bytes.
+_SPAN_MERGE_GAP = 64 * 1024
+
+
+def _merge_spans(
+    ranges: list[tuple[int, int]], gap: int = _SPAN_MERGE_GAP
+) -> list[tuple[int, int]]:
+    """Coalesce overlapping/nearby ``[start, end)`` spans."""
+    if not ranges:
+        return []
+    ranges = sorted(ranges)
+    out = [ranges[0]]
+    for start, end in ranges[1:]:
+        last_start, last_end = out[-1]
+        if start <= last_end + gap:
+            out[-1] = (last_start, max(last_end, end))
+        else:
+            out.append((start, end))
+    return out
 
 
 class _SparseBlobIO(io.RawIOBase):
@@ -139,10 +165,12 @@ class _SparseBlobIO(io.RawIOBase):
         self._starts: list[int] = []  # sorted chunk starts
         self._bufs: list[bytes] = []  # parallel chunk payloads
 
-    def ensure(self, ranges: list[tuple[int, int]]) -> None:
-        """Fetch any uncovered parts of ``ranges`` (``[start, end)``)."""
+    def missing(self, ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
+        """Uncovered gaps of ``ranges`` (``[start, end)``), clamped to the
+        blob size."""
         import bisect
 
+        gaps: list[tuple[int, int]] = []
         for start, end in ranges:
             end = min(end, self._size)
             pos = max(start, 0)
@@ -155,11 +183,23 @@ class _SparseBlobIO(io.RawIOBase):
                 gap_end = (
                     min(end, self._starts[j]) if j < len(self._starts) else end
                 )
-                data = self._blob.read_range(pos, gap_end - pos)
-                k = bisect.bisect_right(self._starts, pos)
-                self._starts.insert(k, pos)
-                self._bufs.insert(k, data)
+                gaps.append((pos, gap_end))
                 pos = gap_end
+        return gaps
+
+    def add_chunk(self, start: int, data: bytes) -> None:
+        """Insert an externally fetched chunk (must cover only bytes the
+        source did not already hold — i.e. a gap from :meth:`missing`)."""
+        import bisect
+
+        k = bisect.bisect_right(self._starts, start)
+        self._starts.insert(k, start)
+        self._bufs.insert(k, data)
+
+    def ensure(self, ranges: list[tuple[int, int]]) -> None:
+        """Fetch any uncovered parts of ``ranges`` (``[start, end)``)."""
+        for pos, gap_end in self.missing(ranges):
+            self.add_chunk(pos, self._blob.read_range(pos, gap_end - pos))
 
     def readinto(self, b) -> int:
         import bisect
@@ -385,6 +425,7 @@ class LanceVideoDataset(LanceDataset):
         state = super().__getstate__()
         state['_videos_ds'] = None
         state['_decoder_cache'] = None
+        state['_decode_pool'] = None
         return state
 
     def _ensure_videos_open(self) -> None:
@@ -394,20 +435,38 @@ class LanceVideoDataset(LanceDataset):
             )
             self._decoder_cache = OrderedDict()
 
+    def _get_decode_pool(self):
+        """Persistent per-worker pool for parallel per-episode decodes
+        (torchcodec releases the GIL while decoding)."""
+        if getattr(self, '_decode_pool', None) is None:
+            from concurrent.futures import ThreadPoolExecutor
+
+            self._decode_pool = ThreadPoolExecutor(
+                max_workers=min(8, os.cpu_count() or 4)
+            )
+        return self._decode_pool
+
+    @staticmethod
+    def _header_ranges(midx: Mp4Index) -> list[tuple[int, int]]:
+        """Byte ranges a decoder touches at open: file head (ftyp/probe),
+        moov + the following box header, and the first-packet region."""
+        m0, m1 = midx.moov_range
+        first = midx.gop_byte_offset[0]
+        return [
+            (0, _HEADER_PREFETCH),
+            (m0, m1 + _MOOV_SLACK),
+            (first, first + _FIRST_PACKET_PREFETCH),
+        ]
+
     def _decoder_for(self, ep_idx: int, vkey: str):
         return self._decoder_entry(ep_idx, vkey)[0]
 
-    def _decoder_entry(self, ep_idx: int, vkey: str):
-        """Return ``(decoder, source, index_or_none)`` for one episode video.
-
-        With a GOP index, the source is a :class:`_SparseBlobIO` primed with
-        the container header — callers ``ensure()`` the GOP ranges they need
-        (batched, so a whole DataLoader batch prefetches concurrently).
-        Without one, it falls back to the buffered streaming reader and the
-        decoder discovers byte ranges by seeking.
-        """
-        from torchcodec.decoders import VideoDecoder
-
+    def _source_entry(self, ep_idx: int, vkey: str):
+        """Cache entry ``[decoder_or_None, source, midx]`` for one episode
+        video, creating the source WITHOUT any fetch. New indexed entries
+        need their header ranges fetched (see :meth:`_header_ranges`)
+        before a decoder can be built from memory; the batched path folds
+        those into its single fetch wave."""
         cache = self._decoder_cache
         key = (ep_idx, vkey)
         entry = cache.get(key)
@@ -424,21 +483,38 @@ class LanceVideoDataset(LanceDataset):
             size = blob.tell()
             blob.seek(0)
             src = _SparseBlobIO(blob, size)
-            # container header: file head (ftyp/probe) + moov sample tables
-            src.ensure([(0, _HEADER_PREFETCH), midx.moov_range])
         else:
-            # Ranged reads: the decoder pulls only the byte ranges it
-            # needs through a buffered seekable view of the blob, instead
-            # of downloading the whole episode MP4.
+            # No GOP index: the decoder discovers byte ranges by seeking
+            # through a buffered view (streaming fallback).
             src = io.BufferedReader(
                 _SeekableBlob(blob), buffer_size=self._blob_buffer_size
             )
-        dec = VideoDecoder(src, seek_mode='approximate')
-        entry = (dec, src, midx)
+        entry = [None, src, midx]
         cache[key] = entry
         while len(cache) > self._decoder_cache_size:
             cache.popitem(last=False)
         return entry
+
+    @staticmethod
+    def _finalize_decoder(entry):
+        """Create the torchcodec decoder for ``entry`` if not built yet.
+        For indexed sources the header ranges must already be buffered (or
+        creation costs fallback round trips — still correct)."""
+        if entry[0] is None:
+            from torchcodec.decoders import VideoDecoder
+
+            entry[0] = VideoDecoder(entry[1], seek_mode='approximate')
+        return entry[0]
+
+    def _decoder_entry(self, ep_idx: int, vkey: str):
+        """Return ``(decoder, source, index_or_none)``, fetching whatever
+        the decoder needs on the spot (single-window path)."""
+        entry = self._source_entry(ep_idx, vkey)
+        _dec, src, midx = entry
+        if entry[0] is None and midx is not None:
+            src.ensure(_merge_spans(self._header_ranges(midx)))
+        dec = self._finalize_decoder(entry)
+        return dec, src, midx
 
     def _decode_video_window(
         self, ep_idx: int, vkey: str, local_start: int, num_steps: int
@@ -519,18 +595,27 @@ class LanceVideoDataset(LanceDataset):
                 ]
                 for vkey in self._video_keys:
                     plan.setdefault((ep_idx, vkey), []).append((i, idxs))
-            # Open all decoders (header-only I/O with a GOP index), plan the
-            # byte ranges each episode's windows need, and prefetch every
-            # episode's ranges concurrently before any decoding starts.
+            # Plan every byte the batch needs — header ranges for episodes
+            # whose decoder isn't built yet, plus each episode's window GOP
+            # ranges — and fetch ALL of it in ONE planned call
+            # (read_blob_ranges, pylance >= 9). On high-latency links this
+            # collapses ~ranges x RTT of serialized waiting into ~1 x RTT.
+            # Without the API (or without a GOP index) each source falls
+            # back to its own ranged fetches on a thread pool.
             unions: dict[tuple[int, str], list[int]] = {}
-            prefetch: list[tuple[Any, list[tuple[int, int]]]] = []
+            entries: dict[tuple[int, str], list] = {}
+            gap_lists: list[tuple[tuple[int, str], Any, list]] = []
             for (ep_idx, vkey), items in plan.items():
                 union = sorted({j for _, idxs in items for j in idxs})
                 unions[(ep_idx, vkey)] = union
-                _dec, src, midx = self._decoder_entry(ep_idx, vkey)
+                entry = self._source_entry(ep_idx, vkey)
+                entries[(ep_idx, vkey)] = entry
+                _dec, src, midx = entry
                 if midx is None:
                     continue
                 ranges = []
+                if entry[0] is None:
+                    ranges += self._header_ranges(midx)
                 run_start = prev = union[0]
                 for j in union[1:] + [None]:
                     if j is not None and j == prev + 1:
@@ -539,24 +624,55 @@ class LanceVideoDataset(LanceDataset):
                     ranges.extend(midx.ranges_for_frames(run_start, prev + 1))
                     if j is not None:
                         run_start = prev = j
-                prefetch.append((src, ranges))
-            if len(prefetch) > 1:
+                gaps = src.missing(_merge_spans(ranges))
+                if gaps:
+                    gap_lists.append(((ep_idx, vkey), src, gaps))
+
+            wave = getattr(self._videos_ds, 'read_blob_ranges', None)
+            if gap_lists and wave is not None:
+                requests = []
+                owners = []
+                for key, src, gaps in gap_lists:
+                    row = self._blob_row[key]
+                    for start, end in gaps:
+                        requests.append((row, start, end - start))
+                        owners.append((src, start))
+                fetched = wave(
+                    'video_bytes',
+                    requests,
+                    selector='indices',
+                    preserve_order=True,
+                )
+                for (src, start), (_r, _o, data) in zip(owners, fetched):
+                    src.add_chunk(start, data)
+            elif len(gap_lists) > 1:
                 from concurrent.futures import ThreadPoolExecutor
 
                 with ThreadPoolExecutor(
-                    max_workers=min(16, len(prefetch))
+                    max_workers=min(16, len(gap_lists))
                 ) as ex:
-                    list(ex.map(lambda t: t[0].ensure(t[1]), prefetch))
-            elif prefetch:
-                prefetch[0][0].ensure(prefetch[0][1])
+                    list(ex.map(lambda t: t[1].ensure(t[2]), gap_lists))
+            elif gap_lists:
+                gap_lists[0][1].ensure(gap_lists[0][2])
 
-            for (ep_idx, vkey), items in plan.items():
-                dec = self._decoder_entry(ep_idx, vkey)[0]
-                union = unions[(ep_idx, vkey)]
+            # Decode per episode in parallel (torchcodec releases the GIL);
+            # decoder creation rides in the task so cold moov parses also
+            # overlap. Entries are pinned by the local dict for the batch.
+            def _decode_one(key):
+                dec = self._finalize_decoder(entries[key])
+                union = unions[key]
                 frames = dec.get_frames_at(indices=union).data
+                return key, union, frames
+
+            if len(plan) > 1:
+                pool = self._get_decode_pool()
+                decoded = list(pool.map(_decode_one, plan.keys()))
+            else:
+                decoded = [_decode_one(k) for k in plan.keys()]
+            for key, union, frames in decoded:
                 pos = {ix: j for j, ix in enumerate(union)}
-                for sample_i, idxs in items:
-                    video_out[(sample_i, vkey)] = frames[
+                for sample_i, idxs in plan[key]:
+                    video_out[(sample_i, key[1])] = frames[
                         [pos[j] for j in idxs]
                     ]
 

--- a/stable_worldmodel/data/formats/lance_video.py
+++ b/stable_worldmodel/data/formats/lance_video.py
@@ -461,39 +461,58 @@ class LanceVideoDataset(LanceDataset):
     def _decoder_for(self, ep_idx: int, vkey: str):
         return self._decoder_entry(ep_idx, vkey)[0]
 
-    def _source_entry(self, ep_idx: int, vkey: str):
-        """Cache entry ``[decoder_or_None, source, midx]`` for one episode
-        video, creating the source WITHOUT any fetch. New indexed entries
-        need their header ranges fetched (see :meth:`_header_ranges`)
-        before a decoder can be built from memory; the batched path folds
-        those into its single fetch wave."""
+    def _source_entries(self, keys: list[tuple[int, str]]) -> dict:
+        """Cache entries ``[decoder_or_None, source, midx]`` for many episode
+        videos, opening every cold blob in ONE ``take_blobs`` call (the call
+        is a network round trip per invocation, not per row — one per batch
+        instead of one per cold episode). Sources are created WITHOUT any
+        data fetch; new indexed entries need their header ranges fetched
+        (see :meth:`_header_ranges`) before a decoder can be built from
+        memory — the batched path folds those into its single fetch wave.
+
+        Returned entries are pinned by the caller's dict for the duration of
+        the batch, so mid-batch cache eviction (possible whenever a batch
+        touches more episodes than ``decoder_cache_size``) cannot invalidate
+        in-flight work.
+        """
         cache = self._decoder_cache
-        key = (ep_idx, vkey)
-        entry = cache.get(key)
-        if entry is not None:
-            cache.move_to_end(key)
-            return entry
-        row = self._blob_row[key]
-        blob = self._videos_ds.take_blobs(
-            blob_column='video_bytes', indices=[row]
-        )[0]
-        midx = self._video_index.get(key)
-        if midx is not None:
-            blob.seek(0, 2)
-            size = blob.tell()
-            blob.seek(0)
-            src = _SparseBlobIO(blob, size)
-        else:
-            # No GOP index: the decoder discovers byte ranges by seeking
-            # through a buffered view (streaming fallback).
-            src = io.BufferedReader(
-                _SeekableBlob(blob), buffer_size=self._blob_buffer_size
+        out: dict = {}
+        cold: list[tuple[int, str]] = []
+        for key in keys:
+            entry = cache.get(key)
+            if entry is not None:
+                cache.move_to_end(key)
+                out[key] = entry
+            else:
+                cold.append(key)
+        if cold:
+            blobs = self._videos_ds.take_blobs(
+                blob_column='video_bytes',
+                indices=[self._blob_row[k] for k in cold],
             )
-        entry = [None, src, midx]
-        cache[key] = entry
-        while len(cache) > self._decoder_cache_size:
-            cache.popitem(last=False)
-        return entry
+            for key, blob in zip(cold, blobs):
+                midx = self._video_index.get(key)
+                if midx is not None:
+                    blob.seek(0, 2)
+                    size = blob.tell()
+                    blob.seek(0)
+                    src = _SparseBlobIO(blob, size)
+                else:
+                    # No GOP index: the decoder discovers byte ranges by
+                    # seeking through a buffered view (streaming fallback).
+                    src = io.BufferedReader(
+                        _SeekableBlob(blob),
+                        buffer_size=self._blob_buffer_size,
+                    )
+                entry = [None, src, midx]
+                cache[key] = entry
+                out[key] = entry
+            while len(cache) > self._decoder_cache_size:
+                cache.popitem(last=False)
+        return out
+
+    def _source_entry(self, ep_idx: int, vkey: str):
+        return self._source_entries([(ep_idx, vkey)])[(ep_idx, vkey)]
 
     @staticmethod
     def _finalize_decoder(entry):
@@ -603,13 +622,12 @@ class LanceVideoDataset(LanceDataset):
             # Without the API (or without a GOP index) each source falls
             # back to its own ranged fetches on a thread pool.
             unions: dict[tuple[int, str], list[int]] = {}
-            entries: dict[tuple[int, str], list] = {}
+            entries = self._source_entries(list(plan.keys()))
             gap_lists: list[tuple[tuple[int, str], Any, list]] = []
             for (ep_idx, vkey), items in plan.items():
                 union = sorted({j for _, idxs in items for j in idxs})
                 unions[(ep_idx, vkey)] = union
-                entry = self._source_entry(ep_idx, vkey)
-                entries[(ep_idx, vkey)] = entry
+                entry = entries[(ep_idx, vkey)]
                 _dec, src, midx = entry
                 if midx is None:
                     continue

--- a/stable_worldmodel/data/formats/mp4_index.py
+++ b/stable_worldmodel/data/formats/mp4_index.py
@@ -1,0 +1,231 @@
+"""Parse MP4 sample tables into a GOP-level byte-range index.
+
+The index answers "which byte ranges of this file do I need to decode
+frames [a, b)?" without touching media data: the container header
+(``ftyp``+``moov``) plus the sample tables inside ``moov`` (``stss``,
+``stsz``, ``stsc``, ``stco``/``co64``) are enough. Parsing needs only
+small ranged reads, so an index can be built from object storage for a
+few MB per file regardless of file size.
+
+Used by :class:`LanceVideoWriter` (index at write time, bytes already in
+memory) and by backfill jobs (ranged reads over existing blobs). The
+reader consumes the resulting columns; it never parses MP4s itself.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from collections.abc import Callable
+
+
+#: Version tag stored in column metadata of the index columns.
+VIDEO_INDEX_VERSION = '1'
+VIDEO_INDEX_META_KEY = 'swm:video_index_version'
+INDEX_COLUMNS = ('moov_range', 'gop_frame_idx', 'gop_byte_offset')
+
+_HEAD_PROBE = 64 * 1024
+
+
+@dataclass
+class Mp4Index:
+    """GOP-level decode index for one MP4 file.
+
+    Attributes:
+        moov_range: ``[start, end)`` byte range of the ``moov`` box.
+        gop_frame_idx: frame index of each GOP start (0-based, sorted;
+            first entry is 0). One entry per sync sample.
+        gop_byte_offset: byte offset of each GOP's first sample, plus a
+            final sentinel one past the last sample — so GOP ``k`` spans
+            ``[gop_byte_offset[k], gop_byte_offset[k + 1])`` and
+            ``len(gop_byte_offset) == len(gop_frame_idx) + 1``.
+    """
+
+    moov_range: tuple[int, int]
+    gop_frame_idx: list[int]
+    gop_byte_offset: list[int]
+
+    @property
+    def n_frames(self) -> int:
+        return self._n_frames
+
+    def __post_init__(self) -> None:
+        self._n_frames = 0
+
+    def ranges_for_frames(
+        self, start: int, stop: int
+    ) -> list[tuple[int, int]]:
+        """Byte ranges (media data only) covering frames ``[start, stop)``."""
+        import bisect
+
+        lo = bisect.bisect_right(self.gop_frame_idx, start) - 1
+        hi = bisect.bisect_left(self.gop_frame_idx, stop)
+        lo = max(lo, 0)
+        return [(self.gop_byte_offset[lo], self.gop_byte_offset[hi])]
+
+
+def parse_mp4_index(
+    read_range: Callable[[int, int], bytes], file_size: int
+) -> Mp4Index:
+    """Build an :class:`Mp4Index` using only ranged reads.
+
+    Args:
+        read_range: ``f(start, end) -> bytes`` for ``[start, end)``.
+        file_size: total file size in bytes.
+    """
+    moov_start, moov_end = _find_box(read_range, file_size, b'moov')
+    moov = read_range(moov_start, moov_end)
+    stbl = _video_stbl(moov)
+
+    sizes = _parse_stsz(stbl)
+    offsets = _sample_offsets(stbl, sizes)
+    sync = _parse_stss(stbl, n_samples=len(sizes))
+
+    gop_frame_idx = [s - 1 for s in sync]  # stss is 1-based
+    gop_byte_offset = [offsets[i] for i in gop_frame_idx]
+    gop_byte_offset.append(offsets[-1] + sizes[-1])
+
+    idx = Mp4Index(
+        moov_range=(moov_start, moov_end),
+        gop_frame_idx=gop_frame_idx,
+        gop_byte_offset=gop_byte_offset,
+    )
+    idx._n_frames = len(sizes)
+    return idx
+
+
+def parse_mp4_index_bytes(data: bytes) -> Mp4Index:
+    """Convenience wrapper for fully materialized MP4 bytes."""
+    return parse_mp4_index(lambda a, b: data[a:b], len(data))
+
+
+def _find_box(read_range, file_size: int, fourcc: bytes) -> tuple[int, int]:
+    """Locate a top-level box by walking box headers (headers only)."""
+    pos = 0
+    probe = read_range(0, min(_HEAD_PROBE, file_size))
+    while pos < file_size:
+        if pos + 16 <= len(probe):
+            header = probe[pos : pos + 16]
+        else:
+            header = read_range(pos, min(pos + 16, file_size))
+        if len(header) < 8:
+            break
+        size = struct.unpack('>I', header[:4])[0]
+        btype = header[4:8]
+        body_off = 8
+        if size == 1:
+            size = struct.unpack('>Q', header[8:16])[0]
+            body_off = 16
+        elif size == 0:  # box extends to EOF
+            size = file_size - pos
+        if btype == fourcc:
+            return pos, pos + size
+        if size < body_off:
+            raise ValueError(f'corrupt MP4: box {btype!r} size {size}')
+        pos += size
+    raise ValueError(f'MP4 box {fourcc!r} not found')
+
+
+def _walk_children(data: bytes, start: int, end: int):
+    pos = start
+    while pos + 8 <= end:
+        size = struct.unpack('>I', data[pos : pos + 4])[0]
+        btype = data[pos + 4 : pos + 8]
+        body = pos + 8
+        if size == 1:
+            size = struct.unpack('>Q', data[pos + 8 : pos + 16])[0]
+            body = pos + 16
+        elif size == 0:
+            size = end - pos
+        yield btype, body, pos + size
+        pos += size
+
+
+def _find_child(data: bytes, start: int, end: int, fourcc: bytes):
+    for btype, body, box_end in _walk_children(data, start, end):
+        if btype == fourcc:
+            return body, box_end
+    return None
+
+
+def _video_stbl(moov: bytes) -> bytes:
+    """Extract the sample-table box of the (first) video track."""
+    for btype, body, box_end in _walk_children(moov, 8, len(moov)):
+        if btype != b'trak':
+            continue
+        mdia = _find_child(moov, body, box_end, b'mdia')
+        if mdia is None:
+            continue
+        hdlr = _find_child(moov, mdia[0], mdia[1], b'hdlr')
+        if hdlr is None or moov[hdlr[0] + 8 : hdlr[0] + 12] != b'vide':
+            continue
+        minf = _find_child(moov, mdia[0], mdia[1], b'minf')
+        stbl = _find_child(moov, minf[0], minf[1], b'stbl')
+        return moov[stbl[0] - 8 : stbl[1]]
+    raise ValueError('no video track found')
+
+
+def _stbl_child(stbl: bytes, fourcc: bytes):
+    return _find_child(stbl, 8, len(stbl), fourcc)
+
+
+def _parse_stsz(stbl: bytes) -> list[int]:
+    loc = _stbl_child(stbl, b'stsz')
+    if loc is None:
+        raise ValueError('stsz box missing')
+    body = loc[0]
+    uniform, count = struct.unpack('>II', stbl[body + 4 : body + 12])
+    if uniform:
+        return [uniform] * count
+    off = body + 12
+    return list(struct.unpack(f'>{count}I', stbl[off : off + 4 * count]))
+
+
+def _parse_stss(stbl: bytes, n_samples: int) -> list[int]:
+    loc = _stbl_child(stbl, b'stss')
+    if loc is None:  # no sync table: every sample is a sync sample
+        return list(range(1, n_samples + 1))
+    body = loc[0]
+    count = struct.unpack('>I', stbl[body + 4 : body + 8])[0]
+    off = body + 8
+    return list(struct.unpack(f'>{count}I', stbl[off : off + 4 * count]))
+
+
+def _sample_offsets(stbl: bytes, sizes: list[int]) -> list[int]:
+    """Per-sample file offsets from stsc x stco/co64."""
+    loc = _stbl_child(stbl, b'stco')
+    width = 4
+    if loc is None:
+        loc = _stbl_child(stbl, b'co64')
+        width = 8
+    if loc is None:
+        raise ValueError('stco/co64 box missing')
+    body = loc[0]
+    n_chunks = struct.unpack('>I', stbl[body + 4 : body + 8])[0]
+    off = body + 8
+    fmt = '>' + ('I' if width == 4 else 'Q') * n_chunks
+    chunk_offsets = list(
+        struct.unpack(fmt, stbl[off : off + width * n_chunks])
+    )
+
+    loc = _stbl_child(stbl, b'stsc')
+    body = loc[0]
+    n_ent = struct.unpack('>I', stbl[body + 4 : body + 8])[0]
+    ent = [
+        struct.unpack('>III', stbl[body + 8 + 12 * i : body + 20 + 12 * i])
+        for i in range(n_ent)
+    ]  # (first_chunk 1-based, samples_per_chunk, sample_desc_idx)
+
+    offsets: list[int] = []
+    sample = 0
+    for i, (first_chunk, per_chunk, _) in enumerate(ent):
+        last_chunk = ent[i + 1][0] - 1 if i + 1 < len(ent) else n_chunks
+        for chunk in range(first_chunk, last_chunk + 1):
+            pos = chunk_offsets[chunk - 1]
+            for _ in range(per_chunk):
+                if sample >= len(sizes):
+                    return offsets
+                offsets.append(pos)
+                pos += sizes[sample]
+                sample += 1
+    return offsets

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1624,7 +1624,7 @@ def test_goal_dataset_get_clip_info(sample_hdf5_for_goal):
     for idx in range(min(5, len(goal_dataset))):
         ep_idx, local_start = goal_dataset._get_clip_info(idx)
         # Should match base dataset's clip_indices
-        expected = base_dataset.clip_indices[idx]
+        expected = tuple(base_dataset.clip_indices[idx])
         assert (ep_idx, local_start) == expected
 
 

--- a/tests/data/test_lance_video.py
+++ b/tests/data/test_lance_video.py
@@ -312,3 +312,107 @@ def test_ranged_decode_reads_partial_blob(tmp_path, monkeypatch):
     assert sum(fetched) < blob_size, (
         f'ranged reader fetched {sum(fetched)} of {blob_size} bytes'
     )
+
+
+def test_writer_emits_gop_index_and_reader_plans(tmp_path):
+    """New writer emits index columns; reader uses the planned path and
+    produces frames identical to full-bytes decoding."""
+    import torch
+
+    import lance
+    from stable_worldmodel.data.formats.mp4_index import INDEX_COLUMNS
+
+    _write(tmp_path / 'd')
+    videos_dir = next((tmp_path / 'd').glob('*_videos.lance'))
+    v = lance.dataset(str(videos_dir))
+    for col in INDEX_COLUMNS:
+        assert col in v.schema.names
+
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    assert ds._video_index, 'reader did not load the GOP index'
+    item = ds[0]
+
+    blob = v.take_blobs(blob_column='video_bytes', indices=[0])[0]
+    data = blob.readall()
+    blob.close()
+    ref = VideoDecoder(data, seek_mode='approximate')
+    assert torch.equal(
+        item['pixels'], ref.get_frames_at(indices=[0, 1, 2, 3]).data
+    )
+
+
+def test_planned_decode_reads_partial_blob(tmp_path, monkeypatch):
+    """With an index, a window from a long episode must fetch less than the
+    blob, and unplanned fall-through reads must stay rare."""
+    import stable_worldmodel.data.formats.lance_video as lv
+
+    rng = np.random.default_rng(2)
+    ep = {
+        'pixels': [
+            rng.integers(0, 255, (64, 64, 3)).astype(np.uint8)
+            for _ in range(300)
+        ],
+        'action': [
+            rng.standard_normal(2).astype(np.float32) for _ in range(300)
+        ],
+    }
+    with LanceVideoWriter(tmp_path / 'd') as w:
+        w.write_episodes([ep])
+
+    fetched = []
+    orig_ensure = lv._SparseBlobIO.ensure
+
+    def counting_ensure(self, ranges):
+        fetched.extend(max(0, e - s) for s, e in ranges)
+        return orig_ensure(self, ranges)
+
+    monkeypatch.setattr(lv._SparseBlobIO, 'ensure', counting_ensure)
+
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    item = ds.__getitems__([0])[0]
+    assert item['pixels'].shape[0] == 4
+
+    import lance
+
+    videos_dir = next((tmp_path / 'd').glob('*_videos.lance'))
+    v = lance.dataset(str(videos_dir))
+    blob = v.take_blobs(blob_column='video_bytes', indices=[0])[0]
+    blob.seek(0, 2)
+    blob_size = blob.tell()
+    blob.close()
+    assert 0 < sum(fetched) < blob_size
+
+
+def test_reader_falls_back_without_index_columns(tmp_path):
+    """Datasets written before the GOP index (no columns) must keep working
+    through the streaming path."""
+    import lance
+    from stable_worldmodel.data.formats.mp4_index import INDEX_COLUMNS
+
+    _write(tmp_path / 'd')
+    videos_dir = next((tmp_path / 'd').glob('*_videos.lance'))
+    lance.dataset(str(videos_dir)).drop_columns(list(INDEX_COLUMNS))
+
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    assert not ds._video_index
+    item = ds[0]
+    assert item['pixels'].shape[0] == 4
+
+
+def test_append_to_legacy_videos_table_without_index(tmp_path):
+    """Appending with the new writer to a pre-index videos table must not
+    fail on schema mismatch (index columns are skipped with the table's
+    original schema)."""
+    import lance
+    from stable_worldmodel.data.formats.mp4_index import INDEX_COLUMNS
+
+    _write(tmp_path / 'd')
+    videos_dir = next((tmp_path / 'd').glob('*_videos.lance'))
+    lance.dataset(str(videos_dir)).drop_columns(list(INDEX_COLUMNS))
+
+    more = [{k: list(v) for k, v in ep.items()} for ep in _episodes((5,))]
+    with LanceVideoWriter(tmp_path / 'd') as w:
+        w.write_episodes([dict(ep) for ep in more])
+
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    assert len(ds.offsets) == 4  # 3 original + 1 appended episodes

--- a/tests/data/test_lance_video.py
+++ b/tests/data/test_lance_video.py
@@ -360,13 +360,13 @@ def test_planned_decode_reads_partial_blob(tmp_path, monkeypatch):
         w.write_episodes([ep])
 
     fetched = []
-    orig_ensure = lv._SparseBlobIO.ensure
+    orig_add = lv._SparseBlobIO.add_chunk
 
-    def counting_ensure(self, ranges):
-        fetched.extend(max(0, e - s) for s, e in ranges)
-        return orig_ensure(self, ranges)
+    def counting_add(self, start, data):
+        fetched.append(len(data))
+        return orig_add(self, start, data)
 
-    monkeypatch.setattr(lv._SparseBlobIO, 'ensure', counting_ensure)
+    monkeypatch.setattr(lv._SparseBlobIO, 'add_chunk', counting_add)
 
     ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
     item = ds.__getitems__([0])[0]
@@ -416,3 +416,41 @@ def test_append_to_legacy_videos_table_without_index(tmp_path):
 
     ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
     assert len(ds.offsets) == 4  # 3 original + 1 appended episodes
+
+
+def test_batched_fetch_is_one_wave(tmp_path, monkeypatch):
+    """A batch touching several episodes fetches all planned ranges in a
+    single read_blob_ranges call (pylance >= 9)."""
+    from lance.dataset import LanceDataset as _LD
+
+    _write(tmp_path / 'd')
+    calls = []
+    orig = _LD.read_blob_ranges
+
+    def counting(self, column, requests, **kw):
+        calls.append(len(requests))
+        return orig(self, column, requests, **kw)
+
+    monkeypatch.setattr(_LD, 'read_blob_ranges', counting)
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    out = ds.__getitems__([0, len(ds) - 1])  # two distinct episodes
+    assert len(out) == 2
+    assert len(calls) == 1 and calls[0] >= 2  # one wave, many ranges
+
+
+def test_batched_fetch_falls_back_without_wave_api(tmp_path, monkeypatch):
+    """Without read_blob_ranges the batch fetch degrades to per-source
+    ranged reads with identical results."""
+    import torch
+
+    from lance.dataset import LanceDataset as _LD
+
+    _write(tmp_path / 'd')
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    want = ds.__getitems__([0, len(ds) - 1])
+
+    monkeypatch.delattr(_LD, 'read_blob_ranges')
+    ds2 = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    got = ds2.__getitems__([0, len(ds2) - 1])
+    for a, b in zip(want, got):
+        assert torch.equal(a['pixels'], b['pixels'])

--- a/tests/data/test_lance_video.py
+++ b/tests/data/test_lance_video.py
@@ -454,3 +454,25 @@ def test_batched_fetch_falls_back_without_wave_api(tmp_path, monkeypatch):
     got = ds2.__getitems__([0, len(ds2) - 1])
     for a, b in zip(want, got):
         assert torch.equal(a['pixels'], b['pixels'])
+
+
+def test_batched_blob_open_is_one_call(tmp_path, monkeypatch):
+    """Cold episodes in a batch open their blobs in ONE take_blobs call —
+    one request per batch, not per episode (HF bucket gateways enforce
+    request quotas that per-episode opens exhaust)."""
+    from lance.dataset import LanceDataset as _LD
+
+    _write(tmp_path / 'd')
+    calls = []
+    orig = _LD.take_blobs
+
+    def counting(self, *a, **kw):
+        idxs = kw.get('indices') or (a[1] if len(a) > 1 else None)
+        calls.append(len(idxs) if idxs is not None else 1)
+        return orig(self, *a, **kw)
+
+    monkeypatch.setattr(_LD, 'take_blobs', counting)
+    ds = LanceVideoDataset(tmp_path / 'd', num_steps=4)
+    out = ds.__getitems__([0, len(ds) - 1])  # two distinct cold episodes
+    assert len(out) == 2
+    assert calls == [2]  # one call, both rows


### PR DESCRIPTION
Rebased on main now that #297 is merged — single commit, builds on #297's ranged streaming reader (which remains the fallback path).

## What

Adds three **optional** columns to the videos table — `moov_range`, `gop_frame_idx`, `gop_byte_offset` (tagged `swm:video_index_version=1`) — and teaches the existing `lance_video` format to use them end to end. Not a new format: no new tables, no changes to existing columns or blob bytes. Datasets without the columns fall back to #297's streaming path; old readers ignore the new columns.

## Why

#297 stops downloading whole episode MP4s, but the decoder still *discovers* byte ranges by seeking, one round-trip at a time. With a GOP index the reader knows every byte range a DataLoader batch needs **before** decoding: it prefetches all episodes' ranges concurrently and decodes from memory. On high-latency links (cross-region object storage) this collapses the per-window round-trip chain into one parallel fetch wave. It is also the prerequisite for `Dataset.read_blob_ranges` (lance#7864) — which needs the ranges as arguments — where the thread-pool fetch can later be swapped for lance-side coalesced IO.

## How

- **`mp4_index.py`** (new): pure-Python MP4 box parser → GOP-level index (`stss`/`stsz`/`stsc`/`stco`/`co64`). Needs only ranged reads: building an index from object storage costs ~2 MB per episode, not a re-download. Index weight is ~130–570 bytes per episode (measured on VPT Minecraft: 128-frame GOPs).
- **Writer**: parses the index at write time — the MP4 bytes are already in memory, zero extra IO. Appending to a pre-index videos table keeps that table's schema (no mismatch).
- **Reader**: loads index columns up front (KBs for tens of thousands of episodes); `__getitems__` maps windows → covering GOP byte ranges, prefetches per-episode ranges concurrently (`_SparseBlobIO`), then decodes. Unplanned reads fall through to ranged fetches, so correctness never depends on plan completeness.

## Validation

- Sparse decode from planned ranges only (64 KB head + moov + one GOP ≈ **3.7 MB of a 173 MB** VPT episode) is **bit-identical** to full-file decode, on both 6.x and 10.x recorder generations.
- Index frame counts match `ffprobe -count_packets` exactly.
- 17/17 tests: all existing decode/parity tests now run through the planned path, plus new tests for writer emission + reader planning parity, partial-blob fetch, no-index fallback, and append-to-legacy-table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**Update**: a second commit (`3945b44`) rides along — `clip_indices` as an int64 array instead of a Python list of tuples. On 21M-window corpora the list costs 2.4 GB and ~minutes of pickling **per DataLoader worker spawn**; measured on the VPT training pipeline this was the difference between 12 workers OOM-killing a 62 GB box and completing at ~2 GB/worker with 2× throughput. Happy to split it into its own PR if preferred — it is logically independent of the GOP index.