### PR TITLE
Pin each env to one thread so async pools can render on GPU

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ swm = "stable_worldmodel.cli:app"
 [project.optional-dependencies]
 train = [
     "transformers>=4.50.0",
-    "stable-pretraining>=0.1.7",
+    "stable-pretraining>=0.1.8",
     "hydra-submitit-launcher",
     "wandb",
 ]

--- a/stable_worldmodel/data/__init__.py
+++ b/stable_worldmodel/data/__init__.py
@@ -35,7 +35,6 @@ from .formats.lerobot import LeRobotAdapter
 try:
     from .formats.hdf5 import HDF5Dataset, HDF5Writer  # noqa: F401
 except ImportError:
-    breakpoint()
     pass
 
 try:

--- a/stable_worldmodel/data/__init__.py
+++ b/stable_worldmodel/data/__init__.py
@@ -35,6 +35,7 @@ from .formats.lerobot import LeRobotAdapter
 try:
     from .formats.hdf5 import HDF5Dataset, HDF5Writer  # noqa: F401
 except ImportError:
+    breakpoint()
     pass
 
 try:

--- a/stable_worldmodel/envs/ogbench/expert_policy.py
+++ b/stable_worldmodel/envs/ogbench/expert_policy.py
@@ -212,20 +212,20 @@ class ExpertPolicy(BasePolicy):
 
         return p_stack
 
-    def get_action(self, info_dict, **kwargs):
+    def get_action(self, info_dict, *, env_mask=None, **kwargs):
         assert hasattr(self, 'env'), 'Environment not set for the policy'
         assert 'privileged/target_task' in info_dict, (
             "'privileged/target_task' must be provided in info_dict"
         )
 
         envs = [e.unwrapped for e in self.env.envs]
-        act_shape = self.env.action_space.shape
-        actions = np.zeros(act_shape, dtype=np.float32)
+        env_indices, actions = self._ready_envs(envs, env_mask)
 
-        for i, env in enumerate(envs):
+        for row, i in enumerate(env_indices):
+            env = envs[i]
             # extract env-relevant info
             info = {
-                k: v[i][0]
+                k: v[row][0]
                 for k, v in info_dict.items()
                 if not k.startswith('_')
             }
@@ -257,7 +257,7 @@ class ExpertPolicy(BasePolicy):
                         0, [xi, xi, xi, xi * 3, xi * 10], action.shape
                     )
             action = np.clip(action, -1, 1)
-            actions[i] = action
+            actions[row] = action
 
             # Set a new task when the current subtask is done.
             if self._agents[i].done:

--- a/stable_worldmodel/envs/piecewise/expert_policy.py
+++ b/stable_worldmodel/envs/piecewise/expert_policy.py
@@ -30,7 +30,7 @@ class ExpertPolicy(BasePolicy):
     def set_env(self, env):
         self.env = env
 
-    def get_action(self, info_dict, **kwargs):
+    def get_action(self, info_dict, *, env_mask=None, **kwargs):
         assert hasattr(self, 'env'), 'Environment not set for the policy'
         assert 'state' in info_dict, "'state' must be provided in info_dict"
         assert 'goal_state' in info_dict, (
@@ -49,15 +49,20 @@ class ExpertPolicy(BasePolicy):
                 envs = [base_env]
                 is_vectorized = False
 
-        actions = np.zeros(self.env.action_space.shape, dtype=np.float32)
+        if is_vectorized:
+            env_indices, actions = self._ready_envs(envs, env_mask)
+        else:
+            env_indices = np.arange(1)
+            actions = np.zeros(self.env.action_space.shape, dtype=np.float32)
 
-        for i, env in enumerate(envs):
+        for row, i in enumerate(env_indices):
+            env = envs[i]
             if is_vectorized:
                 agent_pos = np.asarray(
-                    info_dict['state'][i], dtype=np.float32
+                    info_dict['state'][row], dtype=np.float32
                 ).squeeze()
                 goal_pos = np.asarray(
-                    info_dict['goal_state'][i], dtype=np.float32
+                    info_dict['goal_state'][row], dtype=np.float32
                 ).squeeze()
             else:
                 agent_pos = np.asarray(
@@ -80,7 +85,7 @@ class ExpertPolicy(BasePolicy):
             action = (goal_pos - agent_pos - bias) / speed
 
             if is_vectorized:
-                actions[i] = action
+                actions[row] = action
             else:
                 actions = action
 
@@ -98,13 +103,24 @@ class ExpertPolicy(BasePolicy):
                 < self.action_repeat_prob
             )
             if is_vectorized:
-                actions[repeat_mask] = self._last_action[repeat_mask]
+                # `_last_action` spans the pool; `repeat_mask` only this call.
+                previous = self._last_action[env_indices]
+                actions[repeat_mask] = previous[repeat_mask]
             else:
                 if repeat_mask:
                     actions = self._last_action
 
         actions = np.clip(actions, -1.0, 1.0).astype(np.float32)
-        self._last_action = actions
+        if is_vectorized:
+            if self._last_action is None or self._last_action.shape[0] != len(
+                envs
+            ):
+                self._last_action = np.zeros(
+                    (len(envs), *actions.shape[1:]), dtype=np.float32
+                )
+            self._last_action[env_indices] = actions
+        else:
+            self._last_action = actions
         return actions
 
 

--- a/stable_worldmodel/envs/pusht/expert_policy.py
+++ b/stable_worldmodel/envs/pusht/expert_policy.py
@@ -6,6 +6,8 @@ from stable_worldmodel.policy import BasePolicy
 class WeakPolicy(BasePolicy):
     """Collection policy for PushT environment."""
 
+    info_keys: tuple[str, ...] | None = ()
+
     def __init__(
         self,
         dist_constraint=100,
@@ -46,7 +48,7 @@ class WeakPolicy(BasePolicy):
         )
         self.discrete = 'Discrete' in spec.id
 
-    def get_action(self, info_dict, **kwargs):
+    def get_action(self, info_dict, *, env_mask=None, **kwargs):
         assert hasattr(self, 'env'), 'Environment not set for the policy'
 
         # Handle vectorized envs (VecEnv-style) and single envs gracefully
@@ -59,10 +61,18 @@ class WeakPolicy(BasePolicy):
             else:
                 envs = [base_env]
 
-        act_shape = self.env.action_space.shape
-        actions = np.zeros(act_shape, dtype=np.float32)
+        if env_mask is None:
+            env_indices = np.arange(len(envs))
+            actions = np.zeros(self.env.action_space.shape, dtype=np.float32)
+        else:
+            env_indices = np.flatnonzero(env_mask)
+            single_shape = envs[0].action_space.shape
+            actions = np.zeros(
+                (len(env_indices), *single_shape), dtype=np.float32
+            )
 
-        for i, env in enumerate(envs):
+        for row, env_idx in enumerate(env_indices):
+            env = envs[env_idx]
             # sample a random action
             action = self.rng.uniform(-1, 1, size=env.action_space.shape)
             # scale action to environment position
@@ -83,7 +93,7 @@ class WeakPolicy(BasePolicy):
                 action = env.quantizer.quantize(action)
 
             # set action for this env
-            actions[i] = action
+            actions[row] = action
 
         # VecEnv expects (n_envs, action_dim)
         return actions

--- a/stable_worldmodel/envs/pusht/expert_policy.py
+++ b/stable_worldmodel/envs/pusht/expert_policy.py
@@ -61,15 +61,7 @@ class WeakPolicy(BasePolicy):
             else:
                 envs = [base_env]
 
-        if env_mask is None:
-            env_indices = np.arange(len(envs))
-            actions = np.zeros(self.env.action_space.shape, dtype=np.float32)
-        else:
-            env_indices = np.flatnonzero(env_mask)
-            single_shape = envs[0].action_space.shape
-            actions = np.zeros(
-                (len(env_indices), *single_shape), dtype=np.float32
-            )
+        env_indices, actions = self._ready_envs(envs, env_mask)
 
         for row, env_idx in enumerate(env_indices):
             env = envs[env_idx]

--- a/stable_worldmodel/envs/rocket_landing/expert_policy.py
+++ b/stable_worldmodel/envs/rocket_landing/expert_policy.py
@@ -564,7 +564,7 @@ class ExpertPolicy(BasePolicy):
         elif len(self.controllers) > count:
             self.controllers = self.controllers[:count]
 
-    def get_action(self, info_dict, **kwargs):
+    def get_action(self, info_dict, *, env_mask=None, **kwargs):
         """
         Returns:
             action: numpy array of shape (7,) containing:
@@ -578,12 +578,18 @@ class ExpertPolicy(BasePolicy):
         batched = obs.ndim > 1
         obs_batch = obs if batched else obs[None, :]
 
-        self._ensure_controller_count(obs_batch.shape[0])
+        # Sized by the pool: this call's batch would drop the other envs'.
+        if env_mask is None:
+            env_indices = np.arange(obs_batch.shape[0])
+            self._ensure_controller_count(obs_batch.shape[0])
+        else:
+            env_indices = np.flatnonzero(env_mask)
+            self._ensure_controller_count(len(env_mask))
 
         actions = []
-        for idx, single_obs in enumerate(obs_batch):
-            state_dict = parse_observation(single_obs, 'quaternion')
-            controller = self.controllers[idx]
+        for row, i in enumerate(env_indices):
+            state_dict = parse_observation(obs_batch[row], 'quaternion')
+            controller = self.controllers[i]
             action = controller.compute_control(state_dict)
             controller.post_step_update()
             actions.append(action)

--- a/stable_worldmodel/envs/two_room/expert_policy.py
+++ b/stable_worldmodel/envs/two_room/expert_policy.py
@@ -39,7 +39,7 @@ class ExpertPolicy(BasePolicy):
     def set_env(self, env):
         self.env = env
 
-    def get_action(self, info_dict, **kwargs):
+    def get_action(self, info_dict, *, env_mask=None, **kwargs):
         assert hasattr(self, 'env'), 'Environment not set for the policy'
         assert 'state' in info_dict, "'state' must be provided in info_dict"
         assert 'goal_state' in info_dict, (
@@ -58,15 +58,20 @@ class ExpertPolicy(BasePolicy):
                 envs = [base_env]
                 is_vectorized = False
 
-        actions = np.zeros(self.env.action_space.shape, dtype=np.float32)
+        if is_vectorized:
+            env_indices, actions = self._ready_envs(envs, env_mask)
+        else:
+            env_indices = np.arange(1)
+            actions = np.zeros(self.env.action_space.shape, dtype=np.float32)
 
-        for i, env in enumerate(envs):
+        for row, i in enumerate(env_indices):
+            env = envs[i]
             if is_vectorized:
                 agent_pos = np.asarray(
-                    info_dict['state'][i], dtype=np.float32
+                    info_dict['state'][row], dtype=np.float32
                 ).squeeze()
                 goal_pos = np.asarray(
-                    info_dict['goal_state'][i], dtype=np.float32
+                    info_dict['goal_state'][row], dtype=np.float32
                 ).squeeze()
             else:
                 agent_pos = np.asarray(
@@ -165,7 +170,7 @@ class ExpertPolicy(BasePolicy):
                 direction = np.zeros_like(direction, dtype=np.float32)
 
             if is_vectorized:
-                actions[i] = direction.astype(np.float32)
+                actions[row] = direction.astype(np.float32)
             else:
                 actions = direction.astype(np.float32)
 

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -202,9 +202,9 @@ class RandomPolicy(BasePolicy):
     def set_env(self, env: Any) -> None:
         super().set_env(env)
         if self.seed is not None:
-            self._set_seed(self.seed)
+            self.set_seed(self.seed)
 
-    def _set_seed(self, seed: int) -> None:
+    def set_seed(self, seed: int) -> None:
         if self.env is not None:
             self.env.action_space.seed(seed)
 

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -12,7 +12,9 @@ from torchvision import tv_tensors
 
 from stable_worldmodel.planning.solver import Solver
 from stable_worldmodel.protocols import Actionable, Transformable
-from stable_worldmodel.world.env_pool import AsyncEnvMask
+
+if TYPE_CHECKING:
+    from stable_worldmodel.world.env_pool import AsyncEnvMask
 
 
 @dataclass(frozen=True)

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
-from collections.abc import Callable
 
 import numpy as np
 import torch
+from numpy.typing import NDArray
 from torchvision import tv_tensors
 
 from stable_worldmodel.planning.solver import Solver
 from stable_worldmodel.protocols import Actionable, Transformable
+from stable_worldmodel.world.env_pool import AsyncEnvMask
 
 
 @dataclass(frozen=True)
@@ -57,11 +61,21 @@ class BasePolicy:
         for arg, value in kwargs.items():
             setattr(self, arg, value)
 
-    def get_action(self, obs: Any, **kwargs: Any) -> np.ndarray:
+    def get_action(
+        self,
+        obs: Any,
+        *,
+        env_mask: AsyncEnvMask | None = None,
+        **kwargs: Any,
+    ) -> np.ndarray:
         """Get action from the policy given the observation.
 
         Args:
             obs: The current observation from the environment.
+            env_mask: Optional boolean mask over the full environment pool.
+                When provided, ``obs`` contains only the selected rows, in
+                ascending environment-index order. Stateful policies use the
+                mask to map those rows back to their per-environment state.
             **kwargs: Additional parameters for action selection.
 
         Returns:
@@ -71,6 +85,16 @@ class BasePolicy:
             NotImplementedError: If not implemented by a subclass.
         """
         raise NotImplementedError
+
+    def on_reset(self, env_mask: AsyncEnvMask | None = None) -> None:
+        """Notify the policy that selected environments were reset.
+
+        Args:
+            env_mask: Boolean mask over the full environment pool. ``None``
+                means that every environment was reset.
+
+        Stateless policies do not need to override this hook.
+        """
 
     def set_env(self, env: Any) -> None:
         """Associate this policy with an environment.
@@ -345,11 +369,21 @@ class WorldModelPolicy(BasePolicy):
             'Solver must implement the Solver protocol'
         )
 
