### PR TITLE
Fix GCIQL exports and checkpoint handling

### DIFF
--- a/scripts/train/gciql.py
+++ b/scripts/train/gciql.py
@@ -7,8 +7,6 @@ import stable_pretraining as spt
 import torch
 from einops import rearrange, repeat
 from lightning.pytorch.callbacks import Callback
-from stable_worldmodel.data import column_normalizer as get_column_normalizer
-from stable_worldmodel.wm.utils import save_pretrained
 from lightning.pytorch.loggers import WandbLogger
 from loguru import logger as logging
 from omegaconf import OmegaConf
@@ -16,6 +14,8 @@ from torch.utils.data import DataLoader
 from transformers import AutoModel
 
 import stable_worldmodel as swm
+from stable_worldmodel.data import column_normalizer as get_column_normalizer
+from stable_worldmodel.wm.utils import save_pretrained
 
 # TODO for now we use AWR to extract a policy from the learned value function.
 # we should implement DDPG style training from the learnt critic as well.
@@ -871,6 +871,9 @@ def run(cfg):
     gciql_critics_model = get_gciql_critics_model(cfg)
 
     cache_dir = swm.data.utils.get_cache_dir(sub_folder='checkpoints')
+    value_ckpt_path = cache_dir / (
+        f'{cfg.output_model_name}_value_weights.ckpt'
+    )
 
     if cfg.get('train_value', True):
         dump_object_callback = SaveCkptCallback(
@@ -892,7 +895,7 @@ def run(cfg):
             trainer=trainer,
             module=gciql_critics_model,
             data=data,
-            ckpt_path=f'{cache_dir}/{cfg.output_model_name}_value_weights.ckpt',
+            ckpt_path=value_ckpt_path if value_ckpt_path.exists() else None,
         )
         manager()
 
@@ -906,11 +909,11 @@ def run(cfg):
     )
     data = get_data(cfg, goal_probabilities=goal_probs)
 
-    # load value function weights
-    checkpoint = torch.load(
-        f'{cache_dir}/{cfg.output_model_name}_value_weights.ckpt'
-    )
-    gciql_critics_model.load_state_dict(checkpoint['state_dict'])
+    # A freshly trained critic is already available in memory. Only load a
+    # checkpoint when value training was explicitly skipped.
+    if not cfg.get('train_value', True):
+        checkpoint = torch.load(value_ckpt_path)
+        gciql_critics_model.load_state_dict(checkpoint['state_dict'])
 
     gciql_actor_model = get_gciql_actor_model(cfg, gciql_critics_model)
 
@@ -928,11 +931,14 @@ def run(cfg):
         enable_checkpointing=True,
     )
 
+    policy_ckpt_path = cache_dir / (
+        f'{cfg.output_model_name}_policy_weights.ckpt'
+    )
     manager = spt.Manager(
         trainer=trainer,
         module=gciql_actor_model,
         data=data,
-        ckpt_path=f'{cache_dir}/{cfg.output_model_name}_policy_weights.ckpt',
+        ckpt_path=policy_ckpt_path if policy_ckpt_path.exists() else None,
     )
     manager()
 

--- a/scripts/train/gcivl.py
+++ b/scripts/train/gcivl.py
@@ -7,8 +7,6 @@ import stable_pretraining as spt
 import torch
 from einops import rearrange, repeat
 from lightning.pytorch.callbacks import Callback
-from stable_worldmodel.data import column_normalizer as get_column_normalizer
-from stable_worldmodel.wm.utils import save_pretrained
 from lightning.pytorch.loggers import WandbLogger
 from loguru import logger as logging
 from omegaconf import OmegaConf
@@ -16,6 +14,8 @@ from torch.utils.data import DataLoader
 from transformers import AutoModel
 
 import stable_worldmodel as swm
+from stable_worldmodel.data import column_normalizer as get_column_normalizer
+from stable_worldmodel.wm.utils import save_pretrained
 
 
 # ============================================================================
@@ -816,6 +816,9 @@ def run(cfg):
     ivl_value_model = get_ivl_value_model(cfg)
 
     cache_dir = swm.data.utils.get_cache_dir(sub_folder='checkpoints')
