### PR TITLE
Slim the base install: drop loguru, move the Lance stack into a [data] extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,15 @@
 From PyPI:
 
 ```bash
-pip install stable-worldmodel            # base only
+pip install 'stable-worldmodel[data]'    # recommended: base + Lance dataset I/O
+pip install stable-worldmodel            # planning/model only, no dataset I/O
 pip install 'stable-worldmodel[all]'     # + training, environments, and data formats
 ```
+
+`[data]` pulls in the Lance stack (`lancedb`, `pylance`, `pyarrow`) that backs the
+default dataset format. It is a separate extra so that consumers who only need the
+solvers and world model — e.g. embedding `stable_worldmodel.planning` in a robotics
+image — are not forced to install ~410 MB of native wheels they never import.
 
 LeRobot dataset support is a separate opt-in extra (requires Python 3.12+): `pip install 'stable-worldmodel[lerobot]'`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,12 +12,12 @@ Stable World-Model is an open-source library to conduct world model research.  Y
 === "uv"
 
         :::bash
-        uv add stable-worldmodel
+        uv add 'stable-worldmodel[data]'
 
 === "pip"
 
         :::bash
-        pip install stable-worldmodel
+        pip install 'stable-worldmodel[data]'
 
 === "uv (all dependencies)"
 
@@ -32,6 +32,9 @@ Stable World-Model is an open-source library to conduct world model research.  Y
 
 !!! note ""
     ⚠️ The base installation does not include environment (`env`) or training (`train`) dependencies. Install them separately or use the "all dependencies" option above if you need to run simulations or train models.
+
+!!! note ""
+    The `data` extra shown above adds the Lance stack (`lancedb`, `pylance`, `pyarrow`) behind the default dataset format, and is what most users want. A bare `pip install stable-worldmodel` gives you the solvers, world models, and environments but no dataset reading or writing — useful when embedding `stable_worldmodel.planning` somewhere that cannot afford ~410 MB of native wheels.
 
 A **world model** is a learned simulator that predicts how an environment evolves in response to actions, enabling agents to plan by imagining future outcomes. Stable World-Model provides a unified research ecosystem that simplifies the entire pipeline: from data collection to model training and evaluation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
   "torch",
   "torchvision",
   "numpy",
-  "loguru",
   "tabulate",
   "gymnasium",
   "einops",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,6 @@ dependencies = [
   "tabulate",
   "gymnasium",
   "einops",
-  "lancedb>=0.30.0",
-  "pylance>=4.0.0",
-  "pyarrow",
   "pillow",
   "tqdm",
   "typer",
@@ -40,6 +37,15 @@ train = [
     "datasets>=2.20.0",
     "hydra-submitit-launcher",
     "wandb",
+]
+
+# Lance dataset storage — the default dataset format. Split out of the base
+# install so planning-only consumers (solvers + world model, no dataset IO)
+# are not forced to pull ~410 MB of native wheels.
+data = [
+    "lancedb>=0.30.0",
+    "pylance>=4.0.0",
+    "pyarrow",
 ]
 
 env = [
@@ -61,6 +67,8 @@ format = [
     "hdf5plugin",
     "torchcodec",
     "imageio[ffmpeg]",
+    # Blob-v2 video (lance_video) is layered on the core Lance stack.
+    "stable-worldmodel[data]",
 ]
 
 lerobot = [
@@ -68,7 +76,7 @@ lerobot = [
 ]
 
 all = [
-    "stable-worldmodel[train,env,format]",
+    "stable-worldmodel[train,env,format,data]",
 ]
 
 [dependency-groups]

--- a/scripts/data/collect_cube.py
+++ b/scripts/data/collect_cube.py
@@ -1,14 +1,16 @@
+import logging
 import os
 from pathlib import Path
 
 os.environ['MUJOCO_GL'] = 'glfw'
 import hydra
 import numpy as np
-from loguru import logger as logging
 from omegaconf import DictConfig, OmegaConf
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.ogbench import ExpertPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='ogb')
@@ -41,8 +43,12 @@ def run(cfg: DictConfig):
         options=options,
     )
 
-    logging.success('🎉🎉🎉 Completed data collection for ogbench cube 🎉🎉🎉')
+    logger.info('🎉🎉🎉 Completed data collection for ogbench cube 🎉🎉🎉')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_dmc.py
+++ b/scripts/data/collect_dmc.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -7,7 +8,6 @@ os.environ['MUJOCO_GL'] = 'glfw'
 
 import hydra
 import numpy as np
-from loguru import logger as logging
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.dmcontrol import ExpertPolicy
@@ -26,6 +26,8 @@ ENVS = {
     'swm/ReacherDMControl-v0': ('reacher',),
     'swm/PendulumDMControl-v0': ('pendulum',),
 }
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='dmc')
@@ -59,8 +61,12 @@ def run(cfg):
         options=options,
     )
 
-    logging.success(' 🎉🎉🎉 Completed data collection for dmc 🎉🎉🎉')
+    logger.info(' 🎉🎉🎉 Completed data collection for dmc 🎉🎉🎉')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_pusht_fov.py
+++ b/scripts/data/collect_pusht_fov.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
 import hydra
+import logging
 import numpy as np
-from loguru import logger as logging
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.pusht import WeakPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='default')
@@ -43,10 +45,14 @@ def run(cfg):
             options={'variation': tuple([var] + list(variation_default))},
         )
 
-        logging.success(
+        logger.info(
             f' 🎉🎉🎉 Completed data collection for pusht {var_name} 🎉🎉🎉'
         )
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_pusht_toy.py
+++ b/scripts/data/collect_pusht_toy.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
 import hydra
+import logging
 import numpy as np
-from loguru import logger as logging
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.pusht import WeakPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='default')
@@ -26,8 +28,12 @@ def run(cfg):
             seed=rng.integers(0, 1_000_000).item(),
         )
 
-    logging.success(' 🎉🎉🎉 Completed data collection for pusht_toy 🎉🎉🎉')
+    logger.info(' 🎉🎉🎉 Completed data collection for pusht_toy 🎉🎉🎉')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_reacher.py
+++ b/scripts/data/collect_reacher.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -7,10 +8,11 @@ os.environ['MUJOCO_GL'] = 'glfw'
 
 import hydra
 import numpy as np
-from loguru import logger as logging
 
 import stable_worldmodel as swm
 from stable_worldmodel.policy import RandomPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='reacher')
@@ -35,8 +37,12 @@ def run(cfg):
         options=options,
     )
 
-    logging.success('Completed random data collection for reacher')
+    logger.info('Completed random data collection for reacher')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_scene.py
+++ b/scripts/data/collect_scene.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -5,11 +6,12 @@ os.environ['MUJOCO_GL'] = 'egl'
 
 import hydra
 import numpy as np
-from loguru import logger as logging
 from omegaconf import DictConfig, OmegaConf
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.ogbench import ExpertPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='ogb')
@@ -42,10 +44,12 @@ def run(cfg: DictConfig):
         options=options,
     )
 
-    logging.success(
-        '🎉🎉🎉 Completed data collection for ogbench scene  🎉🎉🎉'
-    )
+    logger.info('🎉🎉🎉 Completed data collection for ogbench scene  🎉🎉🎉')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_tworooms.py
+++ b/scripts/data/collect_tworooms.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
 import hydra
+import logging
 import numpy as np
-from loguru import logger as logging
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.two_room import ExpertPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='default')
@@ -27,8 +29,12 @@ def run(cfg):
         options=options,
     )
 
-    logging.success(' 🎉🎉🎉 Completed data collection for tworoom 🎉🎉🎉')
+    logger.info(' 🎉🎉🎉 Completed data collection for tworoom 🎉🎉🎉')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_tworooms_single_var.py
+++ b/scripts/data/collect_tworooms_single_var.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 
 import hydra
+import logging
 import numpy as np
-from loguru import logger as logging
 import stable_worldmodel as swm
 from stable_worldmodel.envs.two_room import ExpertPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='default')
@@ -45,10 +47,14 @@ def run(cfg):
             options={'variation': tuple([var] + list(variation_default))},
         )
 
-        logging.success(
+        logger.info(
             f' 🎉🎉🎉 Completed data collection for tworoom {var_name} 🎉🎉🎉'
         )
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_weak_discrete_pusht.py
+++ b/scripts/data/collect_weak_discrete_pusht.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
 import hydra
+import logging
 import numpy as np
-from loguru import logger as logging
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.pusht import WeakPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='default')
@@ -32,10 +34,14 @@ def run(cfg):
             options=options,
         )
 
-    logging.success(
+    logger.info(
         ' 🎉🎉🎉 Completed data collection for pusht_discrete_weak_100 🎉🎉🎉'
     )
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/data/collect_weak_pusht.py
+++ b/scripts/data/collect_weak_pusht.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
 import hydra
+import logging
 import numpy as np
-from loguru import logger as logging
 
 import stable_worldmodel as swm
 from stable_worldmodel.envs.pusht import WeakPolicy
+
+logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path='./config', config_name='default')
@@ -30,10 +32,12 @@ def run(cfg):
             options=options,
         )
 
-    logging.success(
-        ' 🎉🎉🎉 Completed data collection for pusht_weak_100 🎉🎉🎉'
-    )
+    logger.info(' 🎉🎉🎉 Completed data collection for pusht_weak_100 🎉🎉🎉')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/expert/sac_online.py
+++ b/scripts/expert/sac_online.py
@@ -1,5 +1,6 @@
 """Script for training SAC expert policies on DMControl environments."""
 
+import logging
 import os
 
 os.environ['MUJOCO_GL'] = 'egl'
@@ -12,7 +13,6 @@ from typing import Any
 import gymnasium as gym
 import numpy as np
 import torch
-from loguru import logger
 from stable_baselines3 import SAC
 from stable_baselines3.common.callbacks import (
     BaseCallback,
@@ -172,6 +172,8 @@ PARAMS_REGISTRY = {
         'run': {**HUMANOID_CFG, 'total_timesteps': 5_000_000},
     },
 }
+
+logger = logging.getLogger(__name__)
 
 
 class RewardLoggerCallback(BaseCallback):
@@ -384,9 +386,7 @@ class DMControlTrainer:
 
             model.save(self.save_dir / 'expert_policy')
             vec_env.save(str(self.save_dir / 'vec_normalize.pkl'))