-    def get_action(self, info_dict: dict, **kwargs: Any) -> np.ndarray:
+    def get_action(
+        self,
+        info_dict: dict,
+        *,
+        env_mask: AsyncEnvMask | None = None,
+        **kwargs: Any,
+    ) -> np.ndarray:
         """Get action via planning with the world model.
 
         Args:
             info_dict: Current state information from the environment.
+            env_mask: Optional boolean mask over the full environment pool.
+                ``info_dict`` contains one row per true entry, in ascending
+                environment-index order. If omitted, all environments are
+                assumed present (sync EnvPool).
             **kwargs: Additional parameters for planning.
 
         Returns:
@@ -357,45 +391,50 @@ class WorldModelPolicy(BasePolicy):
         """
         assert hasattr(self, 'env'), 'Environment not set for the policy'
 
-        info_dict = self._prepare_info(info_dict)
         n_envs = self.env.num_envs
+        env_indices = _selected_env_indices(env_mask, n_envs)
+        batch_size = len(env_indices)
 
-        needs_flush = info_dict.pop('_needs_flush', None)
+        needs_flush = info_dict.get('_needs_flush')
         if needs_flush is not None:
-            for i in range(n_envs):
-                if needs_flush[i]:
-                    self._action_buffer[i].clear()
-                    if self._next_init is not None:
-                        self._next_init[i] = 0
+            flush_rows = _bool_rows(needs_flush, batch_size, '_needs_flush')
+            flush_mask = np.zeros(n_envs, dtype=bool)
+            flush_mask[env_indices[flush_rows]] = True
+            self.on_reset(flush_mask)
+
+        info_dict = self._prepare_info(info_dict)
+        info_dict.pop('_needs_flush', None)
 
         terminated = info_dict.get('terminated')
         dead = (
-            np.asarray(terminated, dtype=bool)
+            _bool_rows(terminated, batch_size, 'terminated')
             if terminated is not None
-            else np.zeros(n_envs, dtype=bool)
+            else np.zeros(batch_size, dtype=bool)
         )
 
-        replan_idx = [
-            i
-            for i in range(n_envs)
-            if len(self._action_buffer[i]) == 0 and not dead[i]
+        replan_rows = [
+            row
+            for row, env_i in enumerate(env_indices)
+            if len(self._action_buffer[env_i]) == 0 and not dead[row]
         ]
+        replan_envs = env_indices[replan_rows]
 
-        if replan_idx:
-            idx_tensor = torch.as_tensor(replan_idx, dtype=torch.long)
+        if replan_rows:
+            row_tensor = torch.as_tensor(replan_rows, dtype=torch.long)
+            env_tensor = torch.as_tensor(replan_envs, dtype=torch.long)
             sliced = {}
             for k, v in info_dict.items():
                 if torch.is_tensor(v):
-                    sliced[k] = v[idx_tensor]
+                    sliced[k] = v[row_tensor]
                 elif isinstance(v, np.ndarray):
-                    sliced[k] = v[replan_idx]
+                    sliced[k] = v[replan_rows]
                 elif isinstance(v, list):
-                    sliced[k] = [v[i] for i in replan_idx]
+                    sliced[k] = [v[i] for i in replan_rows]
                 else:
                     sliced[k] = v
 
             sliced_init = (
-                self._next_init[idx_tensor]
+                self._next_init[env_tensor]
                 if self._next_init is not None
                 else None
             )
@@ -412,37 +451,78 @@ class WorldModelPolicy(BasePolicy):
                     self._next_init = torch.zeros(
                         n_envs, rest.shape[1], rest.shape[2], dtype=rest.dtype
                     )
-                self._next_init[idx_tensor] = rest
+                self._next_init[env_tensor] = rest
             elif not self.cfg.warm_start:
                 self._next_init = None
 
             plan = plan.reshape(
-                len(replan_idx), self.flatten_receding_horizon, -1
+                len(replan_rows), self.flatten_receding_horizon, -1
             )
 
-            for row, env_i in enumerate(replan_idx):
+            for row, env_i in enumerate(replan_envs):
                 self._action_buffer[env_i].extend(plan[row])
 
         single_shape = self.env.single_action_space.shape
         is_discrete = 'Discrete' in type(self.env.single_action_space).__name__
 
         action = torch.full(
-            (n_envs, *single_shape),
+            (batch_size, *single_shape),
             fill_value=0 if is_discrete else float('nan'),
             dtype=torch.long if is_discrete else torch.float32,
         )
 
-        for i in range(n_envs):
-            if not dead[i]:
-                action[i] = self._action_buffer[i].popleft()
+        for row, env_i in enumerate(env_indices):
+            if not dead[row]:
+                action[row] = self._action_buffer[env_i].popleft()
 
-        action = action.reshape(*self.env.action_space.shape)
+        if env_mask is None:
+            action = action.reshape(*self.env.action_space.shape)
         action = action.numpy()
 
         if 'action' in self.process:
             action = self.process['action'].inverse_transform(action)
 
         return action
+
+    def on_reset(self, env_mask: AsyncEnvMask | None = None) -> None:
+        """Clear plans and warm starts for reset environment slots."""
+        if self._action_buffer is None:
+            return
+
+        n_envs = len(self._action_buffer)
+        env_indices = _selected_env_indices(env_mask, n_envs)
+        for env_i in env_indices:
+            self._action_buffer[env_i].clear()
+            if self._next_init is not None:
+                self._next_init[env_i] = 0
+
+
+def _selected_env_indices(
+    env_mask: AsyncEnvMask | None, n_envs: int
+) -> NDArray[np.int64]:
+    """Map an optional full-pool boolean mask to global env indices."""
+    if env_mask is None:
+        return np.arange(n_envs, dtype=np.int64)
+
+    mask = np.asarray(env_mask)
+    if mask.dtype != np.bool_ or mask.shape != (n_envs,):
+        raise ValueError(
+            f'env_mask must be boolean with shape ({n_envs},), '
+            f'got dtype={mask.dtype} and shape={mask.shape}'
+        )
+    return np.flatnonzero(mask)
+
+
+def _bool_rows(value: Any, batch_size: int, name: str) -> NDArray[np.bool_]:
+    """Collapse a batched boolean value to one flag per input row."""
+    if torch.is_tensor(value):
+        value = value.detach().cpu().numpy()
+    rows = np.asarray(value, dtype=bool)
+    if rows.ndim == 0 or rows.shape[0] != batch_size:
+        raise ValueError(
+            f'{name} must have {batch_size} leading rows, got {rows.shape}'
+        )
+    return rows.reshape(batch_size, -1).any(axis=1)
 
 
 # Alias for backward compatibility and type hinting

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -47,10 +47,14 @@ class BasePolicy:
     Attributes:
         env: The environment the policy is associated with.
         type: A string identifier for the policy type.
+        info_keys: Async rollout info selection. ``None`` passes the full
+            ready info dict, ``()`` passes no info, and a tuple passes only
+            those keys.
     """
 
     env: Any
     type: str
+    info_keys: tuple[str, ...] | None = None
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the base policy.
@@ -173,6 +177,8 @@ class BasePolicy:
 
 class RandomPolicy(BasePolicy):
     """Policy that samples random actions from the action space."""
+
+    info_keys: tuple[str, ...] | None = ()
 
     def __init__(self, seed: int | None = None, **kwargs: Any) -> None:
         """Initialize the random policy.

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -202,9 +202,9 @@ class RandomPolicy(BasePolicy):
     def set_env(self, env: Any) -> None:
         super().set_env(env)
         if self.seed is not None:
-            self.set_seed(self.seed)
+            self._set_seed(self.seed)
 
-    def set_seed(self, seed: int) -> None:
+    def _set_seed(self, seed: int) -> None:
         if self.env is not None:
             self.env.action_space.seed(seed)
 

--- a/stable_worldmodel/policy.py
+++ b/stable_worldmodel/policy.py
@@ -102,6 +102,38 @@ class BasePolicy:
         Stateless policies do not need to override this hook.
         """
 
+    def _ready_envs(
+        self,
+        envs: list,
+        env_mask: AsyncEnvMask | None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Resolve an async mask to env indices and an action buffer.
+
+        Per-env policies iterate ``enumerate(env_indices)`` and carry two
+        indices: the position in the loop addresses the narrowed info and the
+        returned actions, while the value is the absolute env index that
+        ``envs`` and any per-environment state are keyed by. Conflating them
+        is what breaks a policy under narrowing.
+
+        Args:
+            envs: Every env in the pool, in absolute index order.
+            env_mask: Boolean mask over the pool, or ``None`` for all envs.
+
+        Returns:
+            The absolute indices to act for, and a zeroed action buffer with
+            one row per index.
+        """
+        if env_mask is None:
+            return (
+                np.arange(len(envs)),
+                np.zeros(self.env.action_space.shape, dtype=np.float32),
+            )
+
+        env_indices = np.flatnonzero(env_mask)
+        single_shape = envs[0].action_space.shape
+        actions = np.zeros((len(env_indices), *single_shape), dtype=np.float32)
+        return env_indices, actions
+
     def set_env(self, env: Any) -> None:
         """Associate this policy with an environment.
 

--- a/stable_worldmodel/world/__init__.py
+++ b/stable_worldmodel/world/__init__.py
@@ -1,4 +1,17 @@
-from .env_pool import EnvPool
+from .env_pool import (
+    AsyncEnvPool,
+    AsyncEnvEvent,
+    AsyncEnvEventKind,
+    AsyncEnvMask,
+    EnvPool,
+)
 from .world import World
 
-__all__ = ['World', 'EnvPool']
+__all__ = [
+    'World',
+    'EnvPool',
+    'AsyncEnvPool',
+    'AsyncEnvEvent',
+    'AsyncEnvEventKind',
+    'AsyncEnvMask',
+]

--- a/stable_worldmodel/world/env_pool.py
+++ b/stable_worldmodel/world/env_pool.py
@@ -35,7 +35,7 @@ from gymnasium.vector.utils import batch_space
 
 
 AsyncEnvEventKind = Literal['step', 'reset']
-AsyncEnvMask = np.NDArray[np.bool_]
+AsyncEnvMask = np.typing.NDArray[np.bool_]
 
 
 class EnvPool:

--- a/stable_worldmodel/world/env_pool.py
+++ b/stable_worldmodel/world/env_pool.py
@@ -37,6 +37,7 @@ from gymnasium.vector.utils import batch_space
 AsyncEnvEventKind = Literal['step', 'reset']
 AsyncEnvMask = np.NDArray[np.bool_]
 
+
 class EnvPool:
     """Batched env runner with selective stepping.
 

--- a/stable_worldmodel/world/env_pool.py
+++ b/stable_worldmodel/world/env_pool.py
@@ -1,7 +1,7 @@
-"""EnvPool: vectorized env wrapper with selective stepping.
+"""Environment pools for synchronous and asynchronous stepping.
 
-A lightweight replacement for ``gymnasium.vector.SyncVectorEnv`` with two
-differences tailored to ``World``:
+``EnvPool`` is a lightweight replacement for
+``gymnasium.vector.SyncVectorEnv`` with two differences tailored to ``World``:
 
 1. ``reset(mask=...)`` and ``step(mask=...)`` can skip individual envs —
    useful for the ``wait`` reset mode where terminated envs freeze until
@@ -10,17 +10,32 @@ differences tailored to ``World``:
    in-place afterwards. Tensor/array values are shaped ``(num_envs, 1, ...)``
    so consumers can rely on a ``(batch, time, ...)`` convention without the
    pool re-stacking every step.
+
+``AsyncEnvPool`` keeps the same spaces, environments, and stacked-info layout,
+but runs one operation per environment on a thread pool. Callers submit work
+for selected environment indices and consume whichever results finish first;
+there is no all-environment step barrier.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
+    ThreadPoolExecutor,
+    wait,
+)
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium.vector.utils import batch_space
 