+    value_ckpt_path = cache_dir / (
+        f'{cfg.output_model_name}_value_weights.ckpt'
+    )
 
     if cfg.get('train_value', True):
         dump_object_callback = SaveCkptCallback(
@@ -837,7 +840,7 @@ def run(cfg):
             trainer=trainer,
             module=ivl_value_model,
             data=data,
-            ckpt_path=f'{cache_dir}/{cfg.output_model_name}_value_weights.ckpt',
+            ckpt_path=value_ckpt_path if value_ckpt_path.exists() else None,
         )
         manager()
 
@@ -851,11 +854,11 @@ def run(cfg):
     )
     data = get_data(cfg, goal_probabilities=goal_probs)
 
-    # load value function weights
-    checkpoint = torch.load(
-        f'{cache_dir}/{cfg.output_model_name}_value_weights.ckpt'
-    )
-    ivl_value_model.load_state_dict(checkpoint['state_dict'])
+    # A freshly trained value model is already available in memory. Only load
+    # a checkpoint when value training was explicitly skipped.
+    if not cfg.get('train_value', True):
+        checkpoint = torch.load(value_ckpt_path)
+        ivl_value_model.load_state_dict(checkpoint['state_dict'])
 
     ivl_actor_model = get_ivl_actor_model(cfg, ivl_value_model)
 
@@ -873,11 +876,14 @@ def run(cfg):
         enable_checkpointing=True,
     )
 
+    policy_ckpt_path = cache_dir / (
+        f'{cfg.output_model_name}_policy_weights.ckpt'
+    )
     manager = spt.Manager(
         trainer=trainer,
         module=ivl_actor_model,
         data=data,
-        ckpt_path=f'{cache_dir}/{cfg.output_model_name}_policy_weights.ckpt',
+        ckpt_path=policy_ckpt_path if policy_ckpt_path.exists() else None,
     )
     manager()
 

--- a/stable_worldmodel/wm/gcrl/__init__.py
+++ b/stable_worldmodel/wm/gcrl/__init__.py
@@ -1,1 +1,15 @@
-from .gcrl import *  # noqa: F403
+from .gcrl import GCRL
+from .module import (
+    Embedder,
+    ExpectileLoss,
+    Predictor,
+    QPredictor,
+)
+
+__all__ = [
+    'GCRL',
+    'Embedder',
+    'ExpectileLoss',
+    'Predictor',
+    'QPredictor',
+]


### PR DESCRIPTION
## Summary

- export the GCRL components used by `scripts/train/gciql.py` from the package namespace
- resume value and policy training only when their checkpoint files actually exist
- reuse the freshly trained critic in memory before AWR policy training, while retaining checkpoint loading for `train_value=false`

## Problem

The GCIQL training entry point currently fails before training with:

```text
AttributeError: module 'stable_worldmodel.wm.gcrl.gcrl' has no attribute 'ExpectileLoss'
```

The package initializer only wildcard-imports `gcrl.py`, while `ExpectileLoss`, `Embedder`, `Predictor`, and `QPredictor` live in `module.py`. Importing the same-named submodule can also leave `swm.wm.gcrl` bound to the submodule instead of a package API containing all components expected by the script.

After fixing the exports, a fresh GCIQL run also passes nonexistent value/policy checkpoint paths to `spt.Manager` and unconditionally reloads the value checkpoint between the two training stages. This prevents a clean two-stage run from scratch with current `stable-pretraining` checkpoint semantics.

## Fix

The package initializer now explicitly defines the public GCRL API. The training script follows the same checkpoint-existence behavior already used by the LeWM training entry point: it passes `None` for a fresh run, resumes only from existing checkpoints, and avoids reloading the critic after it was just trained in the same process.

## Validation

- `ruff check` passed
- TwoRoom two-stage smoke test completed: one critic/value batch followed by one AWR actor batch
- PushT two-stage smoke test completed: one critic/value batch followed by one AWR actor batch
- a full TwoRoom run successfully entered critic/value training on the complete dataset

Tested with Python 3.10, PyTorch 2.11.0+cu128, and `stable-pretraining==0.1.8`.
