### PR TITLE
docs: add CLEAR-LeWM to built-on projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ The full documentation lives at [galilai-group.github.io/stable-worldmodel](http
 ## Built on `stable-worldmodel`
 
 - **[C-JEPA](https://hazel-heejeong-nam.github.io/cjepa/)**
+- **[CLEAR-LeWM](https://github.com/DavidSunok/CLEAR-LeWM)**
 - **[LeWM](https://le-wm.github.io/)**
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The full documentation lives at [galilai-group.github.io/stable-worldmodel](http
 ## Built on `stable-worldmodel`
 
 - **[C-JEPA](https://hazel-heejeong-nam.github.io/cjepa/)**
-- **[CLEAR-LeWM](https://github.com/DavidSunok/CLEAR-LeWM)**
+- **[CLEAR-LeWM](https://davidsunok.github.io/CLEAR-LeWM/)**
 - **[LeWM](https://le-wm.github.io/)**
 
 ## Citation


### PR DESCRIPTION
## Summary

Add [CLEAR-LeWM](https://davidsunok.github.io/CLEAR-LeWM/) to the
`Built on stable-worldmodel` section.

## Why

CLEAR-LeWM is a versioned evaluation suite for LeWM-compatible models
built directly on `stable-worldmodel`. It depends on
`stable-worldmodel[env]==0.1.0` and uses its World and dataset interfaces
to evaluate PushT, Cube, Reacher, and TwoRoom.

The project provides fixed evaluation manifests and complementary
Moderate and Strict profiles while retaining the original protocol as
a compatibility track.

## Scope

README only: one project link. No API, dependency, workflow, or runtime
behavior changes.

- Project: https://davidsunok.github.io/CLEAR-LeWM/
- Source: https://github.com/DavidSunok/CLEAR-LeWM