+
+AsyncEnvEventKind = Literal['step', 'reset']
+AsyncEnvMask = np.NDArray[np.bool_]
 
 class EnvPool:
     """Batched env runner with selective stepping.
@@ -147,6 +162,238 @@ class EnvPool:
             env.close()
 
 
+@dataclass(frozen=True)
+class AsyncEnvEvent:
+    """Result of one asynchronous operation on one environment.
+
+    ``info`` is the unbatched dictionary returned by the environment. The
+    pool also writes it into its shared stacked-info buffers before returning
+    the event.
+    """
+
+    env_idx: int
+    kind: AsyncEnvEventKind
+    info: dict
+    reward: float = 0.0
+    terminated: bool = False
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class _PendingOperation:
+    env_idx: int
+    kind: AsyncEnvEventKind
+    seed: int | None = None
+
+
+class AsyncEnvPool(EnvPool):
+    """Event-driven environment pool with no per-step batch barrier.
+
+    Environments remain in the main process so existing policies can inspect
+    ``pool.envs[i]``. Each environment has at most one operation in flight,
+    while operations for different environments run concurrently.
+
+    The regular :meth:`reset` and :meth:`step` methods remain available as
+    blocking compatibility operations. Asynchronous callers use
+    :meth:`submit_step`, :meth:`submit_reset`, and :meth:`wait_ready`.
+    """
+
+    def __init__(self, env_fns: list):
+        super().__init__(env_fns)
+        self._executor = ThreadPoolExecutor(
+            max_workers=self.num_envs,
+            thread_name_prefix='swm-env',
+        )
+        self._pending: dict[Future, _PendingOperation] = {}
+        self._busy = np.zeros(self.num_envs, dtype=bool)
+        self._closed = False
+
+    @property
+    def has_pending(self) -> bool:
+        """Whether any environment operation is currently in flight."""
+        return bool(self._pending)
+
+    @property
+    def pending_indices(self) -> np.ndarray:
+        """Indices with an operation currently in flight."""
+        return np.flatnonzero(self._busy)
+
+    def reset(
+        self,
+        seed: int | list[int | None] | None = None,
+        options: dict | list[dict | None] | None = None,
+        mask: np.ndarray | None = None,
+    ) -> tuple[None, dict]:
+        self._ensure_idle()
+        return super().reset(seed=seed, options=options, mask=mask)
+
+    def step(
+        self, actions: np.ndarray, mask: np.ndarray | None = None
+    ) -> tuple[None, np.ndarray, np.ndarray, np.ndarray, dict]:
+        self._ensure_idle()
+        return super().step(actions, mask=mask)
+
+    def submit_step(self, env_indices, actions: np.ndarray) -> None:
+        """Submit one action for every selected environment.
+
+        Args:
+            env_indices: Integer indices, or a boolean mask of length
+                ``num_envs``.
+            actions: Actions aligned with ``env_indices``. Its leading
+                dimension must equal the number of selected environments.
+        """
+        indices = _normalize_indices(env_indices, self.num_envs)
+        self._ensure_available(indices)
+        actions = np.asarray(actions)
+        if actions.ndim == 0:
+            actions = actions.reshape(1)
+        if len(actions) != len(indices):
+            raise ValueError(
+                'actions must have one leading entry per environment index; '
+                f'got {len(actions)} actions for {len(indices)} indices'
+            )
+
+        for row, env_idx in enumerate(indices):
+            action = np.array(actions[row], copy=True)
+            self._submit(
+                int(env_idx),
+                'step',
+                _step_env,
+                self.envs[env_idx],
+                action,
+            )
+
+    def submit_reset(
+        self,
+        env_indices,
+        seed: int | list[int | None] | np.ndarray | None = None,
+        options: dict | list[dict | None] | None = None,
+    ) -> None:
+        """Submit independent resets for selected environments."""
+        indices = _normalize_indices(env_indices, self.num_envs)
+        self._ensure_available(indices)
+        seeds = _select_args(seed, indices, self.num_envs, increment=True)
+        opts = _select_args(options, indices, self.num_envs)
+
+        for env_idx, env_seed, env_options in zip(indices, seeds, opts):
+            self._submit(
+                int(env_idx),
+                'reset',
+                _reset_env,
+                self.envs[env_idx],
+                env_seed,
+                env_options,
+                seed=env_seed,
+            )
+
+    def wait_ready(self, timeout: float | None = None) -> list[AsyncEnvEvent]:
+        """Return all operations ready when the first one completes.
+
+        This is the key asynchronous primitive: it waits for *any* pending
+        environment, then opportunistically drains the others that have
+        already completed without waiting for the slowest environment.
+        """
+        if not self._pending:
+            raise RuntimeError(
+                'No asynchronous environment operations pending.'
+            )
+
+        done, _ = wait(
+            tuple(self._pending),
+            timeout=timeout,
+            return_when=FIRST_COMPLETED,
+        )
+        if not done:
+            return []
+
+        done.update(future for future in self._pending if future.done())
+        completed = sorted(
+            ((self._pending[future], future) for future in done),
+            key=lambda item: item[0].env_idx,
+        )
+
+        events = []
+        for operation, future in completed:
+            self._pending.pop(future)
+            self._busy[operation.env_idx] = False
+            try:
+                event = future.result()
+            except Exception as exc:
+                raise RuntimeError(
+                    f'Environment {operation.env_idx} failed during '
+                    f'{operation.kind}.'
+                ) from exc
+
+            if self._stacked_infos is None:
+                raise RuntimeError(
+                    'AsyncEnvPool must be reset once before asynchronous work.'
+                )
+            _write_env_info(self._stacked_infos, event.env_idx, event.info)
+            if operation.kind == 'reset' and operation.seed is not None:
+                self.seeds[event.env_idx] = operation.seed
+            events.append(event)
+
+        return events
+
+    def close(self):
+        """Finish pending work, stop worker threads, and close every env."""
+        if self._closed:
+            return
+        self._closed = True
+        self._executor.shutdown(wait=True, cancel_futures=True)
+        self._pending.clear()
+        self._busy[:] = False
+        super().close()
+
+    def _submit(self, env_idx, kind, fn, *args, seed=None) -> None:
+        if self._closed:
+            raise RuntimeError('AsyncEnvPool is closed.')
+        if self._busy[env_idx]:
+            raise RuntimeError(
+                f'Environment {env_idx} already has an operation in flight.'
+            )
+
+        self._busy[env_idx] = True
+        try:
+            future = self._executor.submit(fn, env_idx, *args)
+        except Exception:
+            self._busy[env_idx] = False
+            raise
+        self._pending[future] = _PendingOperation(env_idx, kind, seed)
+
+    def _ensure_idle(self) -> None:
+        if self._pending:
+            raise RuntimeError(
+                'Cannot run a blocking pool operation while asynchronous '
+                'operations are pending.'
+            )
+
+    def _ensure_available(self, indices: np.ndarray) -> None:
+        busy = indices[self._busy[indices]]
+        if len(busy):
+            raise RuntimeError(
+                f'Environments {busy.tolist()} already have operations '
+                'in flight.'
+            )
+
+
+def _step_env(env_idx: int, env, action) -> AsyncEnvEvent:
+    _, reward, terminated, truncated, info = env.step(action)
+    return AsyncEnvEvent(
+        env_idx=env_idx,
+        kind='step',
+        info=info,
+        reward=float(reward),
+        terminated=bool(terminated),
+        truncated=bool(truncated),
+    )
+
+
+def _reset_env(env_idx: int, env, seed, options) -> AsyncEnvEvent:
+    _, info = env.reset(seed=seed, options=options)
+    return AsyncEnvEvent(env_idx=env_idx, kind='reset', info=info)
+
+
 def _broadcast_arg(arg, n: int, increment: bool = False) -> list:
     if arg is None:
         return [None] * n
@@ -154,9 +401,42 @@ def _broadcast_arg(arg, n: int, increment: bool = False) -> list:
         return arg
     if isinstance(arg, np.ndarray):
         return list(arg)
-    if increment and isinstance(arg, int):
+    if increment and isinstance(arg, (int, np.integer)):
         return [arg + i for i in range(n)]
     return [arg] * n
+
+
+def _normalize_indices(env_indices, n: int) -> np.ndarray:
+    indices = np.asarray(env_indices)
+    if indices.dtype == bool:
+        if indices.shape != (n,):
+            raise ValueError(f'boolean env mask must have shape ({n},)')
+        indices = np.flatnonzero(indices)
+    else:
+        indices = np.atleast_1d(indices).astype(np.int64)
+
+    if ((indices < 0) | (indices >= n)).any():
+        raise IndexError(f'environment indices must be between 0 and {n - 1}')
+    if len(np.unique(indices)) != len(indices):
+        raise ValueError('environment indices must be unique')
+    return indices
+
+
+def _select_args(arg, indices: np.ndarray, n: int, increment: bool = False):
+    if arg is None:
+        return [None] * len(indices)
+    if increment and isinstance(arg, int):
+        return [arg + int(i) for i in indices]
+    if isinstance(arg, (list, np.ndarray)):
+        values = list(arg)
+        if len(values) == n:
+            return [values[i] for i in indices]
+        if len(values) == len(indices):
+            return values
+        raise ValueError(
+            f'per-environment argument must have length {n} or {len(indices)}'
+        )
+    return [arg] * len(indices)
 
 
 def _stack_fresh(per_env_infos: list[dict]) -> dict[str, Any]:

--- a/stable_worldmodel/world/env_pool.py
+++ b/stable_worldmodel/world/env_pool.py
@@ -95,6 +95,22 @@ class EnvPool:
         """Variation space for a single env (alias of ``variation_space``)."""
         return self.variation_space
 
+    def _call_env(self, env_idx: int, fn, *args, **kwargs):
+        """Run one env's operation and return its result.
+
+        Every env access goes through this hook so subclasses can control
+        which thread touches which env. The base pool calls straight
+        through.
+
+        Args:
+            env_idx: Index of the env ``fn`` belongs to.
+            fn: Bound env method to invoke.
+            *args: Positional arguments for ``fn``.
+            **kwargs: Keyword arguments for ``fn``.
+        """
+        del env_idx
+        return fn(*args, **kwargs)
+
     def reset(
         self,
         seed: int | list[int | None] | None = None,
@@ -118,7 +134,9 @@ class EnvPool:
         for i, env in enumerate(self.envs):
             if mask is not None and not mask[i]:
                 continue
-            _, per_env_infos[i] = env.reset(seed=seeds[i], options=opts[i])
+            _, per_env_infos[i] = self._call_env(
+                i, env.reset, seed=seeds[i], options=opts[i]
+            )
             if seeds[i] is not None:
                 self.seeds[i] = seeds[i]
 
@@ -150,8 +168,8 @@ class EnvPool:
         for i, env in enumerate(self.envs):
             if mask is not None and not mask[i]:
                 continue
-            _, rewards[i], terminateds[i], truncateds[i], info = env.step(
-                actions[i]
+            _, rewards[i], terminateds[i], truncateds[i], info = (
+                self._call_env(i, env.step, actions[i])
             )
             _write_env_info(self._stacked_infos, i, info)
 
@@ -197,14 +215,22 @@ class AsyncEnvPool(EnvPool):
     The regular :meth:`reset` and :meth:`step` methods remain available as
     blocking compatibility operations. Asynchronous callers use
     :meth:`submit_step`, :meth:`submit_reset`, and :meth:`wait_ready`.
+
+    Each environment is owned by one worker thread, and both the blocking
+    and asynchronous entry points dispatch to it, so environments holding
+    thread-affine resources such as GPU rendering contexts are safe to use.
     """
 
     def __init__(self, env_fns: list):
         super().__init__(env_fns)
-        self._executor = ThreadPoolExecutor(
-            max_workers=self.num_envs,
-            thread_name_prefix='swm-env',
-        )
+        # One worker per env: an env must always be touched from one thread.
+        self._executors = [
+            ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix=f'swm-env{i}',
+            )
+            for i in range(self.num_envs)
+        ]
         self._pending: dict[Future, _PendingOperation] = {}
         self._busy = np.zeros(self.num_envs, dtype=bool)
         self._closed = False
@@ -233,6 +259,16 @@ class AsyncEnvPool(EnvPool):
     ) -> tuple[None, np.ndarray, np.ndarray, np.ndarray, dict]:
         self._ensure_idle()
         return super().step(actions, mask=mask)
+
+    def _call_env(self, env_idx: int, fn, *args, **kwargs):
+        """Run a blocking operation on the env's own worker thread.
+
+        Without this the blocking :meth:`reset` and :meth:`step` would run
+        on the caller's thread, which for a rendering env binds its context
+        there and breaks every later asynchronous operation.
+        """
+        future = self._executors[env_idx].submit(fn, *args, **kwargs)
+        return future.result()
 
     def submit_step(self, env_indices, actions: np.ndarray) -> None:
         """Submit one action for every selected environment.
@@ -341,7 +377,8 @@ class AsyncEnvPool(EnvPool):
         if self._closed:
             return
         self._closed = True
-        self._executor.shutdown(wait=True, cancel_futures=True)
+        for executor in self._executors:
+            executor.shutdown(wait=True, cancel_futures=True)
         self._pending.clear()
         self._busy[:] = False
         super().close()
@@ -356,7 +393,7 @@ class AsyncEnvPool(EnvPool):
 
         self._busy[env_idx] = True
         try:
-            future = self._executor.submit(fn, env_idx, *args)
+            future = self._executors[env_idx].submit(fn, env_idx, *args)
         except Exception:
             self._busy[env_idx] = False
             raise

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -2,8 +2,8 @@
 
 ``World`` bundles three things:
 
-1. A batched simulator (``EnvPool``) that steps N envs in parallel and
-   can skip terminated envs via a mask.
+1. A batched simulator (``EnvPool``) that can run in synchronous lockstep or
+   asynchronously continue whichever environments finish first.
 2. A preprocessing pipeline (``MegaWrapper``) that resizes pixels,
    lifts everything into the info dict, and applies optional transforms.
 3. A rollout loop that drives ``policy.get_action(infos)`` and handles
@@ -48,12 +48,13 @@ import torch
 
 from stable_worldmodel.policy import Policy
 
-from .env_pool import EnvPool
+from .env_pool import AsyncEnvPool, EnvMask, EnvPool
 from ..plot import save_panel_videos, save_video
 from ..wrapper import MegaWrapper
 
 
 RESET_MODES = ('auto', 'wait')
+STEP_MODES = ('sync', 'async')
 
 
 def _make_env(
@@ -70,16 +71,19 @@ def _make_env(
 class World:
     """Drive a policy through a pool of preprocessed envs.
 