-            logger.success(
-                f'Completed training for {self.domain}::{self.task}'
-            )
+            logger.info(f'Completed training for {self.domain}::{self.task}')
 
         except Exception as e:
             logger.error(
@@ -486,4 +486,8 @@ def main():
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     main()

--- a/scripts/expert/tdmpc2_online.py
+++ b/scripts/expert/tdmpc2_online.py
@@ -38,6 +38,7 @@ Usage:
     python tdmpc2_online.py --domain walker --steps 1000000 --seed 1
 """
 
+import logging
 import os
 
 os.environ['MUJOCO_GL'] = 'egl'
@@ -53,7 +54,6 @@ import torch
 import gymnasium as gym
 from gymnasium import spaces
 from omegaconf import OmegaConf, open_dict
-from loguru import logger as logging
 
 from stable_worldmodel.data.buffer import ReplayBuffer
 from stable_worldmodel.planning.solver.cem import CEMSolver
@@ -147,6 +147,8 @@ GRAD_STEPS = 1
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 _CONFIG_PATH = Path(__file__).parent / 'config' / 'tdmpc2_online.yaml'
 _DEVNULL = open(os.devnull, 'w')
+
+logger = logging.getLogger(__name__)
 
 
 def load_cfg(obs_dim: int, action_dim: int, discount: float) -> OmegaConf:
@@ -282,7 +284,7 @@ def update_model(
 
 def save_checkpoint(model: TDMPC2, save_dir: Path, tag: str):
     torch.save(model, save_dir / f'{tag}_model.pt')
-    logging.info(f'  Checkpoint saved → {tag}')
+    logger.info(f'  Checkpoint saved → {tag}')
 
 
 @torch.no_grad()
@@ -330,11 +332,11 @@ def train_task(
 
     use_wandb = use_wandb and WANDB_AVAILABLE
 
-    logging.info(f'\n{"=" * 60}')
-    logging.info(
+    logger.info(f'\n{"=" * 60}')
+    logger.info(
         f'TD-MPC2 | {domain}-{task} | {total_steps:,} steps | device={DEVICE}'
     )
-    logging.info(f'{"=" * 60}')
+    logger.info(f'{"=" * 60}')
 
     pool = EnvPool(
         [lambda: make_env(gym_id, task=task) for _ in range(N_COLLECT_ENVS)]
@@ -352,7 +354,7 @@ def train_task(
     cfg = load_cfg(obs_dim=obs_dim, action_dim=action_dim, discount=discount)
     horizon = cfg.wm.horizon
 
-    logging.info(
+    logger.info(
         f'  obs_dim={obs_dim} | action_dim={action_dim} | '
         f'horizon={horizon} | discount={discount:.4f} | '
         f'max_ep_steps={max_ep_steps}'
@@ -438,7 +440,7 @@ def train_task(
                 cur_obs[i].clear()
                 cur_act[i].clear()
                 cur_rew[i].clear()
-                logging.info(
+                logger.info(
                     f'[{domain}-{task}] step={step:,} | ep_reward={ep_reward[i]:.2f} | ep_len={ep_steps[i]}'
                 )
                 if use_wandb:
@@ -468,7 +470,7 @@ def train_task(
                 }
                 metrics = update_model(model, batch, cfg, optimizers)
             if step % 5_000 == 0:
-                logging.info(
+                logger.info(
                     f'[{domain}-{task}] step={step:,} | '
                     f'loss={metrics["loss"]:.4f} | '
                     f'rew={metrics["reward_loss"]:.4f} | '
@@ -491,7 +493,7 @@ def train_task(
 
         if step % EVAL_FREQ == 0 and step >= SEED_STEPS:
             eval_r = evaluate(model, gym_id, task)
-            logging.info(
+            logger.info(
                 f'[{domain}-{task}] *** EVAL step={step:,} | mean_reward={eval_r:.2f} ***'
             )
             if use_wandb:
@@ -499,10 +501,10 @@ def train_task(
             if eval_r > best_eval:
                 best_eval = eval_r
                 save_checkpoint(model, save_dir, tag='best')
-                logging.info(f'[{domain}-{task}] New best: {best_eval:.2f}')
+                logger.info(f'[{domain}-{task}] New best: {best_eval:.2f}')
 
     save_checkpoint(model, save_dir, tag='final')
-    logging.info(f'[{domain}-{task}] Done. Best eval reward: {best_eval:.2f}')
+    logger.info(f'[{domain}-{task}] Done. Best eval reward: {best_eval:.2f}')
     pool.close()
     del model
     if torch.cuda.is_available():
@@ -550,24 +552,22 @@ def main():
 
     if args.list:
         for domain, tasks in TASK_REGISTRY.items():
-            logging.info(f'[{domain}]: {", ".join(tasks.keys())}')
+            logger.info(f'[{domain}]: {", ".join(tasks.keys())}')
         return
 
     if not args.domain:
-        logging.error(
-            'Please specify --domain (or use --list to see options).'
-        )
+        logger.error('Please specify --domain (or use --list to see options).')
         sys.exit(1)
 
     domain = args.domain.lower()
     if domain not in TASK_REGISTRY:
-        logging.error(
+        logger.error(
             f"Domain '{domain}' not found. Use --list to see options."
         )
         sys.exit(1)
 
     if args.task and args.task not in TASK_REGISTRY[domain]:
-        logging.error(
+        logger.error(
             f"Task '{args.task}' not found in domain '{domain}'. "
             f'Available: {", ".join(TASK_REGISTRY[domain].keys())}'
         )
@@ -600,4 +600,8 @@ def main():
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     main()

--- a/scripts/train/gcbc.py
+++ b/scripts/train/gcbc.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import hydra
@@ -8,7 +9,6 @@ from lightning.pytorch.callbacks import Callback
 from stable_worldmodel.data import column_normalizer as get_column_normalizer
 from stable_worldmodel.wm.utils import save_pretrained
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger as logging
 from omegaconf import OmegaConf, open_dict
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
@@ -19,6 +19,10 @@ import stable_worldmodel as swm
 # ============================================================================
 # Data Setup
 # ============================================================================
+
+logger = logging.getLogger(__name__)
+
+
 def get_data(cfg):
     """Setup dataset with image transforms and normalization."""
 
@@ -86,11 +90,11 @@ def get_data(cfg):
             lengths=[train_subset_fraction, 1 - train_subset_fraction],
             generator=rnd_gen,
         )
-        logging.info(
+        logger.info(
             f'Using {train_subset_fraction:.1%} of training data: {len(train_set)} samples'
         )
 
-    logging.info(f'Train: {len(train_set)}, Val: {len(val_set)}')
+    logger.info(f'Train: {len(train_set)}, Val: {len(val_set)}')
 
     train = DataLoader(
         train_set,
@@ -159,7 +163,7 @@ def get_gcbc_policy(cfg):
         # Compute action MSE
         action_loss = F.mse_loss(action_pred, action_target)
         if torch.isnan(action_loss):
-            logging.error(
+            logger.error(
                 f'NaN loss! action_pred has nan: {torch.isnan(action_pred).any()}, action_target has nan: {torch.isnan(action_target).any()}'
             )
         batch['loss'] = action_loss
@@ -197,7 +201,7 @@ def get_gcbc_policy(cfg):
     if use_proprio:
         embedding_dim += cfg.wm.proprio_embed_dim  # concatenated to patches
 
-    logging.info(
+    logger.info(
         f'Patches: {num_patches}, Embedding dim: {embedding_dim}, '
         f'Action dim: {effective_act_dim}, Proprio encoder: {use_proprio}'
     )
@@ -340,4 +344,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/train/gciql.py
+++ b/scripts/train/gciql.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import OrderedDict
 
@@ -8,7 +9,6 @@ import torch
 from einops import rearrange, repeat
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger as logging
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
 from transformers import AutoModel
@@ -24,6 +24,10 @@ from stable_worldmodel.wm.utils import save_pretrained
 # ============================================================================
 # Data Setup
 # ============================================================================
+
+logger = logging.getLogger(__name__)
+
+
 def get_data(cfg, goal_probabilities):
     """Setup dataset with image transforms and normalization."""
 
@@ -97,11 +101,11 @@ def get_data(cfg, goal_probabilities):
             lengths=[train_subset_fraction, 1 - train_subset_fraction],
             generator=rnd_gen,
         )
-        logging.info(
+        logger.info(
             f'Using {train_subset_fraction:.1%} of training data: {len(train_set)} samples'
         )
 
-    logging.info(f'Train: {len(train_set)}, Val: {len(val_set)}')
+    logger.info(f'Train: {len(train_set)}, Val: {len(val_set)}')
 
     train = DataLoader(
         train_set,
@@ -177,7 +181,7 @@ def get_gciql_critics_model(cfg):
         }
         for name, tensor in nan_checks.items():
             if tensor is not None and torch.isnan(tensor).any():
-                logging.warning(
+                logger.warning(
                     f'NaN detected in {name}! '
                     f'count={torch.isnan(tensor).sum().item()}, '
                     f'shape={tensor.shape}'
@@ -286,17 +290,17 @@ def get_gciql_critics_model(cfg):
 
         # NaN detection after value prediction
         if torch.isnan(v).any():
-            logging.warning(
+            logger.warning(
                 f'NaN in value_pred! count={torch.isnan(v).sum().item()}'
             )
         if torch.isnan(q).any():
-            logging.warning(
+            logger.warning(
                 f'NaN in q target! count={torch.isnan(q).sum().item()}'
             )
 
         # NaN detection after loss computation
         if torch.isnan(value_loss):
-            logging.warning(
+            logger.warning(
                 f'NaN in value_loss! '
                 f'value_pred range: [{value_pred.min().item():.4f}, {value_pred.max().item():.4f}], '
                 f'value_target range: [{value_target.min().item():.4f}, {value_target.max().item():.4f}]'
@@ -483,7 +487,7 @@ def get_gciql_critics_model(cfg):
         encoder = AutoModel.from_pretrained('facebook/dinov2-small')
         embedding_dim = encoder.config.hidden_size
         encoder_trainable = False
-        logging.info('Using pretrained frozen DINO encoder')
+        logger.info('Using pretrained frozen DINO encoder')
     elif encoder_type == 'vit_tiny':
         # Load trainable ViT tiny from scratch
         encoder = spt.backbone.utils.vit_hf(
@@ -495,7 +499,7 @@ def get_gciql_critics_model(cfg):
         )
         embedding_dim = encoder.config.hidden_size
         encoder_trainable = True
-        logging.info('Using trainable ViT tiny encoder (from scratch)')
+        logger.info('Using trainable ViT tiny encoder (from scratch)')
     else:
         raise ValueError(f'Unknown encoder_type: {encoder_type}')
 
@@ -507,7 +511,7 @@ def get_gciql_critics_model(cfg):
     if cfg.dinowm.get('use_proprio_encoder', True):
         embedding_dim += cfg.dinowm.proprio_embed_dim  # Total embedding size
 
-    logging.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
+    logger.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
 
     # Build causal predictor (transformer that predicts next actions)
     effective_act_dim = (
@@ -565,7 +569,7 @@ def get_gciql_critics_model(cfg):
         )
         extra_encoders = torch.nn.ModuleDict(extra_encoders)
 
-    logging.info(
+    logger.info(
         f'Action dim: {effective_act_dim}, Proprio encoder: {extra_encoders is not None}'
     )
 
@@ -944,4 +948,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/train/gcivl.py
+++ b/scripts/train/gcivl.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import OrderedDict
 
@@ -8,7 +9,6 @@ import torch
 from einops import rearrange, repeat
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger as logging
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
 from transformers import AutoModel
@@ -21,6 +21,10 @@ from stable_worldmodel.wm.utils import save_pretrained
 # ============================================================================
 # Data Setup
 # ============================================================================
+
+logger = logging.getLogger(__name__)
+
+
 def get_data(cfg, goal_probabilities):
     """Setup dataset with image transforms and normalization."""
 
@@ -94,11 +98,11 @@ def get_data(cfg, goal_probabilities):
             lengths=[train_subset_fraction, 1 - train_subset_fraction],
             generator=rnd_gen,
         )
-        logging.info(
+        logger.info(
             f'Using {train_subset_fraction:.1%} of training data: {len(train_set)} samples'
         )
 
-    logging.info(f'Train: {len(train_set)}, Val: {len(val_set)}')
+    logger.info(f'Train: {len(train_set)}, Val: {len(val_set)}')
 
     train = DataLoader(
         train_set,
@@ -173,7 +177,7 @@ def get_ivl_value_model(cfg):
         }
         for name, tensor in nan_checks.items():
             if tensor is not None and torch.isnan(tensor).any():
-                logging.warning(
+                logger.warning(
                     f'NaN detected in {name}! '
                     f'count={torch.isnan(tensor).sum().item()}, '
                     f'shape={tensor.shape}'
@@ -251,17 +255,17 @@ def get_ivl_value_model(cfg):
         # NaN detection after value prediction
         value_pred = v_pred
         if torch.isnan(v_pred).any():
-            logging.warning(
+            logger.warning(
                 f'NaN in value_pred! count={torch.isnan(v_pred).sum().item()}'
             )
         if torch.isnan(q).any():
-            logging.warning(
+            logger.warning(
                 f'NaN in q target! count={torch.isnan(q).sum().item()}'
             )
 
         # NaN detection after loss computation
         if torch.isnan(value_loss):
-            logging.warning(
+            logger.warning(
                 f'NaN in value_loss! '
                 f'value_pred range: [{value_pred.min().item():.4f}, {value_pred.max().item():.4f}], '
                 f'value_target range: [{value_target.min().item():.4f}, {value_target.max().item():.4f}]'
@@ -449,7 +453,7 @@ def get_ivl_value_model(cfg):
         encoder = AutoModel.from_pretrained('facebook/dinov2-small')
         embedding_dim = encoder.config.hidden_size
         encoder_trainable = False
-        logging.info('Using pretrained frozen DINO encoder')
+        logger.info('Using pretrained frozen DINO encoder')
     elif encoder_type == 'vit_tiny':
         # Load trainable ViT tiny from scratch
         encoder = spt.backbone.utils.vit_hf(
@@ -461,7 +465,7 @@ def get_ivl_value_model(cfg):
         )
         embedding_dim = encoder.config.hidden_size
         encoder_trainable = True
-        logging.info('Using trainable ViT tiny encoder (from scratch)')
+        logger.info('Using trainable ViT tiny encoder (from scratch)')
     else:
         raise ValueError(f'Unknown encoder_type: {encoder_type}')
 
@@ -473,7 +477,7 @@ def get_ivl_value_model(cfg):
     if cfg.dinowm.get('use_proprio_encoder', True):
         embedding_dim += cfg.dinowm.proprio_embed_dim  # Total embedding size
 
-    logging.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
+    logger.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
 
     # Build causal predictor (transformer that predicts next actions)
     effective_act_dim = (
@@ -514,7 +518,7 @@ def get_ivl_value_model(cfg):
         )
         extra_encoders = torch.nn.ModuleDict(extra_encoders)
 
-    logging.info(
+    logger.info(
         f'Action dim: {effective_act_dim}, Proprio encoder: {extra_encoders is not None}'
     )
 
@@ -889,4 +893,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/train/hilp.py
+++ b/scripts/train/hilp.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import OrderedDict
 
@@ -10,7 +11,6 @@ from lightning.pytorch.callbacks import Callback
 from stable_worldmodel.data import column_normalizer as get_column_normalizer
 from stable_worldmodel.wm.utils import save_pretrained
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger as logging
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
 from transformers import AutoModel
@@ -24,6 +24,10 @@ import stable_worldmodel as swm
 # ============================================================================
 # Data Setup
 # ============================================================================
+
+logger = logging.getLogger(__name__)
+
+
 def get_data(cfg):
     """Setup dataset with image transforms and normalization."""
 
@@ -87,7 +91,7 @@ def get_data(cfg):
         lengths=[cfg.train_split, 1 - cfg.train_split],
         generator=rnd_gen,
     )
-    logging.info(f'Train: {len(train_set)}, Val: {len(val_set)}')
+    logger.info(f'Train: {len(train_set)}, Val: {len(val_set)}')
 
     train = DataLoader(
         train_set,
@@ -162,7 +166,7 @@ def get_hilp_value_model(cfg):
         }
         for name, tensor in nan_checks.items():
             if tensor is not None and torch.isnan(tensor).any():
-                logging.warning(
+                logger.warning(
                     f'NaN detected in {name}! '
                     f'count={torch.isnan(tensor).sum().item()}, '
                     f'shape={tensor.shape}'
@@ -235,17 +239,17 @@ def get_hilp_value_model(cfg):
         # NaN detection after value prediction
         value_pred = v_pred
         if torch.isnan(v_pred).any():
-            logging.warning(
+            logger.warning(
                 f'NaN in value_pred! count={torch.isnan(v_pred).sum().item()}'
             )
         if torch.isnan(q).any():
-            logging.warning(
+            logger.warning(
                 f'NaN in q target! count={torch.isnan(q).sum().item()}'
             )
 
         # NaN detection after loss computation
         if torch.isnan(value_loss):
-            logging.warning(
+            logger.warning(
                 f'NaN in value_loss! '
                 f'value_pred range: [{value_pred.min().item():.4f}, {value_pred.max().item():.4f}], '
                 f'value_target range: [{value_target.min().item():.4f}, {value_target.max().item():.4f}]'
@@ -421,7 +425,7 @@ def get_hilp_value_model(cfg):
         encoder = AutoModel.from_pretrained('facebook/dinov2-small')
         embedding_dim = encoder.config.hidden_size
         encoder_trainable = False
-        logging.info('Using pretrained frozen DINO encoder')
+        logger.info('Using pretrained frozen DINO encoder')
     elif encoder_type == 'vit_tiny':
         # Load trainable ViT tiny from scratch
         encoder = spt.backbone.utils.vit_hf(
@@ -433,7 +437,7 @@ def get_hilp_value_model(cfg):
         )
         embedding_dim = encoder.config.hidden_size
         encoder_trainable = True
-        logging.info('Using trainable ViT tiny encoder (from scratch)')
+        logger.info('Using trainable ViT tiny encoder (from scratch)')
     else:
         raise ValueError(f'Unknown encoder_type: {encoder_type}')
 
@@ -445,7 +449,7 @@ def get_hilp_value_model(cfg):
     if cfg.dinowm.get('use_proprio_encoder', True):
         embedding_dim += cfg.dinowm.proprio_embed_dim  # Total embedding size
 
-    logging.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
+    logger.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
 
     # Build causal predictor (transformer that predicts next actions)
     effective_act_dim = (
@@ -484,7 +488,7 @@ def get_hilp_value_model(cfg):
         )
         extra_encoders = torch.nn.ModuleDict(extra_encoders)
 
-    logging.info(
+    logger.info(
         f'Action dim: {effective_act_dim}, Proprio encoder: {extra_encoders is not None}'
     )
 
@@ -840,4 +844,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/train/pldm.py
+++ b/scripts/train/pldm.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -8,7 +9,6 @@ from stable_pretraining import data as dt
 import stable_worldmodel as swm
 import torch
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger as logging
 from omegaconf import OmegaConf, open_dict
 from torch.utils.data import DataLoader
 
@@ -18,6 +18,8 @@ from stable_worldmodel.data import column_normalizer as get_column_normalizer
 from stable_worldmodel.wm.loss import PLDMLoss, TemporalStraighteningLoss
 from lightning.pytorch.callbacks import Callback
 from stable_worldmodel.wm.utils import save_pretrained
+
+logger = logging.getLogger(__name__)
 
 
 def get_img_preprocessor(source: str, target: str, img_size: int = 224):
@@ -200,7 +202,7 @@ def run(cfg):
     run_dir = Path(
         swm.data.utils.get_cache_dir(sub_folder='checkpoints'), run_id
     )
-    logging.info(f'🫆🫆🫆 Run ID: {run_id} 🫆🫆🫆')
+    logger.info(f'🫆🫆🫆 Run ID: {run_id} 🫆🫆🫆')
 
     logger = None
     if cfg.wandb.enabled:
@@ -236,4 +238,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/train/prejepa.py
+++ b/scripts/train/prejepa.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -11,7 +12,6 @@ from functools import partial
 from stable_worldmodel.data import column_normalizer as get_column_normalizer
 from stable_worldmodel.wm.utils import save_pretrained
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger as logging
 from omegaconf import OmegaConf, open_dict
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
@@ -21,6 +21,8 @@ from transformers import AutoVideoProcessor
 # ---------------------------------------------------------------------------
 # Data helpers
 # ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
 
 
 def get_img_preprocessor(source, target, img_size=224):
@@ -281,7 +283,7 @@ def run(cfg):
         swm.data.utils.get_cache_dir(sub_folder='checkpoints'), run_id
     )
     run_dir.mkdir(parents=True, exist_ok=True)
-    logging.info(f'Run ID: {run_id}')
+    logger.info(f'Run ID: {run_id}')
 
     with open(run_dir / 'config.yaml', 'w') as f:
         OmegaConf.save(cfg, f)
@@ -317,4 +319,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/train/tdmpc2.py
+++ b/scripts/train/tdmpc2.py
@@ -2,18 +2,20 @@ from functools import partial
 from pathlib import Path
 import hydra
 import lightning as pl
+import logging
 import stable_pretraining as spt
 import stable_worldmodel as swm
 import torch
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger as logging
 from omegaconf import OmegaConf, open_dict
 from torch.utils.data import DataLoader
 import numpy as np
 
 from stable_worldmodel.wm.tdmpc2 import tdmpc2_forward
 from stable_worldmodel.wm.utils import save_pretrained
+
+logger = logging.getLogger(__name__)
 
 
 class SaveCkptCallback(Callback):
@@ -133,7 +135,7 @@ def run(cfg):
         base_dataset._cache[goal_obs_key] = np.concatenate(
             [_raw_obs, goals_by_step], axis=-1
         )
-        logging.info(
+        logger.info(
             f'Goal augmentation: appended last obs of each episode to "{goal_obs_key}" '
             f'(dim {_raw_obs.shape[-1]} → {base_dataset._cache[goal_obs_key].shape[-1]})'
         )
@@ -144,7 +146,7 @@ def run(cfg):
     act_min = valid_actions.min()
 
     if act_max > 1.01 or act_min < -1.01:
-        logging.error(
+        logger.error(
             f'Dataset actions fall outside the [-1, 1] range! (Min: {act_min:.2f}, Max: {act_max:.2f}).\n'
             'TD-MPC2 uses a Tanh actor and strictly requires actions to be bounded between [-1, 1].\n'
             'Please normalize your dataset actions.'
@@ -267,4 +269,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/visualization/utils.py
+++ b/scripts/visualization/utils.py
@@ -1,13 +1,15 @@
 """Shared grid utilities for environment visualization."""
 
+import logging
 import torch
 import torch.nn as nn
 import numpy as np
-from loguru import logger as logging
 
 from stable_worldmodel.envs.ogbench.cube_env import CubeEnv
 from stable_worldmodel.envs.pusht.env import PushT
 from stable_worldmodel.envs.two_room.env import TwoRoomEnv
+
+logger = logging.getLogger(__name__)
 
 
 class LeWMAdapter(nn.Module):
@@ -179,7 +181,7 @@ def get_state_grid(env, grid_size: int = 10):
         - grid: (N, 2) array of grid coordinates
         - state_grid: List of full state vectors for each grid point
     """
-    logging.info(f'Generating state grid for env type: {type(env)}')
+    logger.info(f'Generating state grid for env type: {type(env)}')
 
     if isinstance(env, PushT):
         dim = [0, 1]  # Agent X, Y

--- a/scripts/visualization/visualize_dataset.py
+++ b/scripts/visualization/visualize_dataset.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
 
 import hydra
+import logging
 import matplotlib.pyplot as plt
 import numpy as np
 import stable_pretraining as spt
 import torch
 from einops import rearrange
-from loguru import logger as logging
 from omegaconf import open_dict
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
@@ -28,6 +28,8 @@ DINO_PATCH_SIZE = 14  # DINO encoder uses 14x14 patches
 # ============================================================================
 # Data Loading
 # ============================================================================
+
+logger = logging.getLogger(__name__)
 
 
 def get_data(cfg, dataset_cfg, model_cfg):
@@ -82,7 +84,7 @@ def get_data(cfg, dataset_cfg, model_cfg):
         lengths=[dataset_cfg.visual_split, 1 - dataset_cfg.visual_split],
         generator=rnd_gen,
     )
