### PR TITLE
ogbench: add test-time goal rendering (fixes #224)

### DIFF
--- a/stable_worldmodel/envs/ogbench/cube_env.py
+++ b/stable_worldmodel/envs/ogbench/cube_env.py
@@ -789,6 +789,8 @@ class CubeEnv(ManipSpaceEnv):
                   directly (overrides sampled values when provided).
                 - 'state': Optional simulator state override. Accepts either a
                   dict with 'qpos' and 'qvel' entries, or a (qpos, qvel) tuple.
+                - 'render_goal': Whether to render the goal state to pixels and
+                  expose it as ``info['goal']``. Defaults to True in task mode.
             *args: Variable length argument list passed to parent reset.
             **kwargs: Arbitrary keyword arguments passed to parent reset.
 
@@ -811,6 +813,11 @@ class CubeEnv(ManipSpaceEnv):
                 obs, info = env.reset(options={'variation': ['cube.color', 'camera.angle_delta']})
         """
         options = options or {}
+
+        if self._mode == 'task':
+            # Render the goal state by default so test-time evaluation
+            # without a dataset gets goal pixels in the info dict.
+            options.setdefault('render_goal', True)
 
         swm_spaces.reset_variation_space(
             self.variation_space,
@@ -1401,7 +1408,9 @@ class CubeEnv(ManipSpaceEnv):
         Returns:
             dict: Dictionary containing:
                 - All keys from compute_ob_info() (proprioception and object states)
-                - 'goal': Goal observation (task mode only)
+                - 'target': Goal observation (task mode only)
+                - 'goal': Rendered goal image (task mode, when goal rendering
+                  is enabled at reset)
                 - 'success': Boolean indicating current success status
 
         Note:
@@ -1411,6 +1420,9 @@ class CubeEnv(ManipSpaceEnv):
         reset_info['env_name'] = self.env_name
         reset_info['target'] = self._cur_goal_ob
         reset_info['success'] = self._success
+        goal = getattr(self, '_cur_goal_rendered', None)
+        if goal is not None:
+            reset_info['goal'] = goal
         return reset_info
 
     def get_step_info(self):
@@ -1422,7 +1434,9 @@ class CubeEnv(ManipSpaceEnv):
         Returns:
             dict: Dictionary containing:
                 - All keys from compute_ob_info() (proprioception and object states)
-                - 'goal': Goal observation (task mode only)
+                - 'target': Goal observation (task mode only)
+                - 'goal': Rendered goal image (task mode, when goal rendering
+                  is enabled at reset)
                 - 'success': Boolean indicating whether task is completed
 
         Note:
@@ -1432,6 +1446,9 @@ class CubeEnv(ManipSpaceEnv):
         ob_info['env_name'] = self.env_name
         ob_info['target'] = self._cur_goal_ob
         ob_info['success'] = self._success
+        goal = getattr(self, '_cur_goal_rendered', None)
+        if goal is not None:
+            ob_info['goal'] = goal
         return ob_info
 
     def add_object_info(self, ob_info):

--- a/stable_worldmodel/envs/ogbench/maze_env.py
+++ b/stable_worldmodel/envs/ogbench/maze_env.py
@@ -166,6 +166,7 @@ class MazeEnv(gym.Wrapper):
         self._mjcf_model = mjcf.from_path(self.env.fullpath)
         self._dirty = False
         self._mjcf_tempdir = None
+        self._goal_rendered = None
         # OGBench enables pixel floor encoding at construction time for
         # pixel observations.
         self._pixel_encoding_runtime_state = (
@@ -294,11 +295,15 @@ class MazeEnv(gym.Wrapper):
                   Pass ``['all']`` to resample every variation.
                 - ``'variation_values'``: Dict mapping variation key paths
                   to explicit values, overriding sampled values.
+                - ``'render_goal'``: Whether to render the goal state to
+                  pixels and expose it as ``info['goal']`` at reset and on
+                  every step. Defaults to True.
 
         Returns:
             tuple: ``(observation, info)`` from the underlying env reset.
         """
         options = options or {}
+        options.setdefault('render_goal', True)
 
         swm_spaces.reset_variation_space(
             self.variation_space,
@@ -312,7 +317,13 @@ class MazeEnv(gym.Wrapper):
             self.compile_model()
 
         obs, info = self.env.reset(seed=seed, options=options)
+        # OGBench's `goal` is a goal observation (a state vector for
+        # ob_type='states'); the SWM convention expects `goal` to hold
+        # goal pixels, so replace it with the rendered goal image.
         info.pop('goal', None)
+        self._goal_rendered = info.pop('goal_rendered', None)
+        if self._goal_rendered is not None:
+            info['goal'] = self._goal_rendered
         info['env_name'] = self.env_name
 
         if options.get('state') is not None:
@@ -333,6 +344,8 @@ class MazeEnv(gym.Wrapper):
     def step(self, action):
         obs, reward, terminated, truncated, info = self.env.step(action)
         info['env_name'] = self.env_name
+        if self._goal_rendered is not None:
+            info['goal'] = self._goal_rendered
         return obs, reward, terminated, truncated, info
 
     def set_state(self, qpos, qvel):

--- a/stable_worldmodel/envs/ogbench/scene_env.py
+++ b/stable_worldmodel/envs/ogbench/scene_env.py
@@ -316,6 +316,11 @@ class SceneEnv(ManipSpaceEnv):
     def reset(self, options=None, *args, **kwargs):
         options = options or {}
 
+        if self._mode == 'task':
+            # Render the goal state by default so test-time evaluation
+            # without a dataset gets goal pixels in the info dict.
+            options.setdefault('render_goal', True)
+
         swm_spaces.reset_variation_space(
             self.variation_space,
             seed=None,
@@ -1084,6 +1089,9 @@ class SceneEnv(ManipSpaceEnv):
         reset_info['env_name'] = self.env_name
         reset_info['target'] = self._cur_goal_ob
         reset_info['success'] = self._success
+        goal = getattr(self, '_cur_goal_rendered', None)
+        if goal is not None:
+            reset_info['goal'] = goal
         return reset_info
 
     def get_step_info(self):
@@ -1091,6 +1099,9 @@ class SceneEnv(ManipSpaceEnv):
         ob_info['env_name'] = self.env_name
         ob_info['target'] = self._cur_goal_ob
         ob_info['success'] = self._success
+        goal = getattr(self, '_cur_goal_rendered', None)
+        if goal is not None:
+            ob_info['goal'] = goal
         return ob_info
 
     def add_object_info(self, ob_info):

--- a/tests/envs/test_ogbench_env.py
+++ b/tests/envs/test_ogbench_env.py
@@ -1,0 +1,126 @@
+import numpy as np
+import pytest
+
+
+pytest.importorskip('ogbench')
+
+import stable_worldmodel as swm  # noqa: E402
+from stable_worldmodel.envs.ogbench.cube_env import CubeEnv  # noqa: E402
+from stable_worldmodel.envs.ogbench.maze_env import MazeEnv  # noqa: E402
+from stable_worldmodel.policy import RandomPolicy  # noqa: E402
+
+
+class TestCubeGoalInfo:
+    def test_reset_and_step_info_contain_rendered_goal(self):
+        env = CubeEnv(env_type='single', height=64, width=64)
+        try:
+            _, info = env.reset(seed=0)
+            assert 'goal' in info
+            goal = info['goal']
+            assert isinstance(goal, np.ndarray)
+            assert goal.shape == (64, 64, 3)
+            assert goal.dtype == np.uint8
+
+            _, _, _, _, info = env.step(env.action_space.sample())
+            assert 'goal' in info
+            np.testing.assert_array_equal(info['goal'], goal)
+        finally:
+            env.close()
+
+    def test_goal_differs_from_initial_render(self):
+        env = CubeEnv(env_type='single', height=64, width=64)
+        try:
+            _, info = env.reset(seed=0)
+            # The goal image shows the cube at the target position, not
+            # the initial one.
+            assert not np.array_equal(info['goal'], env.render())
+        finally:
+            env.close()
+
+    def test_render_goal_opt_out(self):
+        env = CubeEnv(env_type='single', height=64, width=64)
+        try:
+            _, info = env.reset(seed=0, options={'render_goal': False})
+            assert 'goal' not in info
+        finally:
+            env.close()
+
+    def test_data_collection_mode_has_no_goal(self):
+        env = CubeEnv(
+            env_type='single',
+            mode='data_collection',
+            terminate_at_goal=False,
+            height=64,
+            width=64,
+        )
+        try:
+            _, info = env.reset(seed=0)
+            assert 'goal' not in info
+
+            _, _, _, _, info = env.step(env.action_space.sample())
+            assert 'goal' not in info
+        finally:
+            env.close()
+
+
+class TestMazeGoalInfo:
+    def test_reset_and_step_info_contain_rendered_goal(self):
+        env = MazeEnv(
+            maze_type='arena',
+            height=64,
+            width=64,
+            render_mode='rgb_array',
+        )
+        try:
+            _, info = env.reset(seed=0)
+            assert 'goal' in info
+            goal = info['goal']
+            assert isinstance(goal, np.ndarray)
+            assert goal.shape == (64, 64, 3)
+            assert goal.dtype == np.uint8
+
+            _, _, _, _, info = env.step(env.action_space.sample())
+            assert 'goal' in info
+            np.testing.assert_array_equal(info['goal'], goal)
+        finally:
+            env.close()
+
+
+class GoalCheckingPolicy(RandomPolicy):
+    """Random policy that records the goal seen at every planning call."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.goal_shapes = []
+
+    def get_action(self, info_dict, **kwargs):
+        assert 'goal' in info_dict, "'goal' missing from infos"
+        self.goal_shapes.append(info_dict['goal'].shape)
+        return super().get_action(info_dict, **kwargs)
+
+
+class TestEvaluateWithoutDataset:
+    def test_cube_episodic_evaluation_provides_goal(self):
+        world = swm.World(
+            'swm/OGBCube-v0',
+            num_envs=1,
+            image_shape=(32, 32),
+            max_episode_steps=2,
+            env_type='single',
+            height=64,
+            width=64,
+            visualize_info=False,
+        )
+        try:
+            policy = GoalCheckingPolicy(seed=0)
+            world.set_policy(policy)
+            results = world.evaluate(episodes=1, seed=0)
+
+            assert 'success_rate' in results
+            assert len(results['episode_successes']) == 1
+            assert policy.goal_shapes
+            assert all(
+                shape == (1, 1, 32, 32, 3) for shape in policy.goal_shapes
+            )
+        finally:
+            world.close()

--- a/tests/test_new_world.py
+++ b/tests/test_new_world.py
@@ -698,6 +698,30 @@ class TestEvaluateFromDataset:
         assert 'model_xml' not in world.infos
         assert 'ep_meta' not in world.infos
 
+    def test_env_goal_overridden_by_dataset_goal(self):
+        class EnvGoalEnv(DatasetResetEnv):
+            """Env that generates its own goal pixels, like the OGBench
+            envs do for dataset-free evaluation."""
+
+            def _make_info(self, terminated):
+                info = super()._make_info(terminated)
+                info['goal'] = np.full((1, 3, 3, 3), 9, dtype=np.uint8)
+                return info
+
+        world = _make_world_with([lambda: EnvGoalEnv(3) for _ in range(2)])
+        world.evaluate(
+            dataset=FakeEvalDataset(),
+            episodes_idx=[0, 1],
+            start_steps=[0, 0],
+            goal_offset=3,
+            eval_budget=5,
+        )
+
+        # The dataset goal (fill value ep+1) wins over the env-generated
+        # goal (fill value 9), on reset and on every subsequent step.
+        assert int(world.infos['goal'][0].max()) == 1
+        assert int(world.infos['goal'][1].max()) == 2
+
     def test_callables_path_gets_merged_row(self):
         received = []
 


### PR DESCRIPTION
Fixes #224

Evaluating without a dataset currently fails on the OGBench envs because the planner needs goal pixels under `info['goal']`, which these envs never provide (they only expose the state-based `target`). With a dataset this works because the World injects the dataset's goal frame.

OGBench actually already computes a valid goal state at every task-mode reset and can render it (the upstream `render_goal` reset option), it just wasn't exposed. This PR turns that option on by default in task mode and puts the rendered image in `info['goal']` at reset and on every step, same as PushT and the other goal-conditioned envs. Applied to `cube_env`, `scene_env`, and `maze_env`.

Dataset-driven eval still overrides the env goal, `data_collection` mode doesn't emit the key (so collected dataset schemas are unchanged), and `options={'render_goal': False}` opts out.

Tests: new `tests/envs/test_ogbench_env.py` covering goal presence in reset/step infos, opt-out, data-collection mode, and a full dataset-free `World.evaluate` on `swm/OGBCube-v0`; plus a test pinning that the dataset goal still wins during dataset eval. Full suite passes locally (py3.12, 1145 passed).

Open to a different interface if you'd prefer, e.g. opt-in rather than default-on, or per-camera goals for `multiview=True` (right now the goal is a single `front_pixels` render, matching what `ResizeGoalWrapper` handles).