-    After construction, ``world.envs`` is an ``EnvPool`` of ``num_envs``
-    environments, each wrapped by ``MegaWrapper`` (and any ``pre_wrappers`` /
-    ``extra_wrappers`` you pass). Attach a policy with ``set_policy(...)`` and then call
-    ``collect()`` or ``evaluate()`` to run rollouts.
+    After construction, ``world.envs`` is a pool of ``num_envs`` environments,
+    each wrapped by ``MegaWrapper`` (and any ``pre_wrappers`` /
+    ``extra_wrappers`` you pass). Attach a policy with ``set_policy(...)`` and
+    then call ``collect()`` or ``evaluate()`` to run rollouts.
 
     Attributes populated during a run:
         infos: Stacked info dict from the last reset/step. Tensor/array
             values have shape ``(num_envs, 1, ...)``.
         rewards, terminateds, truncateds: Per-env step outputs from the
             last ``step()``. Shape ``(num_envs,)``.
+        ready: Boolean mask identifying environments updated by the latest
+            rollout event. It is all active environments in synchronous mode
+            and whichever environments just completed in asynchronous mode.
 
     Args:
         env_name: Gymnasium id registered for the target env
@@ -108,6 +112,8 @@ class World:
             ``pixels`` observation; goal images are resized too. Set False
             for envs without pixels (e.g. audio): ``image_shape`` may then
             be omitted and the raw observation is lifted into info as-is.
+        step_mode: ``'sync'`` for fixed lockstep batches or ``'async'`` to
+            continue environments as soon as each one finishes.
         **kwargs: Forwarded to ``gym.make`` (e.g. ``render_mode``).
     """
 
@@ -124,8 +130,13 @@ class World:
         goal_transform: Callable | None = None,
         image_resample: str | int | None = None,
         add_pixels: bool = True,
+        step_mode: str = 'sync',
         **kwargs: Any,
     ):
+        if step_mode not in STEP_MODES:
+            raise ValueError(
+                f'step_mode must be one of {STEP_MODES}, got {step_mode!r}'
+            )
         if add_pixels and image_shape is None:
             raise ValueError('image_shape is required when add_pixels=True.')
         wrappers = [
@@ -149,12 +160,15 @@ class World:
             add_pixels=add_pixels,
             **kwargs,
         )
-        self.envs = EnvPool([env_fn] * num_envs)
+        pool_cls = AsyncEnvPool if step_mode == 'async' else EnvPool
+        self.envs = pool_cls([env_fn] * num_envs)
+        self.step_mode = step_mode
         self.policy: Policy | None = None
         self.infos: dict = {}
         self.rewards: np.ndarray | None = None
         self.terminateds: np.ndarray | None = None
         self.truncateds: np.ndarray | None = None
+        self.ready = np.zeros(num_envs, dtype=bool)
 
     @property
     def num_envs(self) -> int:
@@ -169,12 +183,12 @@ class World:
         """Attach a policy and configure it for this world's envs.
 
         Calls ``policy.set_env(self.envs)``. If the policy exposes a
-        ``seed`` attribute and ``_set_seed`` method, the seed is applied.
+        ``seed`` attribute and ``set_seed`` method, the seed is applied.
         """
         self.policy = policy
         self.policy.set_env(self.envs)
-        if hasattr(self.policy, '_set_seed') and self.policy.seed is not None:
-            self.policy._set_seed(self.policy.seed)
+        if hasattr(self.policy, 'seed') and self.policy.seed is not None:
+            self.policy.set_seed(self.policy.seed)
 
     def reset(self, seed=None, options=None) -> None:
         """Reset every env and refresh ``self.infos``.
@@ -182,8 +196,12 @@ class World:
         Clears ``terminateds``/``truncateds`` back to all-False.
         """
         _, self.infos = self.envs.reset(seed=seed, options=options)
+        self.rewards = np.zeros(self.num_envs, dtype=np.float32)
         self.terminateds = np.zeros(self.num_envs, dtype=bool)
         self.truncateds = np.zeros(self.num_envs, dtype=bool)
+        if not hasattr(self, 'ready'):
+            self.ready = np.zeros(self.num_envs, dtype=bool)
+        self.ready[:] = False
 
     def evaluate(
         self,
@@ -308,6 +326,7 @@ class World:
         buffers = [defaultdict(list) for _ in range(self.num_envs)]
 
         def on_step(world):
+            ready_indices = np.flatnonzero(world.ready)
             for col, data in world.infos.items():
                 if col.startswith('_'):
                     continue
@@ -318,7 +337,7 @@ class World:
                         data = data.squeeze(1)
                     else:
                         data = np.squeeze(data, axis=1)
-                for i in range(world.num_envs):
+                for i in ready_indices:
                     val = data[i]
                     if isinstance(val, torch.Tensor):
                         val = val.detach().cpu().numpy()
@@ -334,7 +353,9 @@ class World:
         ):
 
             def episode_iter():
-                for env_idx, _ in self._run_iter(
+                pending_episodes = {}
+                next_episode = 0
+                for env_idx, ep_idx in self._run_iter(
                     episodes=episodes,
                     seed=seed,
                     options=options,
@@ -345,8 +366,12 @@ class World:
                     buffers[env_idx].clear()
                     if 'action' in ep:
                         ep['action'].append(ep['action'].pop(0))
-                    pbar.update(1)
-                    yield ep
+                    pending_episodes[ep_idx] = ep
+
+                    while next_episode in pending_episodes:
+                        pbar.update(1)
+                        yield pending_episodes.pop(next_episode)
+                        next_episode += 1
 
             w.write_episodes(episode_iter())
 
@@ -382,6 +407,40 @@ class World:
         mode: str = 'auto',
         on_step=None,
     ):
+        """Drive the configured pool and yield completed episodes.
+
+        Synchronous worlds retain the original fixed-batch rollout. Async
+        worlds use a first-completed event loop.
+        """
+        if getattr(self, 'step_mode', 'sync') == 'async':
+            yield from self._run_iter_async(
+                episodes=episodes,
+                max_steps=max_steps,
+                seed=seed,
+                options=options,
+                mode=mode,
+                on_step=on_step,
+            )
+            return
+
+        yield from self._run_iter_sync(
+            episodes=episodes,
+            max_steps=max_steps,
+            seed=seed,
+            options=options,
+            mode=mode,
+            on_step=on_step,
+        )
+
+    def _run_iter_sync(
+        self,
+        episodes: int | None = None,
+        max_steps: int | None = None,
+        seed: int | None = None,
+        options: dict | None = None,
+        mode: str = 'auto',
+        on_step=None,
+    ):
         """Drive the policy and yield ``(env_idx, ep_count)`` on each
         episode completion. Letting callers consume completions as a
         generator is what makes streaming writes possible without threading.
@@ -408,6 +467,9 @@ class World:
                 self.envs.step(actions, mask=mask)
             )
 
+            if not hasattr(self, 'ready'):
+                self.ready = np.zeros(self.num_envs, dtype=bool)
+            self.ready[:] = True if mask is None else mask
             if on_step:
                 on_step(self)
 
@@ -445,8 +507,138 @@ class World:
             if budget_reached or (mode == 'wait' and not alive.any()):
                 return
 
-    def _get_actions(self) -> np.ndarray:
-        return self.policy.get_action(self.infos)
+    def _run_iter_async(
+        self,
+        episodes: int | None = None,
+        max_steps: int | None = None,
+        seed: int | None = None,
+        options: dict | None = None,
+        mode: str = 'auto',
+        on_step=None,
+    ):
+        """Drive environments from a first-completed event loop."""
+        assert mode in RESET_MODES, f'mode must be one of {RESET_MODES}, received {mode=}'
+
+        if self.policy is None:
+            raise RuntimeError('No policy set.')
+        if episodes is None and max_steps is None:
+            raise ValueError('Provide episodes or max_steps (or both).')
+        if episodes is not None and episodes <= 0:
+            return
+        if not isinstance(self.envs, AsyncEnvPool):
+            raise RuntimeError('Async rollout requires an AsyncEnvPool.')
+
+        if seed is not None or options is not None or not self.infos:
+            self.reset(seed=seed, options=options)
+
+        active_count = (
+            self.num_envs
+            if episodes is None
+            else min(self.num_envs, episodes)
+        )
+        active = np.zeros(self.num_envs, dtype=bool)
+        active[:active_count] = True
+        step_counts = np.zeros(self.num_envs, dtype=np.int64)
+        episode_ids = np.full(self.num_envs, -1, dtype=np.int64)
+        episode_ids[:active_count] = np.arange(active_count)
+        launched = active_count
+
+        actions = self._get_actions(active)
+        self.envs.submit_step(active, actions)
+
+        while self.envs.has_pending:
+            events = self.envs.wait_ready()
+            step_events = [event for event in events if event.kind == 'step']
+            reset_events = [event for event in events if event.kind == 'reset']
+
+            self.ready[:] = False
+            self.rewards[:] = 0.0
+            self.terminateds[:] = False
+            self.truncateds[:] = False
+
+            for event in step_events:
+                i = event.env_idx
+                self.ready[i] = True
+                self.rewards[i] = event.reward
+                self.terminateds[i] = event.terminated
+                self.truncateds[i] = event.truncated
+                step_counts[i] += 1
+
+            if step_events and on_step:
+                on_step(self)
+
+            next_step = [event.env_idx for event in reset_events]
+            reset_indices = list(next_step)
+            completions = []
+
+            for event in step_events:
+                i = event.env_idx
+                env_done = event.terminated or event.truncated
+                budget_done = (
+                    max_steps is not None and step_counts[i] >= max_steps
+                )
+
+                if env_done:
+                    completions.append((i, int(episode_ids[i])))
+
+                    should_reset = (
+                        mode == 'auto'
+                        and not budget_done
+                        and (episodes is None or launched < episodes)
+                    )
+                    if should_reset:
+                        reset_seed = (
+                            seed + launched if seed is not None else None
+                        )
+                        episode_ids[i] = launched
+                        launched += 1
+                        reset_mask = np.zeros(self.num_envs, dtype=bool)
+                        reset_mask[i] = True
+                        self.envs.submit_reset(
+                            reset_mask, seed=[reset_seed], options=options
+                        )
+                    else:
+                        active[i] = False
+                elif budget_done:
+                    active[i] = False
+                else:
+                    next_step.append(i)
+
+            if reset_indices:
+                flush = np.zeros(self.num_envs, dtype=bool)
+                flush[reset_indices] = True
+                self.infos['_needs_flush'] = flush
+                self.terminateds[reset_indices] = False
+                self.truncateds[reset_indices] = False
+
+            if next_step:
+                next_step_mask = np.zeros(self.num_envs, dtype=bool)
+                next_step_mask[next_step] = True
+                actions = self._get_actions(next_step_mask)
+                self.infos.pop('_needs_flush', None)
+                self.envs.submit_step(next_step_mask, actions)
+
+            for env_idx, episode_idx in completions:
+                yield env_idx, episode_idx
+
+    def _get_actions(
+        self, env_mask: EnvMask | None = None
+    ) -> np.ndarray:
+        if env_mask is None:
+            return self.policy.get_action(self.infos)
+
+        indices = np.flatnonzero(env_mask)
+        info_batch = _select_ready(self.infos, indices, self.num_envs)
+        actions = self.policy.get_action(
+            info_batch,
+            env_mask=env_mask,
+        )
+        return _select_actions(
+            actions,
+            indices,
+            self.num_envs,
+            self.envs.single_action_space.shape,
+        )
 
     def _evaluate(self, episodes, seed, options, video, mode) -> dict:
         results = {
@@ -458,7 +650,7 @@ class World:
 
         def on_step(world):
             if frames is not None:
-                for i in range(world.num_envs):
+                for i in np.flatnonzero(world.ready):
                     f = world.infos['pixels'][i]
                     frame = f[-1] if f.ndim > 3 else f
                     frames[i].append(np.asarray(frame).copy())
@@ -540,9 +732,10 @@ class World:
 
         def on_step(world):
             world.infos.update(deepcopy(goal_snapshot))
-            results['episode_successes'] |= world.terminateds
+            ready = np.flatnonzero(world.ready)
+            results['episode_successes'][ready] |= world.terminateds[ready]
             if frames is not None:
-                for i in range(world.num_envs):
+                for i in ready:
                     f = world.infos['pixels'][i]
                     frame = f[-1] if f.ndim > 3 else f
                     frames[i].append(np.asarray(frame).copy())
@@ -562,6 +755,47 @@ class World:
                 },
             )
         return results
+
+
+def _select_ready(infos: dict, indices: np.ndarray, num_envs: int) -> dict:
+    """Select ready environment rows while preserving non-batched values."""
+    selected = {}
+    for key, value in infos.items():
+        if isinstance(value, (np.ndarray, torch.Tensor)):
+            if value.ndim > 0 and value.shape[0] == num_envs:
+                selected[key] = value[indices]
+            else:
+                selected[key] = value
+        elif isinstance(value, list) and len(value) == num_envs:
+            selected[key] = [value[i] for i in indices]
+        else:
+            selected[key] = value
+    return selected
+
+
+def _select_actions(
+    actions,
+    indices: np.ndarray,
+    num_envs: int,
+    single_action_shape: tuple[int, ...],
+) -> np.ndarray:
+    """Normalize policy output to actions for only the ready environments."""
+    actions = np.asarray(actions)
+    if len(indices) == 1 and actions.shape == single_action_shape:
+        actions = actions[None, ...]
+    elif actions.ndim == 0 and len(indices) == 1:
+        actions = actions.reshape(1)
+
+    if actions.ndim == 0:
+        raise ValueError('Policy returned a scalar for multiple environments.')
+    if actions.shape[0] == num_envs and len(indices) != num_envs:
+        actions = actions[indices]
+    if actions.shape[0] != len(indices):
+        raise ValueError(
+            'Policy must return one action per ready environment; '
+            f'got shape {actions.shape} for {len(indices)} ready environments.'
+        )
+    return actions
 
 
 def _extract_init_goal(dataset, episodes_idx, start_steps, goal_offset):

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -48,7 +48,7 @@ import torch
 
 from stable_worldmodel.policy import Policy
 
