### PR TITLE
Fix the README planning quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,14 @@ Datasets and checkpoints are stored under `$STABLEWM_HOME` (defaults to `~/.stab
 ```python
 import stable_worldmodel as swm
 from stable_worldmodel.policy import WorldModelPolicy, PlanConfig
-from stable_worldmodel.solver import CEMSolver
+from stable_worldmodel.planning import (
+    CEMSolver,
+    GoalMSE,
+    ShootingCostEvaluator,
+)
 
 # 1. Collect a dataset
-world = swm.World("swm/PushT-v1", num_envs=8)
+world = swm.World("swm/PushT-v1", num_envs=8, image_shape=(64, 64))
 world.set_policy(your_expert_policy)
 world.collect("data/pusht_demo.lance", episodes=100, seed=0)
 
@@ -67,8 +71,12 @@ dataset = swm.data.load_dataset("data/pusht_demo.lance", num_steps=16)
 world_model = ...  # your model
 
 # 3. Evaluate with model-predictive control
-solver = CEMSolver(model=world_model, num_samples=300)
-policy = WorldModelPolicy(solver=solver, config=PlanConfig(horizon=10))
+cost = ShootingCostEvaluator(model=world_model, objective=GoalMSE())
+solver = CEMSolver(cost=cost, num_samples=300)
+policy = WorldModelPolicy(
+    solver=solver,
+    config=PlanConfig(horizon=10, receding_horizon=1),
+)
 
 world.set_policy(policy)
 results = world.evaluate(episodes=50)


### PR DESCRIPTION
The planning refactor in #282 moved the solver package and separated world-model dynamics from the planning objective, but the README quick start still uses the previous API. As written, it imports a module that no longer exists, passes `model=` to `CEMSolver`, and omits the required `receding_horizon` value. The example also omits `image_shape`, which `World` requires while pixel rendering is enabled.

This provides an explicit image shape, updates the example to use the public `stable_worldmodel.planning` exports, composes the model with `GoalMSE` through `ShootingCostEvaluator`, passes the resulting `cost` to CEM, and sets a one-step receding horizon.

Validation:

- compiled the updated Python code block
- checked the public exports and constructor signatures against the current source
- checked README fences and local links
- ran `git diff --check`

I did not run the runtime test suite because the available interpreter is Python 3.9 and has none of the project dependencies installed; the project requires Python 3.10 or newer.
