### PR TITLE
make solvers return uniform costs

### DIFF
--- a/stable_worldmodel/planning/solver/callbacks/common.py
+++ b/stable_worldmodel/planning/solver/callbacks/common.py
@@ -13,8 +13,7 @@ class Callback:
 
     Subclasses compute a per-env metric and call ``self._reduce(...)`` to
     apply the configured reduction across envs. ``history`` is
-    ``list[list[Any]]`` (batches x steps), matching the shape of
-    ``outputs['cost']`` in the gradient solver.
+    ``list[list[Any]]`` (batches x steps).
     """
 
     name: str | None = None

--- a/stable_worldmodel/planning/solver/gd.py
+++ b/stable_worldmodel/planning/solver/gd.py
@@ -161,7 +161,7 @@ class GradientSolver(torch.nn.Module):
         """Solve the planning problem using gradient descent."""
         start_time = time.time()
         outputs = {
-            'cost': [],  # Will store list of cost histories per batch
+            'costs': [],  # Final cost of the selected sequence, per env
             'actions': None,
         }
 
@@ -224,8 +224,6 @@ class GradientSolver(torch.nn.Module):
                 expanded_infos[k] = v_batch
 
             # Perform Gradient Descent for this batch
-            batch_cost_history = []
-
             for cb in self.callbacks:
                 cb.start_batch()
 
@@ -270,20 +268,23 @@ class GradientSolver(torch.nn.Module):
                         * self.action_noise
                     )
 
-                batch_cost_history.append(cost.item())
-
-            # Store cost history for this batch
-            outputs['cost'].append(batch_cost_history)
-
             # Update the global self.init with the optimized batch values
+            # and evaluate the final candidates (the in-loop costs predate
+            # the last optimizer step)
             with torch.no_grad():
                 self.init[start_idx:end_idx] = batch_init
+                final_costs = self.cost.get_cost(expanded_infos, batch_init)
 
-            top_idx = torch.argsort(costs, dim=1)[:, 0]
+            top_idx = torch.argsort(final_costs, dim=1)[:, 0]
             batch_indices = torch.arange(current_bs)
 
             top_actions_batch = batch_init[batch_indices, top_idx]
             batch_top_actions_list.append(top_actions_batch.detach().cpu())
+
+            # Store the cost of the selected sequence for logging
+            outputs['costs'].extend(
+                final_costs[batch_indices, top_idx].cpu().tolist()
+            )
 
         # Concatenate all batch results
         outputs['actions'] = torch.cat(batch_top_actions_list, dim=0)

--- a/stable_worldmodel/planning/solver/icem.py
+++ b/stable_worldmodel/planning/solver/icem.py
@@ -321,12 +321,14 @@ class ICEMSolver:
                         action_high=self._action_high,
                     )
 
-            final_batch_cost = topk_vals.mean(dim=1).cpu().tolist()
-
             if self.return_mean:
                 mean[start_idx:end_idx] = batch_mean
+                # Average elite cost as a summary of the returned mean
+                final_batch_cost = topk_vals.mean(dim=1).cpu().tolist()
             else:
                 mean[start_idx:end_idx] = topk_candidates[:, 0]
+                # Exact cost of the returned best elite
+                final_batch_cost = topk_vals[:, 0].cpu().tolist()
 
             var[start_idx:end_idx] = batch_var
 

--- a/stable_worldmodel/planning/solver/lagrangian.py
+++ b/stable_worldmodel/planning/solver/lagrangian.py
@@ -199,7 +199,7 @@ class LagrangianSolver(torch.nn.Module):
         """Solve the planning problem using augmented Lagrangian gradient descent."""
         start_time = time.time()
         outputs: dict = {
-            'cost': [],
+            'costs': [],  # Final cost of the selected sequence, per env
             'constraint_violation': [],
             'actions': None,
             'lambdas': None,
@@ -255,7 +255,6 @@ class LagrangianSolver(torch.nn.Module):
                     expanded_infos[k] = v.to(self.device)
 
             rho = self.rho_init
-            batch_cost_history = []
             costs = None
             final_constraints = None
 
@@ -316,8 +315,6 @@ class LagrangianSolver(torch.nn.Module):
                             * self.action_noise
                         )
 
-                    batch_cost_history.append(loss.item())
-
                 # Dual ascent after inner loop converges
                 if constraints is not None:
                     with torch.no_grad():
@@ -352,20 +349,29 @@ class LagrangianSolver(torch.nn.Module):
                             f'cost={mean_cost:.4f}'
                         )
 
-            outputs['cost'].append(batch_cost_history)
-
             if final_constraints is not None:
                 outputs['constraint_violation'].append(
                     F.relu(final_constraints).mean().item()
                 )
 
+            # Update the global self.init with the optimized batch values
+            # and evaluate the final candidates (the in-loop costs predate
+            # the last optimizer step)
             with torch.no_grad():
                 self.init[start_idx:end_idx] = batch_init
+                final_costs = self.cost.get_cost(
+                    expanded_infos.copy(), batch_init
+                )
 
-            top_idx = torch.argsort(costs, dim=1)[:, 0]
+            top_idx = torch.argsort(final_costs, dim=1)[:, 0]
             batch_indices = torch.arange(current_bs)
             top_actions_batch = batch_init[batch_indices, top_idx]
             batch_top_actions_list.append(top_actions_batch.detach().cpu())
+
+            # Store the cost of the selected sequence for logging
+            outputs['costs'].extend(
+                final_costs[batch_indices, top_idx].cpu().tolist()
+            )
 
         outputs['actions'] = torch.cat(batch_top_actions_list, dim=0)
         outputs['lambdas'] = (

--- a/stable_worldmodel/planning/solver/pgd.py
+++ b/stable_worldmodel/planning/solver/pgd.py
@@ -154,7 +154,7 @@ class PGDSolver(torch.nn.Module):
         """Solve the planning problem using projected gradient descent."""
         start_time = time.time()
         outputs = {
-            'cost': [],  # Will store list of cost histories per batch
+            'costs': [],  # Final cost of the selected sequence, per env
             'actions': None,
         }
 
@@ -203,8 +203,6 @@ class PGDSolver(torch.nn.Module):
                 expanded_infos[k] = v_batch
 
             # Perform Gradient Descent for this batch
-            batch_cost_history = []
-
             for step in range(self.n_steps):
                 costs = self.cost.get_cost(expanded_infos, batch_init)
 
@@ -241,19 +239,22 @@ class PGDSolver(torch.nn.Module):
                 with torch.no_grad():
                     batch_init.copy_(self._project_action_simplex(batch_init))
 
-                batch_cost_history.append(cost.item())
-
-            # Store cost history for this batch
-            outputs['cost'].append(batch_cost_history)
-
             # Update the global self.init with the optimized batch values
+            # and evaluate the final candidates (the in-loop costs predate
+            # the last optimizer step and projection)
             with torch.no_grad():
                 self.init[start_idx:end_idx] = batch_init
+                final_costs = self.cost.get_cost(expanded_infos, batch_init)
 
-            top_idx = torch.argsort(costs, dim=1)[:, 0]
+            top_idx = torch.argsort(final_costs, dim=1)[:, 0]
             batch_indices = torch.arange(current_bs)
 
             top_actions_batch = batch_init[batch_indices, top_idx]
+
+            # Store the cost of the selected sequence for logging
+            outputs['costs'].extend(
+                final_costs[batch_indices, top_idx].cpu().tolist()
+            )
 
             # convert one-hot back to discrete actions
             top_actions_batch = self._factor_action_block(

--- a/tests/planning/solver/test_lagrangian.py
+++ b/tests/planning/solver/test_lagrangian.py
@@ -340,7 +340,7 @@ def test_solve_output_keys():
     out = solver.solve({'obs': torch.zeros(2, 4)})
 
     assert 'actions' in out
-    assert 'cost' in out
+    assert 'costs' in out
     assert 'constraint_violation' in out
     assert 'lambdas' in out
 
@@ -708,7 +708,7 @@ def test_cost_decreases_over_steps():
             return (action_candidates - self.goal).pow(2).mean(dim=(-1, -2))
 
     solver = LagrangianSolver(
-        cost=QuadraticCost(goal=0.0),  # goal at zero; init at zero -> cost = 0
+        cost=QuadraticCost(goal=2.0),  # init at zero -> initial cost = 4.0
         n_steps=30,
         n_outer_steps=1,
         num_samples=1,
@@ -717,10 +717,9 @@ def test_cost_decreases_over_steps():
     configure(solver, action_dim=4, n_envs=1, horizon=4, action_block=1)
 
     out = solver.solve({})
-    costs = out['cost'][0]  # list of losses per inner step
-    # The optimizer should not increase cost by more than 2x from first to last
-    # (just a sanity check, not a strict convergence guarantee)
-    assert costs[-1] <= costs[0] * 10 or costs[-1] < 1.0
+    # 'costs' holds the final cost of the selected sequence, one per env
+    assert len(out['costs']) == 1
+    assert out['costs'][0] < 4.0
 
 
 def test_constrained_solve_reduces_violation():


### PR DESCRIPTION
Gradient solvers (GradientSolver, PGDSolver, LagrangianSolver) now follow the same convention as sampling solvers: outputs['costs'] is a flat list with one entry per env — the cost of the returned action sequence — instead of outputs['cost'] holding per-step summed cost histories (use callbacks for per-iteration tracking).

Gradient solvers re-evaluate final candidates under no_grad after the last optimizer step, so both the selected sequence and its reported cost correspond to the actions actually returned (previously selection used costs that predated the final update).
iCEM with return_mean=False now reports the exact cost of the returned best elite (topk_vals[:, 0]) rather than the elite average. Mean-returning solvers (CEM, MPPI, iCEM with return_mean=True, Categorical CEM) keep the elite/sample average as a summary of the optimized distribution.
Updated the Lagrangian tests accordingly; the convergence test previously started at zero cost and passed trivially — it now uses a non-zero goal.