-from .env_pool import AsyncEnvPool, EnvMask, EnvPool
+from .env_pool import AsyncEnvPool, AsyncEnvMask, EnvPool
 from ..plot import save_panel_videos, save_video
 from ..wrapper import MegaWrapper
 
@@ -622,7 +622,7 @@ class World:
                 yield env_idx, episode_idx
 
     def _get_actions(
-        self, env_mask: EnvMask | None = None
+        self, env_mask: AsyncEnvMask | None = None
     ) -> np.ndarray:
         if env_mask is None:
             return self.policy.get_action(self.infos)

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -183,12 +183,12 @@ class World:
         """Attach a policy and configure it for this world's envs.
 
         Calls ``policy.set_env(self.envs)``. If the policy exposes a
-        ``seed`` attribute and ``set_seed`` method, the seed is applied.
+        ``seed`` attribute and ``_set_seed`` method, the seed is applied.
         """
         self.policy = policy
         self.policy.set_env(self.envs)
-        if hasattr(self.policy, 'seed') and self.policy.seed is not None:
-            self.policy.set_seed(self.policy.seed)
+        if hasattr(self.policy, '_set_seed') and self.policy.seed is not None:
+            self.policy._set_seed(self.policy.seed)
 
     def reset(self, seed=None, options=None) -> None:
         """Reset every env and refresh ``self.infos``.
@@ -504,6 +504,7 @@ class World:
                 self.terminateds[done] = False
                 self.truncateds[done] = False
                 self.infos['_needs_flush'] = done
+                self._notify_policy_reset(done)
             elif mode == 'wait':
                 alive[done] = False
 
@@ -610,6 +611,7 @@ class World:
             if reset_indices:
                 flush = np.zeros(self.num_envs, dtype=bool)
                 flush[reset_indices] = True
+                self._notify_policy_reset(flush)
                 self.infos['_needs_flush'] = flush
                 self.terminateds[reset_indices] = False
                 self.truncateds[reset_indices] = False
@@ -755,7 +757,7 @@ class World:
                 },
             )
         return results
-    
+
     def _notify_policy_reset(
         self, env_mask: AsyncEnvMask | None = None
     ) -> None:

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -202,6 +202,7 @@ class World:
         if not hasattr(self, 'ready'):
             self.ready = np.zeros(self.num_envs, dtype=bool)
         self.ready[:] = False
+        self._notify_policy_reset()
 
     def evaluate(
         self,
@@ -754,6 +755,16 @@ class World:
                 },
             )
         return results
+    
+    def _notify_policy_reset(
+        self, env_mask: AsyncEnvMask | None = None
+    ) -> None:
+        if self.policy is None:
+            return
+
+        on_reset = getattr(self.policy, 'on_reset', None)
+        if on_reset is not None:
+            on_reset(env_mask)
 
 
 def _slice_ready(infos: dict, indices: np.ndarray, num_envs: int) -> dict:

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -546,7 +546,8 @@ class World:
         if not isinstance(self.envs, AsyncEnvPool):
             raise RuntimeError('Async rollout requires an AsyncEnvPool.')
 
-        if seed is not None or options is not None or not self.infos:
+        did_reset = seed is not None or options is not None or not self.infos
+        if did_reset:
             self.reset(seed=seed, options=options)
 
         active_count = (
@@ -558,6 +559,12 @@ class World:
         episode_ids = np.full(self.num_envs, -1, dtype=np.int64)
         episode_ids[:active_count] = np.arange(active_count)
         launched = active_count
+
+        # Mirror the sync loop (see #294): surface the initial reset frame to
+        # on_step so collect() records it instead of starting one step late.
+        if did_reset and on_step:
+            self.ready[:] = active
+            on_step(self)
 
         actions = self._get_actions(active)
         self.envs.submit_step(active, actions)
@@ -627,6 +634,10 @@ class World:
                 self.infos['_needs_flush'] = flush
                 self.terminateds[reset_indices] = False
                 self.truncateds[reset_indices] = False
+                # Record the per-env reset frame, matching the sync loop (#294).
+                if on_step:
+                    self.ready[:] = flush
+                    on_step(self)
 
             if next_step:
                 next_step_mask = np.zeros(self.num_envs, dtype=bool)

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -630,7 +630,12 @@ class World:
             return self.policy.get_action(self.infos)
 
         indices = np.flatnonzero(env_mask)
-        ready_info = _slice_ready(self.infos, indices, self.num_envs)
+        ready_info = _slice_policy_info(
+            self.policy,
+            self.infos,
+            indices,
+            self.num_envs,
+        )
         actions = self.policy.get_action(
             ready_info,
             env_mask=env_mask,
@@ -769,20 +774,73 @@ class World:
             on_reset(env_mask)
 
 
+def _contiguous_slice(indices: np.ndarray) -> slice | None:
+    """Return an equivalent ``slice`` when ``indices`` is an ascending run.
+
+    ``indices`` is always sorted and unique (from ``np.flatnonzero``), so a
+    unit-stride run can be expressed as a slice. Slicing returns a *view* of
+    the shared info buffers instead of the copy that advanced indexing forces,
+    which is the common case in async rollouts (a single completed env, or a
+    full batch finishing together).
+    """
+    n = len(indices)
+    if n == 0:
+        return slice(0, 0)
+    start = int(indices[0])
+    stop = int(indices[-1]) + 1
+    if stop - start == n:
+        return slice(start, stop)
+    return None
+
+
 def _slice_ready(infos: dict, indices: np.ndarray, num_envs: int) -> dict:
-    """Select ready environment rows while preserving non-batched values."""
+    """Select ready environment rows while preserving non-batched values.
+
+    Values are only read by policies (``_get_actions`` returns before the pool
+    overwrites the buffers), so a zero-copy view is safe for the contiguous
+    fast path; scattered index sets fall back to a copy.
+    """
+    row_selector = _contiguous_slice(indices)
+    if row_selector is None:
+        row_selector = indices
+
     selected = {}
     for key, value in infos.items():
         if isinstance(value, (np.ndarray, torch.Tensor)):
             if value.ndim > 0 and value.shape[0] == num_envs:
-                selected[key] = value[indices]
+                selected[key] = value[row_selector]
             else:
                 selected[key] = value
         elif isinstance(value, list) and len(value) == num_envs:
-            selected[key] = [value[i] for i in indices]
+            if isinstance(row_selector, slice):
+                selected[key] = value[row_selector]
+            else:
+                selected[key] = [value[i] for i in indices]
         else:
             selected[key] = value
     return selected
+
+
+def _slice_policy_info(
+    policy,
+    infos: dict,
+    indices: np.ndarray,
+    num_envs: int,
+) -> dict:
+    """Select only the ready info keys a policy declares it needs."""
+    info_keys = getattr(policy, 'info_keys', None)
+    if info_keys is None:
+        return _slice_ready(infos, indices, num_envs)
+
+    info_keys = tuple(info_keys)
+    if not info_keys:
+        return {}
+
+    return _slice_ready(
+        {key: infos[key] for key in info_keys if key in infos},
+        indices,
+        num_envs,
+    )
 
 
 def _select_actions(

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -445,7 +445,7 @@ class World:
         episode completion. Letting callers consume completions as a
         generator is what makes streaming writes possible without threading.
         """
-        assert mode in RESET_MODES, f'reset_mode must be one of {RESET_MODES}'
+        assert mode in RESET_MODES, f'mode must be one of {RESET_MODES}, received {mode=}'
 
         if self.policy is None:
             raise RuntimeError('No policy set.')
@@ -628,9 +628,9 @@ class World:
             return self.policy.get_action(self.infos)
 
         indices = np.flatnonzero(env_mask)