-    logging.info(f'Visual ({dataset_cfg.dataset_name}): {len(visual_set)}')
+    logger.info(f'Visual ({dataset_cfg.dataset_name}): {len(visual_set)}')
 
     visual = DataLoader(
         visual_set,
@@ -195,7 +197,7 @@ def get_world_model(cfg, model_cfg):
             emb_dim for emb_dim in model_cfg.get('encoding', {}).values()
         )  # add all extra dims
 
-        logging.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
+        logger.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
 
         # Build causal predictor (transformer that predicts next latent states)
 
@@ -248,7 +250,7 @@ def collect_embeddings(cfg, exp_cfg):
     data = get_data(cfg, exp_cfg.dataset, exp_cfg.world_model)
     world_model = get_world_model(cfg, exp_cfg.world_model)
 
-    logging.info(
+    logger.info(
         f'Encoding dataset: {exp_cfg.dataset.dataset_name} using model: {exp_cfg.world_model.model_name}...'
     )
     dataset_embeddings = []
@@ -328,7 +330,7 @@ def plot_joint_dimensionality_reduction(
     plt.legend(title='Datasets', bbox_to_anchor=(1.05, 1), loc='upper left')
     plt.tight_layout()
 
-    logging.info(f'Saving plot to {output_file}')
+    logger.info(f'Saving plot to {output_file}')
     # Matplotlib automatically handles the output format based on the file extension
     plt.savefig(output_file, dpi=300)
     plt.close()
@@ -364,7 +366,7 @@ def run(cfg):
 
     # Concatenate all datasets for joint dimensionality reduction
     if not all_embeddings_list:
-        logging.warning('No embeddings generated from any experiment.')
+        logger.warning('No embeddings generated from any experiment.')
         return
 
     # Ensure dimensions match before concatenating
@@ -376,7 +378,7 @@ def run(cfg):
                 'Ensure image_size, patch_size, and model architecture are consistent across all datasets.'
             )
 
-    logging.info('Computing Joint Dimensionality Reduction...')
+    logger.info('Computing Joint Dimensionality Reduction...')
     # Concatenate all tensors then convert to numpy for dimensionality reduction
     full_embeddings = torch.cat(all_embeddings_list, dim=0).numpy()
     all_labels = np.array(all_labels_list)  # Convert labels to numpy array
@@ -389,7 +391,7 @@ def run(cfg):
         pca = PCA(n_components=2, random_state=cfg.seed)
         embeddings_2d = pca.fit_transform(full_embeddings)
 
-    logging.info(
+    logger.info(
         f'Dimensionality reduction ({cfg.dimensionality_reduction}) completed. Output shape: {embeddings_2d.shape}'
     )
 
@@ -404,4 +406,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/visualization/visualize_env.py
+++ b/scripts/visualization/visualize_env.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -13,7 +14,6 @@ import numpy as np
 import stable_pretraining as spt
 import torch
 from einops import rearrange
-from loguru import logger as logging
 from omegaconf import OmegaConf, open_dict
 from sklearn import preprocessing
 from sklearn.decomposition import PCA
@@ -39,6 +39,8 @@ DINO_PATCH_SIZE = 14  # DINO encoder uses 14x14 patches
 # ============================================================================
 # Setting up Environment, transform and processing
 # ============================================================================
+
+logger = logging.getLogger(__name__)
 
 
 def img_transform():
@@ -103,7 +105,7 @@ def get_env(cfg):
 
     def _make_scaler(key, target_dim, mean, std):
         if target_dim is None:
-            logging.warning(
+            logger.warning(
                 f"Missing target dim for '{key}', skipping standardization."
             )
             return None
@@ -117,7 +119,7 @@ def get_env(cfg):
             or mean.shape[0] != target_dim
             or std.shape[0] != target_dim
         ):
-            logging.warning(
+            logger.warning(
                 f"Stats for '{key}' do not match dim {target_dim}; using identity standardization."
             )
             mean = np.zeros(target_dim, dtype=np.float32)
@@ -314,7 +316,7 @@ def get_world_model(cfg):
         emb_dim for emb_dim in cfg.world_model.get('encoding', {}).values()
     )  # add all extra dims
 
-    logging.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
+    logger.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
 
     print('>>>> DIM PREDICTOR:', embedding_dim)
 
@@ -429,7 +431,7 @@ def compute_dimensionality_reduction(embeddings, cfg):
     """
     Computes t-SNE projection on the collected embeddings.
     """
-    logging.info(
+    logger.info(
         f'Computing dimensionality reduction with {cfg.dimensionality_reduction}'
     )
     # Flatten if embeddings are spatial (e.g. from patch tokens)
@@ -533,7 +535,7 @@ def plot_distance_maps(
     plt.tight_layout(rect=[0, 0.03, 1, 0.95])
     # Save as PDF
     plt.savefig(save_path, format='pdf')
-    logging.info(f'Distance maps saved to {save_path}')
+    logger.info(f'Distance maps saved to {save_path}')
     plt.close(fig)
 
 
@@ -619,7 +621,7 @@ def plot_representations(
 
     plt.tight_layout()
     plt.savefig(save_path, format='pdf')
-    logging.info(f'Visualization saved to {save_path}')
+    logger.info(f'Visualization saved to {save_path}')
     plt.close(fig)
 
 
@@ -669,7 +671,7 @@ def plot_rotation_representations(
 
     plt.tight_layout()
     plt.savefig(save_path, format='pdf')
-    logging.info(f'Rotation visualization saved to {save_path}')
+    logger.info(f'Rotation visualization saved to {save_path}')
     plt.close(fig)
 
 
@@ -701,9 +703,9 @@ def run(cfg):
     cfg.cache_dir = cache_dir
 
     for dataset_name, dataset_cfg in cfg.datasets.items():
-        logging.info('==============================')
-        logging.info(f'Processing dataset: {dataset_name}')
-        logging.info('==============================')
+        logger.info('==============================')
+        logger.info(f'Processing dataset: {dataset_name}')
+        logger.info('==============================')
 
         local_cfg = make_runtime_cfg(cfg, dataset_cfg)
         wm_cfg = local_cfg.world_model
@@ -722,7 +724,7 @@ def run(cfg):
 
         if visualization_mode == 'rotation':
             # --- Rotation sweep: fixed agent/block positions, varying T angle ---
-            logging.info('Computing rotation embeddings from environment...')
+            logger.info('Computing rotation embeddings from environment...')
             angles, emb_list, pix_list = collect_rotation_embeddings(
                 world_model, env, process, transform, local_cfg
             )
@@ -730,7 +732,7 @@ def run(cfg):
             all_embeddings = torch.cat(emb_list, dim=0).cpu().numpy()
             all_embeddings = rearrange(all_embeddings, 'b ... -> b (...)')
 
-            logging.info(
+            logger.info(
                 f'Computing {local_cfg.dimensionality_reduction} '
                 f'for {all_embeddings.shape[0]} rotation samples...'
             )
@@ -751,7 +753,7 @@ def run(cfg):
 
         else:
             # --- Default: grid sweep over agent/block XY translations ---
-            logging.info('Computing embeddings from environment...')
+            logger.info('Computing embeddings from environment...')
             grid, embeddings_variations, pixels_variations = (
                 collect_embeddings(
                     world_model, env, process, transform, local_cfg
@@ -771,7 +773,7 @@ def run(cfg):
             samples_per_variation = all_embeddings_list[0].shape[0]
 
             # --- Dimensionality reduction ---
-            logging.info(
+            logger.info(
                 f'Computing global {local_cfg.dimensionality_reduction} '
                 f'for {num_variations} variations '
                 f'({all_embeddings_global.shape[0]} samples)...'
@@ -817,10 +819,14 @@ def run(cfg):
                     save_path=distmap_save_path,
                 )
 
-        logging.info(f'Finished dataset: {dataset_name}')
+        logger.info(f'Finished dataset: {dataset_name}')
 
-    logging.info('All datasets processed.')
+    logger.info('All datasets processed.')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/visualization/visualize_trajectories.py
+++ b/scripts/visualization/visualize_trajectories.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import hydra
+import logging
 import matplotlib.animation as animation
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
@@ -8,7 +9,6 @@ import numpy as np
 import stable_pretraining as spt
 import torch
 from einops import rearrange
-from loguru import logger as logging
 from omegaconf import OmegaConf, open_dict
 from scipy.interpolate import interp1d
 from sklearn.decomposition import PCA
@@ -29,6 +29,8 @@ DINO_PATCH_SIZE = 14  # DINO encoder uses 14x14 patches
 # ============================================================================
 # Data Loading
 # ============================================================================
+
+logger = logging.getLogger(__name__)
 
 
 def get_data(cfg, dataset_cfg, model_cfg):
@@ -201,7 +203,7 @@ def get_world_model(cfg, model_cfg):
             emb_dim for emb_dim in model_cfg.get('encoding', {}).values()
         )  # add all extra dims
 
-        logging.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
+        logger.info(f'Patches: {num_patches}, Embedding dim: {embedding_dim}')
 
         # Build causal predictor (transformer that predicts next latent states)
 
@@ -255,7 +257,7 @@ def collect_embeddings(cfg, exp_cfg):
     trajs = get_data(cfg, exp_cfg.dataset, exp_cfg.world_model)
     world_model = get_world_model(cfg, exp_cfg.world_model)
 
-    logging.info(
+    logger.info(
         f'Encoding dataset: {exp_cfg.dataset.dataset_name} using model: {exp_cfg.world_model.model_name}...'
     )
     trajs_embeddings = []  # list to store the embeddings of the trajectories (T x D)
@@ -439,7 +441,7 @@ def plot_static_trajectories(
     plt.tight_layout()
     plt.savefig(output_file)
     plt.close()
-    logging.info(f'Static trajectory plot saved to {output_file}')
+    logger.info(f'Static trajectory plot saved to {output_file}')
 
 
 def create_video_visualization(
@@ -575,7 +577,7 @@ def create_video_visualization(
 
         return artists
 
-    logging.info(f'Generating animation with {n_rows} trajectories...')
+    logger.info(f'Generating animation with {n_rows} trajectories...')
     ani = animation.FuncAnimation(
         fig, update, frames=max_len, interval=100, blit=True
     )
@@ -589,13 +591,13 @@ def create_video_visualization(
                 imageio_ffmpeg.get_ffmpeg_exe()
             )
         except Exception as exc:  # noqa: BLE001
-            logging.warning(
+            logger.warning(
                 f'Could not locate ffmpeg via imageio-ffmpeg: {exc}'
             )
     writer = animation.FFMpegWriter(fps=10, codec='libx264')
     ani.save(output_file, writer=writer)
     plt.close()
-    logging.info(f'Animation saved to {output_file}')
+    logger.info(f'Animation saved to {output_file}')
 
 
 # ============================================================================
@@ -641,7 +643,7 @@ def run(cfg):
                     trajectory_lengths.append(emb.shape[0])
 
     if not all_embeddings_list:
-        logging.warning('No embeddings generated.')
+        logger.warning('No embeddings generated.')
         return
 
     # Check dims
@@ -666,13 +668,13 @@ def run(cfg):
 
     # Run dimensionality reduction:
     if cfg.dimensionality_reduction == 'tsne':
-        logging.info(
+        logger.info(
             f'Computing t-SNE on {full_embeddings.shape[0]} points (Truth + Pred)...'
         )
         tsne = TSNE(n_components=2, random_state=cfg.seed)
         embeddings_2d_flat = tsne.fit_transform(full_embeddings)
     elif cfg.dimensionality_reduction == 'pca':
-        logging.info(
+        logger.info(
             f'Computing PCA on {full_embeddings.shape[0]} points (Truth + Pred)...'
         )
         pca = PCA(n_components=2, random_state=cfg.seed)
@@ -682,7 +684,7 @@ def run(cfg):
             f'Unsupported dimensionality reduction method: {cfg.dimensionality_reduction}'
         )
 
-    logging.info(
+    logger.info(
         f'Dimensionality reduction completed. Output shape: {embeddings_2d_flat.shape}'
     )
 
@@ -721,4 +723,8 @@ def run(cfg):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/scripts/visualization/visualize_value_function.py
+++ b/scripts/visualization/visualize_value_function.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -9,7 +10,6 @@ import hydra
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from loguru import logger as logging
 from omegaconf import OmegaConf
 from sklearn import preprocessing
 from torchvision.transforms import v2 as transforms
@@ -24,6 +24,8 @@ from utils import get_state_grid
 # ============================================================================
 # Dataset Loading
 # ============================================================================
+
+logger = logging.getLogger(__name__)
 
 
 def get_dataset(cfg, dataset_name):
@@ -87,7 +89,7 @@ def get_env(cfg):
         )
 
     dataset = get_dataset(cfg, training_dataset_name)
-    logging.info(
+    logger.info(
         f'Fitting preprocessing scalers on dataset: {training_dataset_name}'
     )
 
@@ -385,7 +387,7 @@ def plot_value_maps(
         values_2d = values.reshape(height, width)
 
         # print statistics of values for this reference
-        logging.info(
+        logger.info(
             f'Reference {ref_idx}: Value stats - min: {values.min():.4f}, max: {values.max():.4f}, mean: {values.mean():.4f}, std: {values.std():.4f}'
         )
 
@@ -415,7 +417,7 @@ def plot_value_maps(
     plt.suptitle('Value Function Visualization', fontsize=16)
     plt.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.savefig(save_path, format='pdf')
-    logging.info(f'Value maps saved to {save_path}')
+    logger.info(f'Value maps saved to {save_path}')
     plt.close(fig)
 
 
@@ -446,9 +448,9 @@ def run(cfg):
     cfg.cache_dir = cache_dir
 
     for dataset_name, dataset_cfg in cfg.datasets.items():
-        logging.info('==============================')
-        logging.info(f'Processing dataset: {dataset_name}')
-        logging.info('==============================')
+        logger.info('==============================')
+        logger.info(f'Processing dataset: {dataset_name}')
+        logger.info('==============================')
 
         local_cfg = make_runtime_cfg(cfg, dataset_cfg)
         wm_cfg = local_cfg.world_model
@@ -470,7 +472,7 @@ def run(cfg):
         ]
 
         # --- Collect embeddings and compute values ---
-        logging.info('Computing embeddings and value function...')
+        logger.info('Computing embeddings and value function...')
         grid, embeddings, pixels_variations, values_per_ref = (
             collect_embeddings_and_values(
                 model, env, process, transform, local_cfg, ref_indices
@@ -500,10 +502,14 @@ def run(cfg):
                 save_path=valuemap_save_path,
             )
 
-        logging.info(f'Finished dataset: {dataset_name}')
+        logger.info(f'Finished dataset: {dataset_name}')
 
-    logging.info('All datasets processed.')
+    logger.info('All datasets processed.')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
     run()

--- a/stable_worldmodel/cli.py
+++ b/stable_worldmodel/cli.py
@@ -1,5 +1,6 @@
 """Stable World Model CLI commands."""
 
+import logging
 from importlib.metadata import version as pkg_version
 
 from typing import Annotated
@@ -1016,6 +1017,14 @@ def main(
     ] = None,
 ):
     """Stable World Model - World Model Research Made Simple."""
+    # The library logs through stdlib ``logging`` and, like any library,
+    # installs no handler of its own. The CLI is an application, so it is the
+    # one place allowed to configure the root logger — without this, every
+    # ``logger.info`` in the package would be silently dropped.
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s | %(name)s | %(message)s',
+    )
 
 
 if __name__ == '__main__':

--- a/stable_worldmodel/cli.py
+++ b/stable_worldmodel/cli.py
@@ -353,8 +353,17 @@ def _inspect_lance_dataset(path) -> None:
     from pathlib import Path
 
     import numpy as np
-    import pyarrow as pa
-    import lancedb
+
+    try:
+        import lancedb
+        import pyarrow as pa
+    except ImportError:
+        print(
+            '[red]Inspecting Lance datasets needs the [data] extra.[/red]\n'
+            "Install it with [cyan]pip install 'stable-worldmodel[data]'"
+            '[/cyan].'
+        )
+        raise typer.Exit(1) from None
 
     path = Path(path)
     table_path = _resolve_lance_table(path)
@@ -526,7 +535,7 @@ def inspect(
     name: Annotated[str, typer.Argument(help='Dataset name to inspect.')],
 ):
     """Show detailed info for a dataset."""
-    from stable_worldmodel.data import detect_format
+    from stable_worldmodel.data import detect_format, list_formats
     from stable_worldmodel.data.utils import get_cache_dir
 
     cache_dir = get_cache_dir(sub_folder='datasets')
@@ -537,6 +546,14 @@ def inspect(
         raise typer.Exit(1)
 
     fmt = detect_format(path)
+    if fmt is None:
+        print(f'[red]Unrecognized dataset format: {path}[/red]')
+        print(
+            'The backing format may not be registered. Installed formats: '
+            f'{list_formats()}. Lance datasets need '
+            "[cyan]pip install 'stable-worldmodel[data]'[/cyan]."
+        )
+        raise typer.Exit(1)
     if fmt.name in ('lance', 'lance_video'):
         _inspect_lance_dataset(path)
     elif fmt.name == 'hdf5':

--- a/stable_worldmodel/data/__init__.py
+++ b/stable_worldmodel/data/__init__.py
@@ -28,11 +28,15 @@ from . import formats as _formats  # noqa: F401
 
 # Re-export concrete readers/writers from their format modules so existing
 # imports like `from stable_worldmodel.data import LanceDataset` keep working.
-# Optional formats (hdf5, video) are re-exported only when their extras are
-# installed; absent ones are simply not bound at module level.
-from .formats.lance import LanceDataset, LanceWriter
+# Optional formats (lance, hdf5, video) are re-exported only when their extras
+# are installed; absent ones are simply not bound at module level.
 from .formats.folder import FolderDataset, FolderWriter, ImageDataset
 from .formats.lerobot import LeRobotAdapter
+
+try:
+    from .formats.lance import LanceDataset, LanceWriter  # noqa: F401
+except ImportError:
+    pass
 
 try:
     from .formats.hdf5 import HDF5Dataset, HDF5Writer  # noqa: F401
@@ -61,8 +65,6 @@ __all__ = [
     'FolderWriter',
     'IdentityScaler',
     'ImageDataset',
-    'LanceDataset',
-    'LanceWriter',
     'LeRobotAdapter',
     'PercentileScaler',
     'ReplayBuffer',
@@ -79,3 +81,11 @@ __all__ = [
     'split_episode_data',
     'validate_write_mode',
 ]
+
+
+# ``LanceDataset``/``LanceWriter`` are bound above only when the ``[data]``
+# extra is installed. Appending them conditionally (rather than listing them
+# unconditionally in __all__) keeps ``import *`` from raising AttributeError
+# on a base install. hdf5/video/lance_video were never in __all__ and stay out.
+if 'LanceDataset' in globals():
+    __all__ += ['LanceDataset', 'LanceWriter']

--- a/stable_worldmodel/data/format.py
+++ b/stable_worldmodel/data/format.py
@@ -79,13 +79,30 @@ def list_formats() -> list[str]:
     return list(FORMATS)
 
 
+# Formats that only register when their optional extra is installed. Used to
+# turn "unknown format 'lance'" — the error a base install hits first, since
+# lance is the default format — into an actionable message.
+_OPTIONAL_FORMAT_EXTRAS = {
+    'lance': 'data',
+    'lance_video': 'format',
+    'hdf5': 'format',
+    'video': 'format',
+    'lerobot': 'lerobot',
+}
+
+
 def get_format(name: str) -> type[Format]:
     try:
         return FORMATS[name]
     except KeyError:
-        raise ValueError(
-            f'unknown format {name!r}; available: {list_formats()}'
-        ) from None
+        msg = f'unknown format {name!r}; available: {list_formats()}'
+        extra = _OPTIONAL_FORMAT_EXTRAS.get(name)
+        if extra is not None:
+            msg += (
+                f'. The {name!r} format needs its optional dependencies: '
+                f'pip install "stable-worldmodel[{extra}]"'
+            )
+        raise ValueError(msg) from None
 
 
 def detect_format(path) -> type[Format] | None:

--- a/stable_worldmodel/data/formats/__init__.py
+++ b/stable_worldmodel/data/formats/__init__.py
@@ -1,18 +1,15 @@
 """Built-in dataset formats. Importing this package registers each format
 whose optional dependencies are available; the rest are silently skipped.
 
-Lance and folder ship with the core install. HDF5, video, and lerobot
-need their backing libraries (h5py, torchcodec/imageio, lerobot); install
-them together with the umbrella extra ``[format]``.
+Only folder and lerobot ship with the core install. Lance — the default
+dataset format — needs lancedb, from the ``[data]`` extra. HDF5, video, and
+blob-v2 lance_video need their backing libraries (h5py, torchcodec/imageio,
+pylance); install them together with the umbrella extra ``[format]``.
 """
 
 from __future__ import annotations
 
 import logging as _logging
-
-from . import lance  # noqa: F401
-from . import folder  # noqa: F401
-from . import lerobot  # noqa: F401
 
 
 def _try_import(modname: str) -> None:
@@ -24,7 +21,17 @@ def _try_import(modname: str) -> None:
         )
 
 
+# Lance needs lancedb + pyarrow from the ``[data]`` extra. Registered first to
+# preserve the original registration order: `detect_format` returns the first
+# format whose `detect()` matches, and while the built-in predicates are
+# mutually exclusive today, keeping the order stable means making Lance
+# optional cannot change which format claims a path.
+_try_import('lance')
+
+from . import folder  # noqa: E402, F401
+from . import lerobot  # noqa: E402, F401
+
 _try_import('hdf5')
 _try_import('video')
-# Blob-v2 video format depends on torchcodec + imageio (optional extras).
+# Blob-v2 video format depends on pylance + torchcodec/imageio.
 _try_import('lance_video')

--- a/stable_worldmodel/data/utils.py
+++ b/stable_worldmodel/data/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import urllib.request
 from pathlib import Path
@@ -8,7 +9,6 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
-from loguru import logger as logging
 from tqdm import tqdm
 
 from stable_worldmodel.utils import DEFAULT_CACHE_DIR, HF_BASE_URL
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from stable_pretraining.data.transforms import WrapTorchTransform
 
     from stable_worldmodel.data.dataset import Dataset
+
+logger = logging.getLogger(__name__)
 
 
 def get_cache_dir(
@@ -201,10 +203,10 @@ def _resolve_dataset_hf(repo_id: str, datasets_dir: Path) -> Path:
     local_dir = datasets_dir / repo_id.replace('/', '--')
 
     if local_dir.is_dir() and any(local_dir.iterdir()):
-        logging.info(f'Using cached dataset for {repo_id} at {local_dir}')
+        logger.info(f'Using cached dataset for {repo_id} at {local_dir}')
         return local_dir
 
-    logging.info(f'Downloading dataset {repo_id} from HuggingFace...')
+    logger.info(f'Downloading dataset {repo_id} from HuggingFace...')
     local_dir.mkdir(parents=True, exist_ok=True)
 
     entry = _hf_find_dataset_entry(repo_id)
@@ -225,7 +227,7 @@ def _resolve_dataset_hf(repo_id: str, datasets_dir: Path) -> Path:
         url = f'{HF_BASE_URL}/datasets/{repo_id}/resolve/main/{entry_path}'
         dest = local_dir / entry_path
         dest.parent.mkdir(parents=True, exist_ok=True)
-        logging.info(f'Fetching {url}')
+        logger.info(f'Fetching {url}')
         _download(url, dest)
 
     return local_dir
@@ -289,7 +291,7 @@ def convert(
     if carry_episode_data and not getattr(
         writer_cls, 'supports_episode_data', False
     ):
-        logging.warning(
+        logger.warning(
             f"convert: destination format '{dest_format}' does not support "
             f'episode data; dropping episode columns {ep_cols}.'
         )
@@ -401,7 +403,7 @@ def merge(
     if carry_episode_data and not getattr(
         writer_cls, 'supports_episode_data', False
     ):
-        logging.warning(
+        logger.warning(
             f"merge: destination format '{dest_format}' does not support "
             f'episode data; dropping episode columns {sorted(ep_reference)}.'
         )

--- a/stable_worldmodel/planning/solver/cem.py
+++ b/stable_worldmodel/planning/solver/cem.py
@@ -1,5 +1,6 @@
 """Cross Entropy Method solver for model-based planning."""
 
+import logging
 import time
 from typing import Any
 
@@ -7,11 +8,12 @@ import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium.spaces import Box
-from loguru import logger as logging
 
 from .utils import prepare_init_action
 from .callbacks import Callback
 from .solver import Costable
+
+logger = logging.getLogger(__name__)
 
 
 class CEMSolver:
@@ -65,7 +67,7 @@ class CEMSolver:
         self._configured = True
 
         if not isinstance(action_space, Box):
-            logging.warning(
+            logger.warning(
                 f'Action space is discrete, got {type(action_space)}. CEMSolver may not work as expected.'
             )
 

--- a/stable_worldmodel/planning/solver/gd.py
+++ b/stable_worldmodel/planning/solver/gd.py
@@ -1,5 +1,6 @@
 """Gradient-based solver for model-based planning."""
 
+import logging
 import time
 from typing import Any
 
@@ -7,11 +8,12 @@ import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium.spaces import Box
-from loguru import logger as logging
 
 from .utils import prepare_init_action
 from .callbacks import Callback
 from .solver import Costable
+
+logger = logging.getLogger(__name__)
 
 
 class GradientSolver(torch.nn.Module):
@@ -89,7 +91,7 @@ class GradientSolver(torch.nn.Module):
         self._configured = True
 
         if not isinstance(action_space, Box):
-            logging.warning(
+            logger.warning(
                 f'Action space is discrete, got {type(action_space)}. GradientSolver may not work as expected.'
             )
 

--- a/stable_worldmodel/planning/solver/icem.py
+++ b/stable_worldmodel/planning/solver/icem.py
@@ -1,5 +1,6 @@
 """Improved Cross Entropy Method (iCEM) solver for model-based planning."""
 
+import logging
 import time
 from typing import Any
 
@@ -7,11 +8,12 @@ import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium.spaces import Box
-from loguru import logger as logging
 
 from .utils import prepare_init_action
 from .callbacks import Callback
 from .solver import Costable
+
+logger = logging.getLogger(__name__)
 
 
 class ICEMSolver:
@@ -92,7 +94,7 @@ class ICEMSolver:
                 action_space.high[0], device=self.device, dtype=self.dtype
             ).repeat(self._config.action_block)
         else:
-            logging.warning(
+            logger.warning(
                 f'Action space is discrete, got {type(action_space)}. ICEMSolver may not work as expected.'
             )
             self._action_low = None

--- a/stable_worldmodel/planning/solver/lagrangian.py
+++ b/stable_worldmodel/planning/solver/lagrangian.py
@@ -1,5 +1,6 @@
 """Lagrangian solver for stable world model."""
 
+import logging
 import time
 from typing import Any
 
@@ -8,10 +9,11 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from gymnasium.spaces import Box
-from loguru import logger as logging
 
 from .utils import prepare_init_action
 from .solver import Constrainable, Costable
+
+logger = logging.getLogger(__name__)
 
 
 class LagrangianSolver(torch.nn.Module):
@@ -107,7 +109,7 @@ class LagrangianSolver(torch.nn.Module):
         self._configured = True
 
         if not isinstance(action_space, Box):
-            logging.warning(
+            logger.warning(
                 f'Action space is discrete, got {type(action_space)}. LagrangianSolver may not work as expected.'
             )
 

--- a/stable_worldmodel/planning/solver/mppi.py
+++ b/stable_worldmodel/planning/solver/mppi.py
@@ -1,5 +1,6 @@
 """Model Predictive Path Integral solver for model-based planning."""
 
+import logging
 import time
 from typing import Any
 
@@ -7,10 +8,11 @@ import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium.spaces import Box
-from loguru import logger as logging
 
 from .utils import prepare_init_action
 from .solver import Costable
+
+logger = logging.getLogger(__name__)
 
 
 class MPPISolver:
@@ -65,7 +67,7 @@ class MPPISolver:
         self._configured = True
 
         if not isinstance(action_space, Box):
-            logging.warning(
+            logger.warning(
                 f'Action space is discrete, got {type(action_space)}. MPPISolver may not work as expected.'
             )
 

--- a/stable_worldmodel/planning/solver/predictive_sampling.py
+++ b/stable_worldmodel/planning/solver/predictive_sampling.py
@@ -4,6 +4,7 @@ Reference: Howell et al., "Predictive Sampling: Real-time Behaviour Synthesis
 with MuJoCo", 2022.
 """
 
+import logging
 import time
 from typing import Any
 
@@ -11,9 +12,10 @@ import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium.spaces import Box
-from loguru import logger as logging
 
 from .solver import Costable
+
+logger = logging.getLogger(__name__)
 
 
 class PredictiveSamplingSolver:
@@ -59,7 +61,7 @@ class PredictiveSamplingSolver:
         self._configured = True
 
         if not isinstance(action_space, Box):
-            logging.warning(
+            logger.warning(
                 f'Action space is discrete, got {type(action_space)}. PredictiveSamplingSolver may not work as expected.'
             )
 

--- a/stable_worldmodel/spaces.py
+++ b/stable_worldmodel/spaces.py
@@ -1,13 +1,15 @@
 """Extended Gymnasium spaces with state tracking and constraint support."""
 
+import logging
 import time
 from typing import Any
 from collections.abc import Callable, Generator, Iterable, Sequence
 
 from gymnasium import spaces
-from loguru import logger as logging
 
 import stable_worldmodel as swm
+
+logger = logging.getLogger(__name__)
 
 
 def reset_variation_space(
@@ -113,7 +115,7 @@ class Discrete(spaces.Discrete):
             True if the current value is valid, False otherwise.
         """
         if not self.constrain_fn(self.value):
-            logging.warning(
+            logger.warning(
                 f'Discrete: value {self.value} does not satisfy constrain_fn'
             )
             return False
@@ -153,7 +155,7 @@ class Discrete(spaces.Discrete):
                 warn_after_s is not None
                 and (time.time() - start) > warn_after_s
             ):
-                logging.warning(
+                logger.warning(
                     'rejection sampling: rejection sampling is taking a while...'
                 )
         raise RuntimeError(
@@ -246,7 +248,7 @@ class MultiDiscrete(spaces.MultiDiscrete):
             True if current values are valid, False otherwise.
         """
         if not self.constrain_fn(self.value):
-            logging.warning(
+            logger.warning(
                 f'MultiDiscrete: value {self.value} does not satisfy constrain_fn'
             )
             return False
@@ -286,7 +288,7 @@ class MultiDiscrete(spaces.MultiDiscrete):
                 warn_after_s is not None
                 and (time.time() - start) > warn_after_s
             ):
-                logging.warning(
+                logger.warning(
                     'rejection sampling: rejection sampling is taking a while...'
                 )
         raise RuntimeError(
@@ -383,7 +385,7 @@ class Box(spaces.Box):
             True if the current value is valid, False otherwise.
         """
         if not self.constrain_fn(self.value):
-            logging.warning(
+            logger.warning(
                 f'Box: value {self.value} does not satisfy constrain_fn'
             )
             return False
@@ -423,7 +425,7 @@ class Box(spaces.Box):
                 warn_after_s is not None
                 and (time.time() - start) > warn_after_s
             ):
-                logging.warning(
+                logger.warning(
                     'rejection sampling: rejection sampling is taking a while...'
                 )
         raise RuntimeError(
@@ -525,7 +527,7 @@ class Dict(spaces.Dict):
             missing_keys = set(self.spaces.keys()).difference(
                 set(sampling_order)
             )
-            logging.warning(
+            logger.warning(
                 f'Dict sampling_order is missing keys {missing_keys}, adding them at the end of the sampling order'
             )
             self._sampling_order = list(sampling_order) + [
@@ -549,7 +551,7 @@ class Dict(spaces.Dict):
             if hasattr(v, 'init_value'):
                 init_val[k] = v.init_value
             else:
-                logging.warning(
+                logger.warning(
                     f'Space {k} of type {type(v)} does not have init_value property, using default sample instead'
                 )
                 init_val[k] = v.sample()
@@ -661,7 +663,7 @@ class Dict(spaces.Dict):
             if hasattr(v, 'check'):
                 if not v.check():
                     if debug:
-                        logging.warning(f'Dict: space {k} failed check()')
+                        logger.warning(f'Dict: space {k} failed check()')
                     return False
         return True
 
@@ -725,7 +727,7 @@ class Dict(spaces.Dict):
                 warn_after_s is not None
                 and (time.time() - start) > warn_after_s
             ):
-                logging.warning('rejection sampling is taking a while...')
+                logger.warning('rejection sampling is taking a while...')
 
         raise RuntimeError(
             f'constrain_fn not satisfied after {max_tries} draws'

--- a/stable_worldmodel/utils.py
+++ b/stable_worldmodel/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for stable_worldmodel."""
 
+import logging
 import os
 
 
@@ -11,10 +12,11 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from loguru import logger as logging
 
 DEFAULT_CACHE_DIR = os.path.expanduser('~/.stable_worldmodel')
 HF_BASE_URL = 'https://huggingface.co'
+
+logger = logging.getLogger(__name__)
 
 
 def exists(val: Any) -> bool:
@@ -54,7 +56,7 @@ def pretraining(
     if not os.path.isfile(script_path):
         raise ValueError(f'Script {script_path} does not exist.')
 
-    logging.info(
+    logger.info(
         f'🏃🏃🏃 Running pretraining script: {script_path} with args: {args} 🏃🏃🏃'
     )
     env = os.environ.copy()
@@ -67,7 +69,7 @@ def pretraining(
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
 
-    logging.info('🏁🏁🏁 Pretraining script finished 🏁🏁🏁')
+    logger.info('🏁🏁🏁 Pretraining script finished 🏁🏁🏁')
 
 
 def flatten_dict(d: dict, parent_key: str = '', sep: str = '.') -> dict:

--- a/stable_worldmodel/wm/utils.py
+++ b/stable_worldmodel/wm/utils.py
@@ -1,13 +1,15 @@
 import json
+import logging
 import urllib.request
 from pathlib import Path
 import torch
 
-from loguru import logger as logging
 from tqdm import tqdm
 
 from stable_worldmodel.utils import HF_BASE_URL
 from stable_worldmodel.data import get_cache_dir, ensure_dir_exists
+
+logger = logging.getLogger(__name__)
 
 
 def save_pretrained(
@@ -27,7 +29,7 @@ def save_pretrained(
     torch.save(model.state_dict(), checkpoint_path)
 
     if config is None:
-        logging.warning('No config! Loading will have to be done manually.')
+        logger.warning('No config! Loading will have to be done manually.')
         return
 
     if config_key is not None and config_key in config:
@@ -40,7 +42,7 @@ def save_pretrained(
     with open(config_path, 'w') as f:
         json.dump(config, f, indent=2)
 
-    logging.info(f'📦📦📦 Model saved to {checkpoint_path} 📦📦📦')
+    logger.info(f'📦📦📦 Model saved to {checkpoint_path} 📦📦📦')
 
     return
 
@@ -135,7 +137,7 @@ def _resolve_folder(folder: Path) -> tuple[Path, dict]:
             f'Ambiguous checkpoint: multiple .pt files in {folder}. '
             'Specify the file directly.'
         )
-    logging.info(f'Loading checkpoint from folder {folder}...')
+    logger.info(f'Loading checkpoint from folder {folder}...')
     return pt_files[0], _load_config(folder)
 
 
@@ -147,15 +149,15 @@ def _resolve_hf(repo_id: str, cache_dir: Path) -> tuple[Path, dict]:
     local_dir = cache_dir / f'models--{repo_id.replace("/", "--")}'
 
     if local_dir.is_dir():
-        logging.info(f'Loading {repo_id} from local cache...')
+        logger.info(f'Loading {repo_id} from local cache...')
         return _resolve_folder(local_dir)
 
-    logging.info(f'Downloading {repo_id} from HuggingFace...')
+    logger.info(f'Downloading {repo_id} from HuggingFace...')
     local_dir.mkdir(parents=True, exist_ok=True)
     for filename in ('config.json', 'weights.pt'):
         url = f'{HF_BASE_URL}/{repo_id}/resolve/main/{filename}'
         dest = local_dir / filename
-        logging.info(f'Fetching {url}')
+        logger.info(f'Fetching {url}')
         _download(url, dest)
 
     return _resolve_folder(local_dir)

--- a/stable_worldmodel/wrapper/__init__.py
+++ b/stable_worldmodel/wrapper/__init__.py
@@ -1,3 +1,18 @@
+"""Environment wrappers.
+
+The ``default`` wrappers depend only on gymnasium/numpy and are imported
+eagerly — :class:`~stable_worldmodel.world.World` needs ``MegaWrapper`` at
+import time.
+
+The ``visual`` wrappers are backed by OpenCV, which ships in the ``[env]``
+extra rather than the base install. They are therefore resolved lazily
+(PEP 562): importing this package — and so importing ``World`` — keeps
+working without cv2, and only reaching for a visual wrapper requires it.
+"""
+
+import importlib
+from typing import TYPE_CHECKING
+
 from stable_worldmodel.wrapper.default import (
     AddPixelsWrapper,
     EnsureGoalInfoWrapper,
@@ -8,24 +23,69 @@ from stable_worldmodel.wrapper.default import (
     MegaWrapper,
     ResizeGoalWrapper,
 )
-from stable_worldmodel.wrapper.visual import (
-    BlurWrapper,
-    ChromaKeyWrapper,
-    ColorJitterWrapper,
-    CutoutWrapper,
-    GrayscaleWrapper,
-    MovingPatchWrapper,
-    NoiseWrapper,
-    OcclusionWrapper,
-    RandomConvWrapper,
-    RandomShiftWrapper,
-    ResolutionWrapper,
-    constant,
-    cosine,
-    exponential,
-    linear,
-    sinusoidal,
+
+
+# Names living in `.visual`, which imports cv2 at module scope.
+_LAZY_VISUAL = frozenset(
+    {
+        'BlurWrapper',
+        'ChromaKeyWrapper',
+        'ColorJitterWrapper',
+        'CutoutWrapper',
+        'GrayscaleWrapper',
+        'MovingPatchWrapper',
+        'NoiseWrapper',
+        'OcclusionWrapper',
+        'RandomConvWrapper',
+        'RandomShiftWrapper',
+        'ResolutionWrapper',
+        'constant',
+        'cosine',
+        'exponential',
+        'linear',
+        'sinusoidal',
+    }
 )
+
+if TYPE_CHECKING:
+    from stable_worldmodel.wrapper.visual import (
+        BlurWrapper,
+        ChromaKeyWrapper,
+        ColorJitterWrapper,
+        CutoutWrapper,
+        GrayscaleWrapper,
+        MovingPatchWrapper,
+        NoiseWrapper,
+        OcclusionWrapper,
+        RandomConvWrapper,
+        RandomShiftWrapper,
+        ResolutionWrapper,
+        constant,
+        cosine,
+        exponential,
+        linear,
+        sinusoidal,
+    )
+
+
+def __getattr__(name: str):
+    if name in _LAZY_VISUAL:
+        try:
+            mod = importlib.import_module('stable_worldmodel.wrapper.visual')
+        except ImportError as exc:
+            raise ImportError(
+                f'{name!r} is an OpenCV-backed visual wrapper and needs the '
+                "'env' extra: pip install 'stable-worldmodel[env]' "
+                f'(original error: {exc})'
+            ) from exc
+        attr = getattr(mod, name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__) | set(globals().keys()))
 
 
 __all__ = [

--- a/tests/data/test_episode_data.py
+++ b/tests/data/test_episode_data.py
@@ -3,6 +3,8 @@ forwarding (Merge/Concat), and convert carry-through."""
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from stable_worldmodel.data import (
@@ -156,20 +158,18 @@ def test_convert_lance_to_lance_carries_episode_data(tmp_path):
     assert ds.get_episode_data()['model_xml'] == ['<scene 0/>', '<scene 1/>']
 
 
-def test_convert_to_folder_drops_episode_data_with_warning(tmp_path):
-    from loguru import logger
-
+def test_convert_to_folder_drops_episode_data_with_warning(tmp_path, caplog):
     src = tmp_path / 'src.lance'
     _write_lance_with_episode_data(src)
 
     dest = tmp_path / 'folder_out'
-    messages: list[str] = []
-    sink_id = logger.add(lambda m: messages.append(str(m)), level='WARNING')
-    try:
+    with caplog.at_level(
+        logging.WARNING, logger='stable_worldmodel.data.utils'
+    ):
         convert(str(src), str(dest), dest_format='folder', progress=False)
-    finally:
-        logger.remove(sink_id)
-    assert any('does not support episode data' in m for m in messages)
+    assert any(
+        'does not support episode data' in r.message for r in caplog.records
+    )
 
     # Round the folder back into lance: the episode data is gone for good
     # (proving the folder writer never received the reserved key).

--- a/tests/planning/solver/test_lagrangian.py
+++ b/tests/planning/solver/test_lagrangian.py
@@ -1,5 +1,7 @@
 """Tests for LagrangianSolver class."""
 
+import logging
+
 import numpy as np
 import pytest
 import torch
@@ -759,13 +761,15 @@ def test_configure_non_box_action_space_warns(caplog):
     solver = make_solver()
     discrete_space = gym_spaces.Discrete(5)
 
-    # loguru captures to stdlib when propagate=True; use capfd or just check no crash
-    # The warning is emitted via loguru — we just verify configure() doesn't raise
-    solver.configure(
-        action_space=discrete_space,
-        n_envs=2,
-        config=PlanConfig(horizon=4, receding_horizon=1, action_block=1),
-    )
+    with caplog.at_level(
+        logging.WARNING, logger='stable_worldmodel.planning.solver.lagrangian'
+    ):
+        solver.configure(
+            action_space=discrete_space,
+            n_envs=2,
+            config=PlanConfig(horizon=4, receding_horizon=1, action_block=1),
+        )
+    assert any('Action space is discrete' in r.message for r in caplog.records)
     assert (
         solver._configured
     )  # configure still succeeds despite wrong space type

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -114,7 +114,7 @@ def test_discrete_space_constraint_function_warn_sample():
     constraint_fn = MagicMock(return_value=False)
     space = spaces.Discrete(5, init_value=2, constrain_fn=constraint_fn)
 
-    with patch('stable_worldmodel.spaces.logging.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         with pytest.raises(RuntimeError):
             space.sample(max_tries=1, warn_after_s=0.0)
         mock_warning.assert_called()
@@ -163,7 +163,7 @@ def test_discrete_space_sample_without_setting_value_constraint():
 def test_discrete_space_check_warning_on_constraint_fail():
     """Test that check() logs warning when constraint fails."""
     space = spaces.Discrete(5, init_value=2, constrain_fn=lambda x: False)
-    with patch('stable_worldmodel.spaces.logging.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         result = space.check()
         assert not result
         mock_warning.assert_called_once()
@@ -308,7 +308,7 @@ def test_multidiscrete_space_constraint_function_warn_sample():
         [3, 4, 5], init_value=np.array([1, 2, 3]), constrain_fn=constraint_fn
     )
 
-    with patch('stable_worldmodel.spaces.logging.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         with pytest.raises(RuntimeError):
             space.sample(max_tries=1, warn_after_s=0.0)
         mock_warning.assert_called()
@@ -369,7 +369,7 @@ def test_multidiscrete_space_check_warning_on_constraint_fail():
     space = spaces.MultiDiscrete(
         [5, 5], init_value=np.array([2, 2]), constrain_fn=lambda x: False
     )
-    with patch('stable_worldmodel.spaces.logging.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         result = space.check()
         assert not result
         mock_warning.assert_called_once()
@@ -553,7 +553,7 @@ def test_box_space_constraint_function_warn_sample():
         constrain_fn=constraint_fn,
     )
 
-    with patch('loguru.logger.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         with pytest.raises(RuntimeError):
             space.sample(max_tries=5, warn_after_s=0.0)
         mock_warning.assert_called()
@@ -638,7 +638,7 @@ def test_box_space_check_warning_on_constraint_fail():
         init_value=init_val,
         constrain_fn=lambda x: False,
     )
-    with patch('stable_worldmodel.spaces.logging.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         result = space.check()
         assert not result
         mock_warning.assert_called_once()
@@ -1122,7 +1122,7 @@ def test_dict_space_one_level_sampling_order_partial():
 
 def test_dict_space_one_level_sampling_order_partial_warning():
     """Test that warning is logged for partial sampling order."""
-    with patch('stable_worldmodel.spaces.logging.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         space = spaces.Dict(
             {
                 'x': spaces.Discrete(5, init_value=2),
@@ -1242,7 +1242,7 @@ def test_dict_space_one_level_check_debug():
         }
     )
 
-    with patch('stable_worldmodel.spaces.logging.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         result = space.check(debug=True)
         assert not result
         mock_warning.assert_called()
@@ -1299,7 +1299,7 @@ def test_dict_space_one_level_constraint_warn_sample():
         constrain_fn=constraint_fn,
     )
 
-    with patch('stable_worldmodel.spaces.logging.warning') as mock_warning:
+    with patch('stable_worldmodel.spaces.logger.warning') as mock_warning:
         with pytest.raises(RuntimeError):
             space.sample(max_tries=5, warn_after_s=0.0)
         mock_warning.assert_called()


### PR DESCRIPTION
## Why

Downstream consumers that only want `stable_worldmodel.planning` (solvers + world model, no dataset I/O) were forced to install the whole Lance stack. The import-time cost was already fixed upstream — `import stable_worldmodel.planning` pulls in no `cv2`, `lance`, `lancedb`, `pygame`, `pymunk` or `shapely` — but the *install-time* cost remained, because those wheels were declared base dependencies regardless of whether anything imported them.

## What changed

**`loguru` → stdlib `logging`.** It was a genuine base dependency (imported by six solvers plus `spaces`/`utils`/`data.utils`), which vendoring downstream had specifically been trying to avoid. Each module now uses a `logging.getLogger(__name__)` logger. Since loguru prints INFO to stderr with no setup and stdlib does not, the library installs no handler (correct for a library) and the CLI root callback calls `basicConfig` — the one place that is an application. `scripts/` migrated too, with `basicConfig` in each `__main__` guard.

Note `logger.success()` is loguru-only and has no stdlib equivalent; the 11 call sites in `scripts/` are mapped to `info`, which is what they all meant.

**`lancedb` / `pylance` / `pyarrow` → new `[data]` extra.** `lance` becomes a probed format like `hdf5`/`video` — registration order is preserved exactly, so `detect_format` still resolves paths identically. `LanceDataset`/`LanceWriter` are re-exported and added to `__all__` only when bound, so `import *` cannot `AttributeError` on a base install. `get_format()` and the affected `swm` CLI paths now name the extra to install rather than failing opaquely.

`[format]` declares `stable-worldmodel[data]`, so it remains a superset; `[all]` is unchanged in effect.

**OpenCV-backed visual wrappers made lazy.** `World` needs only `MegaWrapper` from `wrapper.default`, which depends on nothing beyond gymnasium/numpy — but `wrapper/__init__` also imported `.visual` eagerly, and that module imports `cv2` at module scope. Since cv2 ships in `[env]`, a base install lost `World` to a module it never touches. The visual names now resolve lazily via PEP 562, the same idiom the top-level `stable_worldmodel/__init__` already uses, and touching one without cv2 raises an `ImportError` naming the extra.

This is what makes the slimmed base install actually useful: a `World` now constructs and resets on a stock gymnasium env with neither cv2 nor pygame loaded — the case for anyone plugging swm planning into their own environment.

One trap worth recording for future readers: **`pylance` is required by the core Lance format, not just `lance_video`.** Grepping this package for a module-level `import lance` only hits `lance_video.py`, which suggests pylance is optional — but `lance.py` calls `LanceTable.to_lance()` on five read/write paths, and lancedb implements that as `try: import lance / except ImportError: raise ImportError("...pip install pylance")`. The dependency arrives through lancedb, invisible to a grep of our own source. Hence pylance sits in `[data]`.

## Effect

| install | packages | Lance stack |
|---|---|---|
| `stable-worldmodel` | 77 | none |
| `stable-worldmodel[data]` | 121 | lancedb, pylance, pyarrow (~410 MB) |
| `stable-worldmodel[format]` | 138 | + h5py, torchcodec, imageio |

`[data]` is now the recommended default in the README and docs, so the common path is unchanged for normal users — only deliberately-minimal consumers take the bare route.

## Verification

- Simulated a base install with an import blocker on `lancedb`/`lance`/`pyarrow`: `stable_worldmodel.planning` imports clean with no Lance stack loaded, formats degrade to `['folder', 'lerobot', 'video']`, star-import works.
- `list_formats()` is byte-identical to `main` in a full install: `['lance', 'folder', 'lerobot', 'video', 'lance_video']`.
- All four extras resolve, including the self-referential `[format] → [data]`.
- Test suite failing set is identical to `main` — the 22 pre-existing failures from an env without `mujoco`/`gymnasium_robotics`, unrelated to this branch.
- The lazy-wrapper change **unblocks test collection**: `tests/test_world.py`, `tests/test_new_world.py` and `tests/test_wrappers.py` previously could not be collected at all without cv2. Collection goes 733 -> 873, and all 140 newly-collected tests pass (832 passed total).
- `pre-commit` clean.

## Notes for review

The `cv2` follow-up flagged in the first revision of this description is now included here (third bullet above) rather than deferred.

Still outstanding, and out of scope: the bundled environments (`pusht`, `two_room`) import cv2 at module scope themselves. They are registered lazily through gymnasium entry points, so they do not affect import of the package — but running them still needs `[env]`, as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