-        info_batch = _select_ready(self.infos, indices, self.num_envs)
+        ready_info = _slice_ready(self.infos, indices, self.num_envs)
         actions = self.policy.get_action(
-            info_batch,
+            ready_info,
             env_mask=env_mask,
         )
         return _select_actions(
@@ -757,7 +757,7 @@ class World:
         return results
 
 
-def _select_ready(infos: dict, indices: np.ndarray, num_envs: int) -> dict:
+def _slice_ready(infos: dict, indices: np.ndarray, num_envs: int) -> dict:
     """Select ready environment rows while preserving non-batched values."""
     selected = {}
     for key, value in infos.items():

--- a/stable_worldmodel/world/world.py
+++ b/stable_worldmodel/world/world.py
@@ -445,7 +445,9 @@ class World:
         episode completion. Letting callers consume completions as a
         generator is what makes streaming writes possible without threading.
         """
-        assert mode in RESET_MODES, f'mode must be one of {RESET_MODES}, received {mode=}'
+        assert mode in RESET_MODES, (
+            f'mode must be one of {RESET_MODES}, received {mode=}'
+        )
 
         if self.policy is None:
             raise RuntimeError('No policy set.')
@@ -517,7 +519,9 @@ class World:
         on_step=None,
     ):
         """Drive environments from a first-completed event loop."""
-        assert mode in RESET_MODES, f'mode must be one of {RESET_MODES}, received {mode=}'
+        assert mode in RESET_MODES, (
+            f'mode must be one of {RESET_MODES}, received {mode=}'
+        )
 
         if self.policy is None:
             raise RuntimeError('No policy set.')
@@ -532,9 +536,7 @@ class World:
             self.reset(seed=seed, options=options)
 
         active_count = (
-            self.num_envs
-            if episodes is None
-            else min(self.num_envs, episodes)
+            self.num_envs if episodes is None else min(self.num_envs, episodes)
         )
         active = np.zeros(self.num_envs, dtype=bool)
         active[:active_count] = True
@@ -618,12 +620,9 @@ class World:
                 self.infos.pop('_needs_flush', None)
                 self.envs.submit_step(next_step_mask, actions)
 
-            for env_idx, episode_idx in completions:
-                yield env_idx, episode_idx
+            yield from completions
 
-    def _get_actions(
-        self, env_mask: AsyncEnvMask | None = None
-    ) -> np.ndarray:
+    def _get_actions(self, env_mask: AsyncEnvMask | None = None) -> np.ndarray:
         if env_mask is None:
             return self.policy.get_action(self.infos)
 

--- a/tests/envs/test_ogbench_policy.py
+++ b/tests/envs/test_ogbench_policy.py
@@ -1,0 +1,135 @@
+"""Tests for OGBench environment expert policy."""
+
+from unittest.mock import MagicMock
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+from stable_worldmodel.world.world import _slice_policy_info
+
+
+pytest.importorskip('ogbench')
+
+from stable_worldmodel.envs.ogbench import ExpertPolicy  # noqa: E402
+
+
+NUM_ENVS = 4
+ACTION_DIM = 5
+MASK = np.array([False, True, False, True])
+
+
+################################
+## ExpertPolicy Tests         ##
+################################
+
+
+class MockCubeEnv:
+    """Only what the policy reads off an env: action space and cube count."""
+
+    def __init__(self):
+        self.action_space = gym.spaces.Box(
+            low=-1, high=1, shape=(ACTION_DIM,), dtype=np.float32
+        )
+        self._env_type = 'single'  # read by _get_cube_stack_prob
+
+    @property
+    def unwrapped(self):
+        return self
+
+
+class MarkerOracle:
+    """Oracle whose action identifies the environment it was asked for."""
+
+    def __init__(self, env_idx):
+        self.env_idx = env_idx
+        self.done = False
+
+    def reset(self, *args, **kwargs):
+        pass
+
+    def select_action(self, *args, **kwargs):
+        # Inside [-1, 1]: the policy clips, which would erase larger tags.
+        return np.full(ACTION_DIM, self.env_idx / 10.0, dtype=np.float32)
+
+
+@pytest.fixture
+def masked_policy():
+    """ExpertPolicy over mock envs, with every oracle replaced by a marker."""
+    envs = [MockCubeEnv() for _ in range(NUM_ENVS)]
+
+    vec_env = MagicMock()
+    vec_env.spec = None
+    vec_env.envs = envs
+    vec_env.num_envs = NUM_ENVS
+    vec_env.action_space = gym.spaces.Box(
+        low=-1, high=1, shape=(NUM_ENVS, ACTION_DIM), dtype=np.float32
+    )
+
+    policy = ExpertPolicy(
+        policy_type='markov_oracle',
+        action_noise=0.0,
+        p_random_action=0.0,
+        seed=0,
+    )
+    # set_env is skipped: it builds real oracles against a live MuJoCo model.
+    policy.env = vec_env
+    policy._p_stack = np.zeros(NUM_ENVS)
+    policy._xi = np.zeros(NUM_ENVS)
+    policy._agents = [None] * NUM_ENVS
+    policy._oracle_agents = {
+        'cube': [MarkerOracle(i) for i in range(NUM_ENVS)]
+    }
+    return policy
+
+
+def _info(num_rows):
+    """Minimal info dict; `step_idx == 0` makes the policy adopt the oracles."""
+    return {
+        'step_idx': np.zeros((num_rows, 1), dtype=np.int64),
+        'privileged/target_task': np.array([['cube']] * num_rows),
+    }
+
+
+def test_expert_policy_get_action_with_env_mask_returns_selected_rows(
+    masked_policy,
+):
+    """Each returned row must come from its own environment."""
+    indices = np.flatnonzero(MASK)
+    ready = _slice_policy_info(
+        masked_policy, _info(NUM_ENVS), indices, NUM_ENVS
+    )
+
+    actions = masked_policy.get_action(ready, env_mask=MASK)
+
+    assert actions.shape == (len(indices), ACTION_DIM)
+    for row, env_idx in enumerate(indices):
+        np.testing.assert_allclose(actions[row], env_idx / 10.0, atol=1e-6)
+
+
+def test_expert_policy_get_action_without_mask_acts_for_every_env(
+    masked_policy,
+):
+    """`env_mask=None` keeps the original full-width behaviour."""
+    actions = masked_policy.get_action(_info(NUM_ENVS))
+
+    assert actions.shape == (NUM_ENVS, ACTION_DIM)
+    for env_idx in range(NUM_ENVS):
+        np.testing.assert_allclose(actions[env_idx], env_idx / 10.0, atol=1e-6)
+
+
+def test_expert_policy_keeps_per_env_state_on_a_masked_call(masked_policy):
+    """Per-env buffers stay keyed by absolute index, not by row."""
+    indices = np.flatnonzero(MASK)
+    ready = _slice_policy_info(
+        masked_policy, _info(NUM_ENVS), indices, NUM_ENVS
+    )
+
+    masked_policy.get_action(ready, env_mask=MASK)
+
+    assert len(masked_policy._agents) == NUM_ENVS
+    for env_idx in indices:
+        assert masked_policy._agents[env_idx].env_idx == env_idx
+    # Envs outside the mask were left untouched.
+    for env_idx in set(range(NUM_ENVS)) - set(indices.tolist()):
+        assert masked_policy._agents[env_idx] is None

--- a/tests/envs/test_piecewise_policy.py
+++ b/tests/envs/test_piecewise_policy.py
@@ -1,0 +1,57 @@
+"""Tests for Piecewise environment expert policy."""
+
+import gymnasium as gym
+import numpy as np
+
+from stable_worldmodel.envs.piecewise.expert_policy import ExpertPolicy
+from stable_worldmodel.world.env_pool import EnvPool
+from stable_worldmodel.world.world import _slice_policy_info
+
+
+NUM_ENVS = 4
+MASK = np.array([False, True, False, True])
+
+
+################################
+## ExpertPolicy Tests         ##
+################################
+
+
+def _pool():
+    return EnvPool(
+        [lambda: gym.make('swm/Piecewise-v0') for _ in range(NUM_ENVS)]
+    )
+
+
+def test_expert_policy_get_action_with_env_mask_returns_selected_rows():
+    """An env's action must not depend on which other envs were ready."""
+    pool = _pool()
+    # Noise off, so a difference means indexing rather than RNG draw count.
+    policy = ExpertPolicy(action_noise=0.0, action_repeat_prob=0.0, seed=0)
+    policy.set_env(pool)
+    _, infos = pool.reset(seed=0)
+    indices = np.flatnonzero(MASK)
+
+    full = np.asarray(policy.get_action(infos))
+    ready = _slice_policy_info(policy, infos, indices, NUM_ENVS)
+    narrowed = np.asarray(policy.get_action(ready, env_mask=MASK))
+
+    assert narrowed.shape[0] == len(indices)
+    for row, env_idx in enumerate(indices):
+        np.testing.assert_allclose(
+            narrowed[row], full[env_idx], rtol=1e-6, atol=1e-6
+        )
+    pool.close()
+
+
+def test_expert_policy_without_mask_keeps_full_width():
+    """`env_mask=None` must still act for every env, at pool width."""
+    pool = _pool()
+    policy = ExpertPolicy(action_noise=0.0, action_repeat_prob=0.0, seed=0)
+    policy.set_env(pool)
+    _, infos = pool.reset(seed=0)
+
+    actions = np.asarray(policy.get_action(infos))
+
+    assert actions.shape == pool.action_space.shape
+    pool.close()

--- a/tests/envs/test_pusht_policy.py
+++ b/tests/envs/test_pusht_policy.py
@@ -1,8 +1,10 @@
 """Tests for PushT environment expert policy."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import gymnasium as gym
+import numpy as np
 import pytest
 
 from stable_worldmodel.envs.pusht.expert_policy import WeakPolicy
@@ -49,6 +51,7 @@ def test_weak_policy_init_default():
     policy = WeakPolicy()
     assert policy.dist_constraint == 100
     assert policy.discrete is False
+    assert policy.info_keys == ()
 
 
 def test_weak_policy_init_custom_constraint():
@@ -176,3 +179,45 @@ def test_weak_policy_set_env_sub_env_no_spec():
     policy = WeakPolicy()
     with pytest.raises(AssertionError):
         policy.set_env(mock_env)
+
+
+def test_weak_policy_get_action_with_env_mask_returns_selected_rows():
+    class MockPushTEnv:
+        def __init__(self, agent_pos, block_pos):
+            self.spec = SimpleNamespace(id='swm/PushT-v0')
+            self.action_space = gym.spaces.Box(
+                low=-1, high=1, shape=(2,), dtype=np.float32
+            )
+            self.action_scale = 10.0
+            self.agent = SimpleNamespace(
+                position=np.asarray(agent_pos, dtype=np.float32)
+            )
+            self.block = SimpleNamespace(
+                position=SimpleNamespace(x=block_pos[0], y=block_pos[1])
+            )
+
+        @property
+        def unwrapped(self):
+            return self
+
+    envs = [
+        MockPushTEnv((0.0, 0.0), (1.0, 1.0)),
+        MockPushTEnv((2.0, 2.0), (3.0, 3.0)),
+        MockPushTEnv((4.0, 4.0), (5.0, 5.0)),
+    ]
+    vec_env = MagicMock()
+    vec_env.spec = None
+    vec_env.envs = envs
+    vec_env.action_space = gym.spaces.Box(
+        low=-1, high=1, shape=(3, 2), dtype=np.float32
+    )
+
+    policy = WeakPolicy(seed=0)
+    policy.set_env(vec_env)
+
+    actions = policy.get_action({}, env_mask=np.array([False, True, True]))
+
+    assert actions.shape == (2, 2)
+    assert actions.dtype == np.float32
+    assert np.all(actions >= -1)
+    assert np.all(actions <= 1)

--- a/tests/envs/test_pusht_policy.py
+++ b/tests/envs/test_pusht_policy.py
@@ -221,3 +221,55 @@ def test_weak_policy_get_action_with_env_mask_returns_selected_rows():
     assert actions.dtype == np.float32
     assert np.all(actions >= -1)
     assert np.all(actions <= 1)
+
+
+def test_weak_policy_with_env_mask_maps_rows_to_their_own_envs():
+    """Each returned row must be computed from its own env."""
+
+    class MockPushTEnv:
+        def __init__(self, block_pos):
+            self.spec = SimpleNamespace(id='swm/PushT-v0')
+            self.action_space = gym.spaces.Box(
+                low=-1, high=1, shape=(2,), dtype=np.float32
+            )
+            self.action_scale = 10.0
+            self.agent = SimpleNamespace(
+                position=np.zeros(2, dtype=np.float32)
+            )
+            self.block = SimpleNamespace(
+                position=SimpleNamespace(x=block_pos[0], y=block_pos[1])
+            )
+
+        @property
+        def unwrapped(self):
+            return self
+
+    # Distinct blocks, so a row taken from the wrong env is visible.
+    envs = [
+        MockPushTEnv((1.0, 1.0)),
+        MockPushTEnv((2.0, 2.0)),
+        MockPushTEnv((3.0, 3.0)),
+    ]
+    vec_env = MagicMock()
+    vec_env.spec = None
+    vec_env.envs = envs
+    vec_env.action_space = gym.spaces.Box(
+        low=-1, high=1, shape=(3, 2), dtype=np.float32
+    )
+
+    policy = WeakPolicy(dist_constraint=1e-9, seed=0)
+    policy.set_env(vec_env)
+
+    mask = np.array([False, True, True])
+    actions = policy.get_action({}, env_mask=mask)
+
+    assert actions.shape == (2, 2)
+    for row, env_idx in enumerate(np.flatnonzero(mask)):
+        env = envs[env_idx]
+        expected = (
+            np.array(
+                [env.block.position.x, env.block.position.y], dtype=np.float32
+            )
+            / env.action_scale
+        )
+        np.testing.assert_allclose(actions[row], expected, atol=1e-5)

--- a/tests/envs/test_rocket_landing_policy.py
+++ b/tests/envs/test_rocket_landing_policy.py
@@ -1,0 +1,34 @@
+"""Tests for rocket landing environment expert policy."""
+
+import numpy as np
+import pytest
+
+
+# Skips where cvxpy/pybullet/PyFlyt are absent; none are declared in pyproject.
+expert_policy = pytest.importorskip(
+    'stable_worldmodel.envs.rocket_landing.expert_policy'
+)
+
+
+NUM_ENVS = 4
+MASK = np.array([False, True, False, True])
+OBS_DIM = 13
+
+
+################################
+## ExpertPolicy Tests         ##
+################################
+
+
+def test_expert_policy_keeps_every_controller_on_a_masked_call():
+    """A masked call must not resize the per-env controller list."""
+    policy = expert_policy.ExpertPolicy()
+    policy._ensure_controller_count(NUM_ENVS)
+    controllers = list(policy.controllers)
+
+    obs = np.zeros((NUM_ENVS, OBS_DIM), dtype=np.float32)
+    obs[:, 6] = 1.0  # unit quaternion
+    policy.get_action({'state': obs[np.flatnonzero(MASK)]}, env_mask=MASK)
+
+    assert len(policy.controllers) == NUM_ENVS
+    assert policy.controllers == controllers

--- a/tests/envs/test_two_room_policy.py
+++ b/tests/envs/test_two_room_policy.py
@@ -1,0 +1,44 @@
+"""Tests for TwoRoom environment expert policy."""
+
+import gymnasium as gym
+import numpy as np
+
+from stable_worldmodel.envs.two_room.expert_policy import ExpertPolicy
+from stable_worldmodel.world.env_pool import EnvPool
+from stable_worldmodel.world.world import _slice_policy_info
+
+
+NUM_ENVS = 4
+MASK = np.array([False, True, False, True])
+
+
+################################
+## ExpertPolicy Tests         ##
+################################
+
+
+def _pool():
+    return EnvPool(
+        [lambda: gym.make('swm/TwoRoom-v1') for _ in range(NUM_ENVS)]
+    )
+
+
+def test_expert_policy_get_action_with_env_mask_returns_selected_rows():
+    """An env's action must not depend on which other envs were ready."""
+    pool = _pool()
+    # Noise off, so a difference means indexing rather than RNG draw count.
+    policy = ExpertPolicy(action_noise=0.0, action_repeat_prob=0.0, seed=0)
+    policy.set_env(pool)
+    _, infos = pool.reset(seed=0)
+    indices = np.flatnonzero(MASK)
+
+    full = np.asarray(policy.get_action(infos))
+    ready = _slice_policy_info(policy, infos, indices, NUM_ENVS)
+    narrowed = np.asarray(policy.get_action(ready, env_mask=MASK))
+
+    assert narrowed.shape[0] == len(indices)
+    for row, env_idx in enumerate(indices):
+        np.testing.assert_allclose(
+            narrowed[row], full[env_idx], rtol=1e-6, atol=1e-6
+        )
+    pool.close()

--- a/tests/test_env_pool.py
+++ b/tests/test_env_pool.py
@@ -1,11 +1,14 @@
 """Tests for EnvPool — self-contained, no real envs needed."""
 
+import threading
+
 import gymnasium as gym
 import numpy as np
 import pytest
 import torch
 
 from stable_worldmodel.world.env_pool import (
+    AsyncEnvPool,
     EnvPool,
     _broadcast_arg,
     _stack_fresh,
@@ -56,6 +59,26 @@ class CounterEnv(gym.Env):
 
 def _make_pool(n: int = 3, max_steps: int = 5) -> EnvPool:
     return EnvPool([lambda ms=max_steps: CounterEnv(ms) for _ in range(n)])
+
+
+class ThreadRecordingEnv(CounterEnv):
+    """Counter env that records which thread ran each of its operations.
+
+    Stands in for an env holding a thread-affine resource such as a GPU
+    rendering context, without needing a GPU.
+    """
+
+    def __init__(self, max_steps: int = 100):
+        super().__init__(max_steps)
+        self.thread_ids: set[int] = set()
+
+    def reset(self, *, seed=None, options=None):
+        self.thread_ids.add(threading.get_ident())
+        return super().reset(seed=seed, options=options)
+
+    def step(self, action):
+        self.thread_ids.add(threading.get_ident())
+        return super().step(action)
 
 
 # -- EnvPool properties ---------------------------------------------------
@@ -638,4 +661,71 @@ def test_interleaved_termination_and_reset():
     assert rewards[1] == 0.0  # not stepped
     assert infos['state'][0] == 1.0
     assert infos['state'][1] == 2.0  # stale from before
+    pool.close()
+
+
+# -- Thread affinity ------------------------------------------------------
+
+
+def _make_thread_pool(n: int = 4) -> AsyncEnvPool:
+    return AsyncEnvPool([ThreadRecordingEnv for _ in range(n)])
+
+
+def _drain(pool: AsyncEnvPool) -> None:
+    while pool.has_pending:
+        pool.wait_ready()
+
+
+def test_async_env_stays_on_one_thread():
+    """Each env must be touched by exactly one thread, ever."""
+    pool = _make_thread_pool(4)
+    actions = np.zeros((4, 2))
+
+    pool.reset(seed=0)
+    for _ in range(5):
+        pool.submit_step(np.arange(4), actions)
+        _drain(pool)
+    pool.step(actions)
+
+    for env_idx, env in enumerate(pool.envs):
+        assert len(env.thread_ids) == 1, (
+            f'env {env_idx} was touched by {len(env.thread_ids)} threads: '
+            f'{sorted(env.thread_ids)}'
+        )
+    pool.close()
+
+
+def test_async_envs_run_on_distinct_threads():
+    """Affinity must not collapse the pool onto a single worker."""
+    pool = _make_thread_pool(4)
+
+    pool.reset(seed=0)
+    pool.submit_step(np.arange(4), np.zeros((4, 2)))
+    _drain(pool)
+
+    threads = {next(iter(env.thread_ids)) for env in pool.envs}
+    assert len(threads) == 4
+    pool.close()
+
+
+def test_async_env_thread_is_not_the_caller():
+    """Blocking operations dispatch to the worker, not the calling thread."""
+    pool = _make_thread_pool(2)
+
+    pool.reset(seed=0)
+
+    for env in pool.envs:
+        assert threading.get_ident() not in env.thread_ids
+    pool.close()
+
+
+def test_sync_pool_runs_on_the_calling_thread():
+    """The dispatch hook must leave the synchronous pool's behaviour alone."""
+    pool = EnvPool([ThreadRecordingEnv for _ in range(2)])
+
+    pool.reset(seed=0)
+    pool.step(np.zeros((2, 2)))
+
+    for env in pool.envs:
+        assert env.thread_ids == {threading.get_ident()}
     pool.close()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -346,7 +346,7 @@ class MockSolver:
 
     @property
     def action_dim(self) -> int:
-        return self._action_space.shape[0] * self._config.action_block
+        return self._action_space.shape[-1] * self._config.action_block
 
     @property
     def n_envs(self) -> int:
@@ -357,7 +357,7 @@ class MockSolver:
         return self._config.horizon
 
     def solve(self, info_dict, init_action=None):
-        action_dim = self._action_space.shape[0]
+        action_dim = self._action_space.shape[-1]
         batch = (
             len(next(iter(info_dict.values()))) if info_dict else self._n_envs
         )
@@ -571,6 +571,107 @@ def test_worldmodel_policy_selective_replan():
     assert len(policy._action_buffer[1]) == 1
     # env 1's warm-start slot should be untouched; env 0's slot was overwritten
     assert torch.equal(policy._next_init[1], next_init_before[1])
+
+
+def test_worldmodel_policy_async_only_consumes_ready_slots():
+    """A ready-only call must leave busy environments' plans untouched."""
+    solver = MockSolver()
+    config = PlanConfig(horizon=4, receding_horizon=2)
+    policy = WorldModelPolicy(solver=solver, config=config)
+
+    mock_env = MagicMock()
+    mock_env.num_envs = 3
+    mock_env.action_space = gym_spaces.Box(low=-1, high=1, shape=(3, 2))
+    mock_env.single_action_space = gym_spaces.Box(low=-1, high=1, shape=(2,))
+    policy.set_env(mock_env)
+
+    for env_i, buffer in enumerate(policy._action_buffer):
+        buffer.extend(
+            [
+                torch.full((2,), float(env_i * 10 + 1)),
+                torch.full((2,), float(env_i * 10 + 2)),
+            ]
+        )
+
+    info = {
+        'pixels': np.zeros((1, 1, 4, 4, 3), dtype=np.float32),
+        'goal': np.zeros((1, 1, 4, 4, 3), dtype=np.float32),
+    }
+    action = policy.get_action(
+        info, env_mask=np.array([False, True, False])
+    )
+
+    np.testing.assert_array_equal(action, np.full((1, 2), 11.0))
+    assert [len(buffer) for buffer in policy._action_buffer] == [2, 1, 2]
+    assert solver.call_count == 0
+
+
+def test_worldmodel_policy_async_replans_ready_empty_slots():
+    """Only empty buffers among ready environments enter the solver batch."""
+    solver = MockSolver()
+    config = PlanConfig(horizon=4, receding_horizon=2)
+    policy = WorldModelPolicy(solver=solver, config=config)
+
+    mock_env = MagicMock()
+    mock_env.num_envs = 3
+    mock_env.action_space = gym_spaces.Box(low=-1, high=1, shape=(3, 2))
+    mock_env.single_action_space = gym_spaces.Box(low=-1, high=1, shape=(2,))
+    policy.set_env(mock_env)
+    policy._action_buffer[0].append(torch.full((2,), 10.0))
+    policy._action_buffer[1].append(torch.full((2,), 20.0))
+
+    info = {
+        'pixels': np.zeros((2, 1, 4, 4, 3), dtype=np.float32),
+        'goal': np.zeros((2, 1, 4, 4, 3), dtype=np.float32),
+    }
+    action = policy.get_action(
+        info, env_mask=np.array([False, True, True])
+    )
+
+    assert solver.call_count == 1
+    assert solver.last_batch_size == 1
+    np.testing.assert_array_equal(action[0], np.full(2, 20.0))
+    np.testing.assert_array_equal(action[1], np.zeros(2))
+    assert [len(buffer) for buffer in policy._action_buffer] == [1, 0, 1]
+
+
+def test_worldmodel_policy_on_reset_only_clears_selected_slots():
+    """Per-environment reset preserves unrelated plans and warm starts."""
+    solver = MockSolver()
+    config = PlanConfig(horizon=4, receding_horizon=2)
+    policy = WorldModelPolicy(solver=solver, config=config)
+
+    mock_env = MagicMock()
+    mock_env.num_envs = 3
+    mock_env.action_space = gym_spaces.Box(low=-1, high=1, shape=(3, 2))
+    mock_env.single_action_space = gym_spaces.Box(low=-1, high=1, shape=(2,))
+    policy.set_env(mock_env)
+    for buffer in policy._action_buffer:
+        buffer.append(torch.ones(2))
+    policy._next_init = torch.ones(3, 2, 2)
+
+    policy.on_reset(np.array([False, True, False]))
+
+    assert [len(buffer) for buffer in policy._action_buffer] == [1, 0, 1]
+    assert policy._next_init[0].eq(1).all()
+    assert policy._next_init[1].eq(0).all()
+    assert policy._next_init[2].eq(1).all()
+
+
+def test_worldmodel_policy_rejects_non_boolean_env_mask():
+    """The scheduling contract accepts one full-pool boolean mask only."""
+    solver = MockSolver()
+    policy = WorldModelPolicy(
+        solver=solver, config=PlanConfig(horizon=4, receding_horizon=2)
+    )
+    mock_env = MagicMock()
+    mock_env.num_envs = 3
+    mock_env.action_space = gym_spaces.Box(low=-1, high=1, shape=(3, 2))
+    mock_env.single_action_space = gym_spaces.Box(low=-1, high=1, shape=(2,))
+    policy.set_env(mock_env)
+
+    with pytest.raises(ValueError, match='env_mask must be boolean'):
+        policy.get_action({}, env_mask=np.array([0, 1, 0]))
 
 
 def test_worldmodel_policy_no_warm_start():

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -597,9 +597,7 @@ def test_worldmodel_policy_async_only_consumes_ready_slots():
         'pixels': np.zeros((1, 1, 4, 4, 3), dtype=np.float32),
         'goal': np.zeros((1, 1, 4, 4, 3), dtype=np.float32),
     }
-    action = policy.get_action(
-        info, env_mask=np.array([False, True, False])
-    )
+    action = policy.get_action(info, env_mask=np.array([False, True, False]))
 
     np.testing.assert_array_equal(action, np.full((1, 2), 11.0))
     assert [len(buffer) for buffer in policy._action_buffer] == [2, 1, 2]
@@ -624,9 +622,7 @@ def test_worldmodel_policy_async_replans_ready_empty_slots():
         'pixels': np.zeros((2, 1, 4, 4, 3), dtype=np.float32),
         'goal': np.zeros((2, 1, 4, 4, 3), dtype=np.float32),
     }
-    action = policy.get_action(
-        info, env_mask=np.array([False, True, True])
-    )
+    action = policy.get_action(info, env_mask=np.array([False, True, True]))
 
     assert solver.call_count == 1
     assert solver.last_batch_size == 1

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -95,6 +95,19 @@ class RecordingPolicy:
         return actions
 
 
+class ResetAwarePolicy(RecordingPolicy):
+    """Recording policy that also implements the reset-hook contract."""
+
+    def __init__(self):
+        super().__init__()
+        self.reset_masks = []
+
+    def on_reset(self, env_mask=None):
+        self.reset_masks.append(
+            None if env_mask is None else np.array(env_mask, copy=True)
+        )
+
+
 def _make_world(num_envs=2, max_steps=3):
     """Build a World with CounterEnv directly, bypassing gym.make."""
     pool = EnvPool(
@@ -466,6 +479,32 @@ class TestSetPolicy:
         assert world.truncateds is not None
         assert len(world.infos) > 0
         np.testing.assert_array_equal(world.terminateds, [False, False])
+
+    def test_reset_notifies_policy_that_all_envs_reset(self):
+        world = _make_world(num_envs=2)
+        policy = ResetAwarePolicy()
+        world.policy = policy
+        policy.set_env(world.envs)
+
+        world.reset(seed=42)
+
+        assert policy.reset_masks == [None]
+
+    def test_auto_reset_notifies_policy_with_done_env_mask(self):
+        world = _make_world(num_envs=2, max_steps=100)
+        world.envs.envs[0]._max_steps = 2
+        policy = ResetAwarePolicy()
+        world.policy = policy
+        policy.set_env(world.envs)
+
+        world._run(episodes=2, seed=0, mode='auto')
+
+        selective_masks = [
+            mask for mask in policy.reset_masks if mask is not None
+        ]
+        assert selective_masks
+        for mask in selective_masks:
+            np.testing.assert_array_equal(mask, [True, False])
 
     def test_reset_per_env_options_passed_through(self):
         seen = {'opts': None}

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -122,7 +122,9 @@ class InfoKeysPolicy(RecordingPolicy):
         self.last_env_mask = (
             None if env_mask is None else np.array(env_mask, copy=True)
         )
-        return np.zeros((self.env.num_envs, *self.env.single_action_space.shape))
+        return np.zeros(
+            (self.env.num_envs, *self.env.single_action_space.shape)
+        )
 
 
 class AsyncReadyPolicy:

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -463,7 +463,7 @@ class TestSetPolicy:
                 self.seed = 1234
                 self.seed_calls = []
 
-            def _set_seed(self, seed):
+            def set_seed(self, seed):
                 self.seed_calls.append(seed)
 
         world = _make_world(num_envs=2)

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -463,7 +463,7 @@ class TestSetPolicy:
                 self.seed = 1234
                 self.seed_calls = []
 
-            def set_seed(self, seed):
+            def _set_seed(self, seed):
                 self.seed_calls.append(seed)
 
         world = _make_world(num_envs=2)

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -108,6 +108,23 @@ class ResetAwarePolicy(RecordingPolicy):
         )
 
 
+class InfoKeysPolicy(RecordingPolicy):
+    """Recording policy that declares async info-key requirements."""
+
+    def __init__(self, info_keys):
+        super().__init__()
+        self.info_keys = info_keys
+        self.last_env_mask = None
+
+    def get_action(self, info_dict, *, env_mask=None, **kwargs):
+        self.call_count += 1
+        self.last_infos = {k: v for k, v in info_dict.items()}
+        self.last_env_mask = (
+            None if env_mask is None else np.array(env_mask, copy=True)
+        )
+        return np.zeros((self.env.num_envs, *self.env.single_action_space.shape))
+
+
 def _make_world(num_envs=2, max_steps=3):
     """Build a World with CounterEnv directly, bypassing gym.make."""
     pool = EnvPool(
@@ -527,6 +544,38 @@ class TestSetPolicy:
         world.reset(options=per_env)
         # The second env's reset is called last, so `seen` holds its options.
         assert seen['opts'] == {'variation': ['b']}
+
+
+class TestAsyncPolicyInfo:
+    def test_async_get_actions_skips_info_for_no_info_policy(self):
+        world = _make_world(num_envs=3)
+        world.reset(seed=0)
+        policy = InfoKeysPolicy(info_keys=())
+        world.set_policy(policy)
+
+        mask = np.array([False, True, True])
+        actions = world._get_actions(mask)
+
+        assert policy.last_infos == {}
+        np.testing.assert_array_equal(policy.last_env_mask, mask)
+        assert actions.shape == (2, 2)
+
+    def test_async_get_actions_slices_only_declared_info_keys(self):
+        world = _make_world(num_envs=3)
+        world.reset(seed=0)
+        world.infos['state'] = np.array([[[1.0]], [[2.0]], [[3.0]]])
+        world.infos['unused'] = np.array([[[10.0]], [[20.0]], [[30.0]]])
+        policy = InfoKeysPolicy(info_keys=('state',))
+        world.set_policy(policy)
+
+        mask = np.array([False, True, True])
+        actions = world._get_actions(mask)
+
+        assert list(policy.last_infos) == ['state']
+        np.testing.assert_array_equal(
+            policy.last_infos['state'], np.array([[[2.0]], [[3.0]]])
+        )
+        assert actions.shape == (2, 2)
 
 
 class TestWorldMisc:

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -6,7 +6,7 @@ import gymnasium as gym
 import numpy as np
 import pytest
 
-from stable_worldmodel.world.env_pool import EnvPool
+from stable_worldmodel.world.env_pool import AsyncEnvPool, EnvPool
 from stable_worldmodel.world.world import World
 
 
@@ -125,6 +125,27 @@ class InfoKeysPolicy(RecordingPolicy):
         return np.zeros((self.env.num_envs, *self.env.single_action_space.shape))
 
 
+class AsyncReadyPolicy:
+    """Minimal async-aware policy: returns one zero action per ready env."""
+
+    def __init__(self):
+        self.env = None
+
+    def set_env(self, env):
+        self.env = env
+
+    def get_action(self, info_dict, *, env_mask=None, **kwargs):
+        info_dict.pop('_needs_flush', None)
+        count = (
+            self.env.num_envs
+            if env_mask is None
+            else int(np.count_nonzero(env_mask))
+        )
+        return np.zeros(
+            (count, *self.env.single_action_space.shape), dtype=np.float32
+        )
+
+
 def _make_world(num_envs=2, max_steps=3):
     """Build a World with CounterEnv directly, bypassing gym.make."""
     pool = EnvPool(
@@ -137,6 +158,23 @@ def _make_world(num_envs=2, max_steps=3):
     world.rewards = None
     world.terminateds = None
     world.truncateds = None
+    return world
+
+
+def _make_async_world(num_envs=1, max_steps=3):
+    """Build an async World (AsyncEnvPool + step_mode='async')."""
+    pool = AsyncEnvPool(
+        [lambda ms=max_steps: CounterEnv(ms) for _ in range(num_envs)]
+    )
+    world = object.__new__(World)
+    world.envs = pool
+    world.step_mode = 'async'
+    world.policy = None
+    world.infos = {}
+    world.rewards = None
+    world.terminateds = None
+    world.truncateds = None
+    world.ready = np.zeros(num_envs, dtype=bool)
     return world
 
 
@@ -225,6 +263,31 @@ class TestRunAutoMode:
         assert states[3] == 0.0  # reset happened, fresh env
         assert states[4] == 1.0
         assert states[5] == 2.0
+
+    def test_async_infos_updated_after_reset(self):
+        """Async parity with #294: on_step fires after the initial reset and
+        each per-env auto-reset, so the reset frame (state=0) is captured just
+        like the sync loop. num_envs=1 keeps the event order deterministic."""
+        world = _make_async_world(num_envs=1, max_steps=2)
+        policy = AsyncReadyPolicy()
+        world.policy = policy
+        policy.set_env(world.envs)
+
+        infos_after_reset = []
+
+        def on_step(w):
+            infos_after_reset.append(w.infos['state'][0].copy())
+
+        try:
+            world._run(episodes=2, seed=0, mode='auto', on_step=on_step)
+        finally:
+            world.envs.close()
+
+        # Same trace as the sync case:
+        # episode 1: reset (0), step 1, step 2 (terminates)
+        # episode 2: reset (0), step 1, step 2 (terminates)
+        states = [s[0] for s in infos_after_reset]
+        assert states == [0.0, 1.0, 2.0, 0.0, 1.0, 2.0]
 
 
 class TestRunWaitMode:


### PR DESCRIPTION
**Stacked on #290 — please merge that first.** This branches off `sami-bg:async-env`
(`ad0aed2`), so until #290 lands the diff here also shows its commits; once it merges into `main`
this collapses to the files below.

Two things stop async stepping from working on a real environment. Both surface the first time you
collect from `swm/OGBCube-v0` with `step_mode='async'`, and neither is reachable from CI today.

## 1. GPU rendering: `EGL_BAD_ACCESS`

```
OpenGL.raw.EGL._errors.EGLError: EGLError(
	err = EGL_BAD_ACCESS,
	baseOperation = eglMakeCurrent,
```

MuJoCo's `GLContext.__init__` creates a context but never binds it — the bind happens on the
**first render**, on whatever thread renders first, and is never released (`Renderer.render` calls
`make_current()` every frame). EGL refuses a context that is already current on another thread, so
an env is only safe if the same thread always touches it.

Two things break that:

1. **The shared executor.** `ThreadPoolExecutor(max_workers=num_envs)` posts env *i* to whichever
   worker is free, so an env migrates between threads across operations.
2. **The blocking entry points.** `reset()`/`step()` run on the *caller's* thread, and
   `_run_iter_async` calls `self.reset(...)` before the first `submit_step` — binding every context
   to the main thread. Per-env workers alone would still fail on the first async step.

**Fix:** one single-worker executor per env, and both entry points routed through a `_call_env`
hook. No concurrency is lost — the class already guarantees at most one operation in flight per env,
so the shared pool never gave an individual env more than one worker. `EnvPool` calls straight
through and is unchanged.

## 2. Policy narrowing: `IndexError`, and worse

```
File "stable_worldmodel/envs/ogbench/expert_policy.py", line 228, in get_action
    k: v[i][0]
IndexError: index 10 is out of bounds for axis 0 with size 10
```

`_slice_policy_info` narrows the info dict to the ready envs, so `get_action` receives one row per
*ready* env while `self.env.envs` and every per-env buffer stay full-width and absolute-indexed.
#290 updated `envs/pusht/expert_policy.py` for that contract; the others still walk every env by
absolute index. Before #290 that was correct, because nothing handed them compacted arrays.

**Without this change these envs are broken on the async path:**

| policy | under narrowing |
|---|---|
| `ogbench` | **raises** `IndexError` |
| `two_room` | **raises** `IndexError` |
| `piecewise` | **raises** `IndexError` |
| `rocket_landing` | **silently wrong** — no exception |
| `pusht` | fine (migrated by #290) |
| `dmcontrol` | fine — derives its batch from the info array, never indexes `self.env.envs` |

It fires two ways: with `episodes < num_envs` the rollout activates only
`min(num_envs, episodes)` envs, so the first `_get_actions` raises (`world.py:569`); otherwise
everything starts active and it survives until `next_step_mask` narrows as envs finish
(`world.py:645`).

`rocket_landing` is the one worth pausing on. It never raises: `_ensure_controller_count` sizes the
controller list by the *ready batch*, so a masked call **truncates** `self.controllers` and then
indexes them by compacted row — quietly flying each rocket with another's controller state and
corrupting collected data rather than failing.

**Fix:** a `_ready_envs` helper on `BasePolicy` that resolves the mask and sizes the action buffer,
plus two indices carried through each policy — `row` for the narrowed info and returned actions, `i`
for `envs` and per-env state. `pusht` is refactored onto the helper (no behaviour change) so it has
a second caller. `piecewise` additionally keeps `_last_action` as a full-width buffer, since it is
written back across calls.

Two things deliberately **not** changed: `dmcontrol` needs no fix, and `two_room`'s
`action_repeat_prob` is dead code (`_last_action` is read but never assigned, so the branch never
executes) — a pre-existing bug, unrelated to narrowing, left alone here.

## Tests

Both halves are tested without a GPU, which is the coverage gap that let this ship.

* **Thread affinity** — a stub env recording `threading.get_ident()`, driven through a mixed
  sequence (blocking reset → async steps → blocking step), asserting each env only ever saw one
  thread.
* **Narrowing** — one file per policy, following the existing `tests/envs/test_<env>_policy.py`
  layout. Each asserts that an env's action does not depend on which *other* envs were ready, with
  the narrowed input built by the real `_slice_policy_info` so the test cannot drift from the
  caller. `two_room` and `piecewise` compare real rollouts; `ogbench` uses mock envs and marker
  oracles, because two OGBCube `World`s built from the same seed produce different actions (a call
  retargets the env through `set_new_target`), which makes rollout comparison inherently unstable.
  `rocket_landing` asserts its controller list survives a masked call, since shape-equivalence
  alone would not catch a silent truncation.
* **`test_pusht_policy.py` already had a mask test**
  (`test_weak_policy_get_action_with_env_mask_returns_selected_rows`) covering shape, dtype and
  bounds. This PR adds a provenance assertion beside it — which env each returned row was computed
  from — and reuses its mock-env style for the new files.

Against the unfixed branch:

| test | stock `async-env` | this PR |
|---|---|---|
| 3 thread-affinity cases | fail | pass |
| narrowing: `ogbench`, `two_room`, `piecewise` | fail | pass |
| narrowing: `pusht` | pass | pass |
| narrowing: `rocket_landing` | fail (`assert 2 == 4`) | pass |
| sync-path guards | pass | pass |

`pusht` passing both ways is the point — it pins the helper refactor as behaviour-preserving.

Run 20x in a `linux/amd64` container matching this workflow (osmesa system deps,
`MUJOCO_GL=osmesa`): 0 failures. Worth stating because an earlier draft of the ogbench test was
flaky there — it compared two live rollouts — and that only showed up under the CI configuration,
never on a dev machine. `pre-commit run --all-files` clean; full suite green on 3.10 and 3.12.
And `rocket_landing`'s silent failure is visible in its red: without the fix a masked call leaves
`len(self.controllers) == 2` for a pool of 4, having discarded two envs' controller state without
raising.

One caveat on that last row: `rocket_landing` needs `cvxpy`, `pybullet` and `PyFlyt`, which are in
neither `pyproject.toml` nor any extra — so `uv sync --all-extras` does not install them and this
case **skips in CI**. I ran it in a `linux/amd64` container with those three added; the result above
is real, but the test stays dormant here until the deps are declared. Happy to declare them if you
want it running, though that is a call about pulling heavy dependencies into the project.

### Every changed policy, through a real rollout

The tests above stop at the policy boundary. Each policy was also driven through actual async
collection via `World`, which additionally exercises `_select_actions` scattering narrowed rows back
to pool width and repeated calls whose masks change as envs terminate. `num_envs=8`, and two runs
per env: **4 episodes** (`episodes < num_envs`, so the very first `_get_actions` is already masked)
and **16 episodes** (`episodes > num_envs`, so the mask narrows as envs finish). Same box, stock
`ad0aed2` then this PR:

| env | stock, 4 eps | stock, 16 eps | this PR, 4 eps | this PR, 16 eps |
|---|---|---|---|---|
| `swm/OGBCube-v0` | `IndexError` | `EGL_BAD_ACCESS` | 164 states | 656 states |
| `swm/TwoRoom-v1` | `IndexError` | `IndexError` | 136 states | 425 states |
| `swm/Piecewise-v0` | `IndexError` | `IndexError` | 79 states | 299 states |
| `swm/PushT-v1` | completes | completes | 164 states | 656 states |
| `swm/PFRocketLanding-v0` | completes | completes | 164 states | 656 states |

At `max_episode_steps=40` a full episode is 41 states (40 steps plus the reset frame), so 164 and
656 are the complete expected output. `TwoRoom` and `Piecewise` come in lower because those envs
terminate on reaching the goal, so their episodes are shorter and vary run to run — expected, not a
truncated collection.

The counts show each run wrote its full trajectory rather than exiting early with a partial file.
They do not show that env *i* received the action computed from env *i*'s observation; that is what
the unit tests assert, by comparing against the unmasked call and checking per-env state keying.

`PushT` completing on stock is expected — #290 migrated it — and it still completes here, which is
what makes the shared-helper refactor safe. `PFRocketLanding` completing on stock is the point about
its failure being silent: the run succeeds while controller state is quietly discarded, so only the
unit assertion catches it.

`dmcontrol` could not be included: its expert policy requires a trained checkpoint
(`ckpt_path`, `vec_normalize_path`). Its safety is a code-reading claim — it derives its batch from
the info array and never indexes `self.env.envs` — not a measured one.

Full suite: **1072 passed, 1 skipped, 1 xfailed**. `pre-commit` clean (ruff 0.12.8).

## On real hardware

Dedicated A10, `MUJOCO_GL=egl`, 20 rendering envs — stock and patched on the **same box, same
command** (24 episodes, `swm/OGBCube-v0`):

```
stock ad0aed2   err = EGL_BAD_ACCESS, baseOperation = eglMakeCurrent
                RuntimeError: Environment 19 failed during step.
                  env_pool.py:382 in _step_env -> renderer.py:162 in render     (exit 1)

this PR         24 episodes -> 4824 states in 38.2s (~126 states/s)             (exit 0)
```

The stock traceback lands on `renderer.py:162` — the `make_current()` call this PR is about.

End-to-end collection through `World` completes in both policy regimes with zero `EGL_BAD_ACCESS`
and zero `IndexError`: `episodes > num_envs` (24/20, the late `next_step_mask` path) and
`episodes < num_envs` (10/20, which raises immediately at `world.py:569`). Schema is valid — 34
columns, flat `proprio_*`/`privileged_*`, `ep_idx`, `pixels` (224, 224, 3).

Throughput, 40 episodes / 20 envs / seed 7031, 3 runs per cell, median (details in the comment
below):

| regime | sync | async | |
|---|---|---|---|
| lockstep (`ep_len` 201±0) | **145.4** states/s | 127.7 states/s | async 12% slower |
| staggered (`ep_len` 2–201) | 109.5 states/s | **140.9** states/s | async **29% faster** |

Async wins exactly where the barrier costs something. With `terminate_at_goal=False` every episode
is the same length, so there is nothing to stagger and the per-env dispatch shows up as ~12%
overhead — a worst case for the feature rather than a verdict on it.



